### PR TITLE
CLI: make base DB optional and auto-initialize default HF base DBs

### DIFF
--- a/src/genai_tag_db_tools/cli.py
+++ b/src/genai_tag_db_tools/cli.py
@@ -87,7 +87,6 @@ def _set_db_paths(base_db_paths: Iterable[str] | None, user_db_dir: str | None) 
     if base_db_paths:
         runtime.set_base_database_paths([Path(p) for p in base_db_paths])
     else:
-        from genai_tag_db_tools.core_api import ensure_databases
         from genai_tag_db_tools.io.hf_downloader import default_cache_dir
 
         cache = DbCacheConfig(cache_dir=str(default_cache_dir()))

--- a/src/genai_tag_db_tools/cli.py
+++ b/src/genai_tag_db_tools/cli.py
@@ -86,6 +86,38 @@ def _set_db_paths(base_db_paths: Iterable[str] | None, user_db_dir: str | None) 
 
     if base_db_paths:
         runtime.set_base_database_paths([Path(p) for p in base_db_paths])
+    else:
+        from genai_tag_db_tools.core_api import ensure_databases
+        from genai_tag_db_tools.io.hf_downloader import default_cache_dir
+
+        cache = DbCacheConfig(cache_dir=str(default_cache_dir()))
+        requests = [
+            EnsureDbRequest(
+                source=DbSourceRef(
+                    repo_id="NEXTAltair/genai-image-tag-db-CC4",
+                    filename="genai-image-tag-db-cc4.sqlite",
+                ),
+                cache=cache,
+            ),
+            EnsureDbRequest(
+                source=DbSourceRef(
+                    repo_id="NEXTAltair/genai-image-tag-db-mit",
+                    filename="genai-image-tag-db-mit.sqlite",
+                ),
+                cache=cache,
+            ),
+            EnsureDbRequest(
+                source=DbSourceRef(
+                    repo_id="NEXTAltair/genai-image-tag-db",
+                    filename="genai-image-tag-db-cc0.sqlite",
+                ),
+                cache=cache,
+            ),
+        ]
+        results = ensure_databases(requests)
+        base_paths = [Path(result.db_path) for result in results]
+        runtime.set_base_database_paths(base_paths)
+        runtime.init_engine(base_paths[0])
     if user_db_dir:
         runtime.init_user_db(Path(user_db_dir))
 
@@ -174,13 +206,7 @@ def cmd_convert(args: argparse.Namespace) -> None:
         print(converted)
 
 
-def _add_base_db_args(parser: argparse.ArgumentParser, required: bool = True) -> None:
-    parser.add_argument(
-        "--base-db",
-        action="append",
-        required=required,
-        help="Base database path. Repeat for multiple base DBs. Optional if using default cache.",
-    )
+def _add_base_db_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--user-db-dir",
         help="User database directory. Required for register.",
@@ -240,7 +266,7 @@ def main() -> None:
     convert_parser.add_argument("--format-name", required=True, help="Target format (e.g., danbooru, e621)")
     convert_parser.add_argument("--separator", default=", ", help="Tag separator (default: ', ')")
     convert_parser.add_argument("--json", action="store_true", help="Output as JSON")
-    _add_base_db_args(convert_parser, required=False)
+    _add_base_db_args(convert_parser)
     convert_parser.set_defaults(func=cmd_convert)
 
     args = parser.parse_args()

--- a/tests/unit/test_cli_integration.py
+++ b/tests/unit/test_cli_integration.py
@@ -129,6 +129,26 @@ class TestCmdSearch:
 class TestCmdRegister:
     """Test cmd_register command."""
 
+    def _mock_default_bases(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        from genai_tag_db_tools.models import EnsureDbResult
+
+        db_paths = []
+        for filename in (
+            "genai-image-tag-db-cc4.sqlite",
+            "genai-image-tag-db-mit.sqlite",
+            "genai-image-tag-db-cc0.sqlite",
+        ):
+            path = tmp_path / filename
+            path.touch()
+            db_paths.append(path)
+
+        results = [
+            EnsureDbResult(db_path=str(path), sha256="mock", revision=None, cached=True)
+            for path in db_paths
+        ]
+
+        monkeypatch.setattr("genai_tag_db_tools.cli.ensure_databases", lambda _requests: results)
+
     @patch("genai_tag_db_tools.cli._build_register_service")
     @patch("genai_tag_db_tools.cli.register_tag")
     def test_register_basic_tag(
@@ -136,9 +156,11 @@ class TestCmdRegister:
         mock_register: MagicMock,
         mock_service: MagicMock,
         tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
         """基本的なタグ登録"""
+        self._mock_default_bases(monkeypatch, tmp_path)
         # Mock response
         mock_result = TagRecordPublic(
             tag="new_tag",
@@ -202,9 +224,14 @@ class TestCmdRegister:
     @patch("genai_tag_db_tools.cli._build_register_service")
     @patch("genai_tag_db_tools.cli.register_tag")
     def test_register_with_translations(
-        self, mock_register: MagicMock, mock_service: MagicMock, tmp_path: Path
+        self,
+        mock_register: MagicMock,
+        mock_service: MagicMock,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """翻訳付きタグ登録"""
+        self._mock_default_bases(monkeypatch, tmp_path)
         mock_result = TagRecordPublic(
             tag="translated_tag",
             source_tag=None,


### PR DESCRIPTION
### Motivation
- The CLI previously required a `--base-db` argument but the base DBs are now standard HF-hosted datasets using HF CAS, so a fixed default set can be used instead of forcing a path.
- Simplify UX by downloading and initializing the default base DBs automatically when no base DBs are provided.

### Description
- When no `base_db_paths` are provided, the CLI now calls `ensure_databases` with three default HF dataset specs and uses `default_cache_dir` for caching to obtain base DB files.
- The results are converted to `Path`s and `runtime.set_base_database_paths` is invoked followed by `runtime.init_engine` on the primary base DB.
- The `--base-db` CLI argument was removed from `_add_base_db_args` and the helper signature was simplified, with call sites updated accordingly.
- The user DB initialization remains controlled by `--user-db-dir` and `runtime.init_user_db` is still invoked when provided.

### Testing
- No automated tests were run for this change.
- The change was committed locally and lint/format checks (if any) were not executed as part of this rollout.
- Manual code inspection was performed during the rollout to ensure correct function usage of `ensure_databases` and runtime initialization.
- Further automated or integration tests should be added to verify HF download fallback and CLI behavior in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69520006bad08329a02fe03f737a0f38)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements automatic base DB bootstrapping and updates tests accordingly.
> 
> - CLI now auto-downloads and initializes default HF-hosted base DBs when no `base_db_paths` are provided: calls `ensure_databases` for three defaults using `default_cache_dir`, sets `runtime` base paths, and runs `runtime.init_engine` on the primary DB
> - Simplifies CLI args by removing `--base-db` from `_add_base_db_args`; user DB remains configurable via `--user-db-dir`
> - Adds/updates tests: new GUI integration tests for `MainWindow` init with mocked HF downloads and synchronous `QThreadPool`; unit/integration tests for CLI to cover default base DB fallback, `_set_db_paths`, register/search/stats/convert flows, and translation handling
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d9d6e8e982f5f0d36b10f3aa2705a95601f5f810. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->