### PR TITLE
Rebuild PreloadedData model at import to fix forward-ref errors

### DIFF
--- a/src/genai_tag_db_tools/models.py
+++ b/src/genai_tag_db_tools/models.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, TypedDict
+from typing import TypedDict
 
 from pydantic import BaseModel, Field
 
-if TYPE_CHECKING:
-    from genai_tag_db_tools.db.schema import Tag, TagStatus, TagTranslation
+from genai_tag_db_tools.db.schema import Tag, TagStatus, TagTranslation
 
 
 class DbSourceRef(BaseModel):
@@ -280,3 +279,6 @@ class PreloadedData(BaseModel):
     trans_by_tag_id: dict[int, list[TagTranslation]]
     status_by_tag_format: dict[tuple[int, int], TagStatus]
     statuses_by_tag_id: dict[int, list[TagStatus]]
+
+
+PreloadedData.model_rebuild()

--- a/tests/unit/test_tag_searcher.py
+++ b/tests/unit/test_tag_searcher.py
@@ -34,10 +34,6 @@ def _seed_format_and_type(session: Session, *, format_id: int = 1, type_id: int 
 
 
 def test_search_tags_filters_by_format_type_language(session_factory: Callable[[], Session]) -> None:
-    from genai_tag_db_tools.db.schema import Tag, TagStatus, TagTranslation  # noqa: F401
-    from genai_tag_db_tools.models import PreloadedData
-
-    PreloadedData.model_rebuild()
     reader = TagReader(session_factory)
     merged_reader = MergedTagReader(base_repo=reader)
     repo = TagRepository(session_factory, reader=merged_reader)
@@ -99,10 +95,6 @@ def test_get_formats_languages_types(session_factory: Callable[[], Session]) -> 
 def test_search_tags_resolve_preferred_replaces_tag_and_translations(
     session_factory: Callable[[], Session],
 ) -> None:
-    from genai_tag_db_tools.db.schema import Tag, TagStatus, TagTranslation  # noqa: F401
-    from genai_tag_db_tools.models import PreloadedData
-
-    PreloadedData.model_rebuild()
     reader = TagReader(session_factory)
     merged_reader = MergedTagReader(base_repo=reader)
     repo = TagRepository(session_factory, reader=merged_reader)


### PR DESCRIPTION
### Motivation
- Fix runtime error where `PreloadedData` was reported as "not fully defined" due to Pydantic v2 forward refs from `from __future__ import annotations`.
- Ensure DB schema types (`Tag`, `TagStatus`, `TagTranslation`) are resolved at runtime so callers/tests don't need to trigger a manual rebuild.
- Make tests exercise the same runtime initialization used by the application to surface startup-only regressions.
- Remove redundant manual `PreloadedData.model_rebuild()` calls from tests to simplify test setup.

### Description
- Import `Tag`, `TagStatus`, and `TagTranslation` from `genai_tag_db_tools.db.schema` at runtime so type annotations reference real types.
- Call `PreloadedData.model_rebuild()` immediately after the `PreloadedData` class definition to resolve Pydantic forward refs.
- Remove manual imports and `PreloadedData.model_rebuild()` invocations from `tests/unit/test_tag_searcher.py` so tests rely on normal runtime initialization.
- Preserve `model_config = {"arbitrary_types_allowed": True}` on `PreloadedData` to allow arbitrary DB types.

### Testing
- No automated tests were executed as part of this change.
- Unit tests were updated to remove forced rebuilds, but test execution/CI was not run here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951682834508329b4624cbc7b065d65)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Fix Pydantic forward refs for `PreloadedData`**
> 
> - Import `Tag`, `TagStatus`, `TagTranslation` from `genai_tag_db_tools.db.schema` at runtime so annotations reference real types
> - Invoke `PreloadedData.model_rebuild()` immediately after the class to resolve forward refs
> 
> **Test cleanup**
> 
> - Remove manual imports and `PreloadedData.model_rebuild()` calls from `tests/unit/test_tag_searcher.py` so tests use normal runtime initialization
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 77be6454584ee38d24179fb3e65a6b762adda818. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->