### PR TITLE
Fix TagRegisterService initialization in CLI

### DIFF
--- a/src/genai_tag_db_tools/cli.py
+++ b/src/genai_tag_db_tools/cli.py
@@ -123,7 +123,7 @@ def _set_db_paths(base_db_paths: Iterable[str] | None, user_db_dir: str | None) 
 
 def _build_register_service() -> TagRegisterService:
     repo = get_default_repository()
-    return TagRegisterService(parent=None, repository=repo)
+    return TagRegisterService(repository=repo)
 
 
 def cmd_ensure_dbs(args: argparse.Namespace) -> None:

--- a/src/genai_tag_db_tools/gui/services/tag_search_service.py
+++ b/src/genai_tag_db_tools/gui/services/tag_search_service.py
@@ -8,13 +8,9 @@ from PySide6.QtCore import QObject
 from genai_tag_db_tools.db.repository import get_default_reader
 from genai_tag_db_tools.gui.services.gui_service_base import GuiServiceBase
 from genai_tag_db_tools.services.tag_search import TagSearcher
-from genai_tag_db_tools.gui.services.tag_statistics_service import TagStatisticsService
 
 if TYPE_CHECKING:
     from genai_tag_db_tools.db.repository import MergedTagReader
-
-__all__ = ["TagSearchService", "TagStatisticsService"]
-
 
 class TagSearchService(GuiServiceBase):
     """GUI向け検索サービス(TagSearcher を利用)"""

--- a/src/genai_tag_db_tools/gui/services/tag_search_service.py
+++ b/src/genai_tag_db_tools/gui/services/tag_search_service.py
@@ -13,6 +13,8 @@ from genai_tag_db_tools.gui.services.tag_statistics_service import TagStatistics
 if TYPE_CHECKING:
     from genai_tag_db_tools.db.repository import MergedTagReader
 
+__all__ = ["TagSearchService", "TagStatisticsService"]
+
 
 class TagSearchService(GuiServiceBase):
     """GUI向け検索サービス(TagSearcher を利用)"""

--- a/src/genai_tag_db_tools/gui/services/tag_search_service.py
+++ b/src/genai_tag_db_tools/gui/services/tag_search_service.py
@@ -8,6 +8,7 @@ from PySide6.QtCore import QObject
 from genai_tag_db_tools.db.repository import get_default_reader
 from genai_tag_db_tools.gui.services.gui_service_base import GuiServiceBase
 from genai_tag_db_tools.services.tag_search import TagSearcher
+from genai_tag_db_tools.gui.services.tag_statistics_service import TagStatisticsService
 
 if TYPE_CHECKING:
     from genai_tag_db_tools.db.repository import MergedTagReader

--- a/tests/unit/test_app_services_core_api_integration.py
+++ b/tests/unit/test_app_services_core_api_integration.py
@@ -7,7 +7,8 @@ import polars as pl
 import pytest
 from pydantic import ValidationError
 
-from genai_tag_db_tools.gui.services.tag_search_service import TagSearchService, TagStatisticsService
+from genai_tag_db_tools.gui.services.tag_search_service import TagSearchService
+from genai_tag_db_tools.gui.services.tag_statistics_service import TagStatisticsService
 from genai_tag_db_tools.models import TagRecordPublic, TagSearchResult, TagStatisticsResult
 
 


### PR DESCRIPTION
### Motivation
- A mypy error reported an unexpected `parent` keyword when constructing `TagRegisterService` from the CLI helper. 
- The `TagRegisterService` constructor accepts `repository` and `reader`, not a `parent` argument. 

### Description
- Updated `_build_register_service` in `src/genai_tag_db_tools/cli.py` to call `TagRegisterService(repository=repo)` instead of passing `parent=None`. 
- This aligns the CLI code with the `TagRegisterService` signature defined in `src/genai_tag_db_tools/services/tag_register.py`.

### Testing
- Ran static type checks with `uv run mypy src/genai_tag_db_tools` and it completed successfully. 
- Mypy output reported no issues across the checked source files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695252d68be08329b76fa788a74548b5)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - **CLI:** Fix `_build_register_service` to call `TagRegisterService(repository=repo)` (remove unsupported `parent=None`).
> - **Tests:** Update imports to use `genai_tag_db_tools.gui.services.tag_statistics_service.TagStatisticsService` instead of importing it from `tag_search_service`.
> - *Misc:* Minor whitespace cleanup in `tag_search_service.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8336b4fc28d2ed1d16d4044468ef0e4c1a59608c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->