### PR TITLE
Fix merged format ID lookup in reader

### DIFF
--- a/src/genai_tag_db_tools/db/repository.py
+++ b/src/genai_tag_db_tools/db/repository.py
@@ -1368,13 +1368,13 @@ class MergedTagReader:
     def get_format_id(self, format_name: str) -> int:
         if self._has_user():
             assert self.user_repo is not None
-            result = self.user_repo.get_format_id(format_name)
-            if result != 0:
-                return result
+            for format_id, name in self.user_repo.get_format_map().items():
+                if name == format_name:
+                    return format_id
         for repo in self._iter_base_repos():
-            result = repo.get_format_id(format_name)
-            if result != 0:
-                return result
+            for format_id, name in repo.get_format_map().items():
+                if name == format_name:
+                    return format_id
         raise ValueError(f"format_name not found: {format_name}")
 
     # ------------------------------------------------------------------

--- a/src/genai_tag_db_tools/db/repository.py
+++ b/src/genai_tag_db_tools/db/repository.py
@@ -1366,9 +1366,15 @@ class MergedTagReader:
         return self._first_found("get_metadata_value", key)
 
     def get_format_id(self, format_name: str) -> int:
-        result = self._first_found("get_format_id", format_name)
-        if result:
-            return result
+        if self._has_user():
+            assert self.user_repo is not None
+            result = self.user_repo.get_format_id(format_name)
+            if result != 0:
+                return result
+        for repo in self._iter_base_repos():
+            result = repo.get_format_id(format_name)
+            if result != 0:
+                return result
         raise ValueError(f"format_name not found: {format_name}")
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Fix a bug where `MergedTagReader.get_format_id` treated a `0` result from the user DB as a found value and therefore prevented searching base repositories, causing `ValueError: format_name not found` for formats present only in base DBs.

### Description
- Replace the previous `_first_found`-based lookup in `MergedTagReader.get_format_id` with explicit checks that treat `0` as “not found”.
- First query `user_repo.get_format_id`, return if `!= 0`, then iterate base repos and return the first non-zero result, otherwise raise `ValueError`.
- Modified file: `src/genai_tag_db_tools/db/repository.py` (function `MergedTagReader.get_format_id`).

### Testing
- Ran `pytest -q tests/unit/test_format_id_collision_avoidance.py`, but the test run failed to collect due to a missing dependency: `ModuleNotFoundError: No module named 'sqlalchemy'` in the current environment.
- The change targets the previously failing CI case (`test_format_id_collision_avoidance`), which raised `ValueError` before this fix; the patch addresses that logic so the test should pass when run in an environment with dependencies installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986e0ab9fb88329a1e89f8d39f0ca7a)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to format lookup logic; risk is limited to callers of `MergedTagReader.get_format_id` if the new iteration order/behavior differs in edge cases.
> 
> **Overview**
> Fixes `MergedTagReader.get_format_id` to reliably resolve `format_name` across merged repositories.
> 
> The method no longer relies on `_first_found` semantics (which could treat sentinel values as “found”); it now explicitly scans `get_format_map()` in the user repo first, then base repos, and raises `ValueError` only if the name is absent everywhere.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 971b27ab8e3bef3b1759d88c822b76a93d38341c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->