### PR TITLE
Fix SQLite variable overflow in broad tag searches

### DIFF
--- a/src/genai_tag_db_tools/core_api.py
+++ b/src/genai_tag_db_tools/core_api.py
@@ -161,6 +161,10 @@ def search_tags(repo: MergedTagReader, request: TagSearchRequest) -> TagSearchRe
         resolve_preferred=request.resolve_preferred,
     )
     rows = _filter_rows(rows, request)
+    if request.offset:
+        rows = rows[request.offset :]
+    if request.limit is not None:
+        rows = rows[: request.limit]
     items = [
         TagRecordPublic(
             tag=row["tag"],

--- a/src/genai_tag_db_tools/db/query_utils.py
+++ b/src/genai_tag_db_tools/db/query_utils.py
@@ -1,5 +1,5 @@
 from logging import Logger
-from typing import TypedDict
+from typing import Any, TypedDict
 
 from sqlalchemy.orm import Session
 from sqlalchemy.sql import or_
@@ -48,7 +48,14 @@ class TagSearchQueryBuilder:
     def __init__(self, session: Session) -> None:
         self.session = session
 
-    def initial_tag_ids(self, keyword: str, use_like: bool) -> set[int]:
+    def initial_tag_ids(
+        self,
+        keyword: str,
+        use_like: bool,
+        *,
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> set[int]:
         tag_query = self.session.query(Tag.tag_id)
         translation_query = self.session.query(TagTranslation.tag_id)
 
@@ -62,6 +69,13 @@ class TagSearchQueryBuilder:
             TagTranslation.translation.like(keyword) if use_like else TagTranslation.translation == keyword
         )
         translation_query = translation_query.filter(translation_condition)
+
+        if offset > 0:
+            tag_query = tag_query.offset(offset)
+            translation_query = translation_query.offset(offset)
+        if limit is not None:
+            tag_query = tag_query.limit(limit)
+            translation_query = translation_query.limit(limit)
 
         tag_ids = {row[0] for row in tag_query.all()}
         translation_ids = {row[0] for row in translation_query.all()}
@@ -204,36 +218,61 @@ class TagSearchPreloader:
     def __init__(self, session: Session) -> None:
         self.session = session
 
+    def _query_in_chunks(
+        self,
+        model: type[Any],
+        column: Any,
+        ids: set[int],
+        *,
+        chunk_size: int = 900,
+    ) -> list:
+        if not ids:
+            return []
+
+        ordered_ids = sorted(ids)
+        rows: list = []
+        for start in range(0, len(ordered_ids), chunk_size):
+            chunk = ordered_ids[start : start + chunk_size]
+            rows.extend(self.session.query(model).filter(column.in_(chunk)).all())
+        return rows
+
     def load(self, tag_ids: set[int]) -> PreloadedData:
-        initial_status_rows = self.session.query(TagStatus).filter(TagStatus.tag_id.in_(tag_ids)).all()
+        if not tag_ids:
+            return PreloadedData(
+                format_name_by_id={},
+                type_name_by_key={},
+                usage_by_key={},
+                tags_by_id={},
+                trans_by_tag_id={},
+                status_by_tag_format={},
+                statuses_by_tag_id={},
+            )
+
+        initial_status_rows = self._query_in_chunks(TagStatus, TagStatus.tag_id, tag_ids)
         preferred_ids = {
             row.preferred_tag_id for row in initial_status_rows if row.preferred_tag_id is not None
         }
         status_tag_ids = set(tag_ids) | preferred_ids
-        status_rows = self.session.query(TagStatus).filter(TagStatus.tag_id.in_(status_tag_ids)).all()
+        status_rows = self._query_in_chunks(TagStatus, TagStatus.tag_id, status_tag_ids)
         format_ids = {row.format_id for row in status_rows}
         format_name_by_id = {
             fmt.format_id: fmt.format_name
-            for fmt in self.session.query(TagFormat).filter(TagFormat.format_id.in_(format_ids)).all()
+            for fmt in self._query_in_chunks(TagFormat, TagFormat.format_id, format_ids)
         }
         type_name_by_key = {
             (mapping.format_id, mapping.type_id): (mapping.type_name.type_name if mapping.type_name else "")
-            for mapping in self.session.query(TagTypeFormatMapping)
-            .filter(TagTypeFormatMapping.format_id.in_(format_ids))
-            .all()
+            for mapping in self._query_in_chunks(
+                TagTypeFormatMapping,
+                TagTypeFormatMapping.format_id,
+                format_ids,
+            )
         }
         usage_by_key = {
             (usage.tag_id, usage.format_id): usage.count
-            for usage in self.session.query(TagUsageCounts)
-            .filter(TagUsageCounts.tag_id.in_(status_tag_ids))
-            .all()
+            for usage in self._query_in_chunks(TagUsageCounts, TagUsageCounts.tag_id, status_tag_ids)
         }
-        tags_by_id = {
-            t.tag_id: t for t in self.session.query(Tag).filter(Tag.tag_id.in_(status_tag_ids)).all()
-        }
-        all_translations = (
-            self.session.query(TagTranslation).filter(TagTranslation.tag_id.in_(status_tag_ids)).all()
-        )
+        tags_by_id = {t.tag_id: t for t in self._query_in_chunks(Tag, Tag.tag_id, status_tag_ids)}
+        all_translations = self._query_in_chunks(TagTranslation, TagTranslation.tag_id, status_tag_ids)
         trans_by_tag_id: dict[int, list[TagTranslation]] = {}
         for tr in all_translations:
             trans_by_tag_id.setdefault(tr.tag_id, []).append(tr)

--- a/src/genai_tag_db_tools/db/repository.py
+++ b/src/genai_tag_db_tools/db/repository.py
@@ -220,12 +220,14 @@ class TagReader:
         max_usage: int | None = None,
         alias: bool | None = None,
         resolve_preferred: bool = False,
+        limit: int | None = None,
+        offset: int = 0,
     ) -> list[TagSearchRow]:
         keyword, use_like = normalize_search_keyword(keyword, partial)
 
         with self.session_factory() as session:
             builder = TagSearchQueryBuilder(session)
-            tag_ids = builder.initial_tag_ids(keyword, use_like)
+            tag_ids = builder.initial_tag_ids(keyword, use_like, limit=limit, offset=offset)
             if not tag_ids:
                 return []
 

--- a/src/genai_tag_db_tools/models.py
+++ b/src/genai_tag_db_tools/models.py
@@ -93,6 +93,8 @@ class TagSearchRequest(BaseModel):
     include_deprecated: bool = Field(default=False, description="Include deprecated tags")
     min_usage: int | None = Field(default=None, description="Minimum usage count")
     max_usage: int | None = Field(default=None, description="Maximum usage count")
+    limit: int | None = Field(default=None, ge=1, description="Maximum number of rows")
+    offset: int = Field(default=0, ge=0, description="Number of rows to skip")
 
 
 class TagIdRef(BaseModel):

--- a/tests/unit/test_core_api.py
+++ b/tests/unit/test_core_api.py
@@ -157,6 +157,56 @@ def test_search_tags_filters_and_maps():
     assert result.total == 1
 
 
+def test_search_tags_applies_limit_and_offset_after_filtering():
+    rows = [
+        {
+            "tag": "cat",
+            "source_tag": "cat",
+            "tag_id": 1,
+            "format_name": "danbooru",
+            "type_id": 1,
+            "type_name": "general",
+            "alias": False,
+            "deprecated": False,
+            "usage_count": 100,
+            "translations": None,
+            "format_statuses": {"danbooru": {"status": "active"}},
+        },
+        {
+            "tag": "dog",
+            "source_tag": "dog",
+            "tag_id": 2,
+            "format_name": "danbooru",
+            "type_id": 1,
+            "type_name": "general",
+            "alias": False,
+            "deprecated": False,
+            "usage_count": 90,
+            "translations": None,
+            "format_statuses": {"danbooru": {"status": "active"}},
+        },
+        {
+            "tag": "fox",
+            "source_tag": "fox",
+            "tag_id": 3,
+            "format_name": "danbooru",
+            "type_id": 1,
+            "type_name": "general",
+            "alias": False,
+            "deprecated": False,
+            "usage_count": 80,
+            "translations": None,
+            "format_statuses": {"danbooru": {"status": "active"}},
+        },
+    ]
+    repo = DummyRepo(rows)
+    request = TagSearchRequest(query="a", limit=1, offset=1)
+    result = core_api.search_tags(repo, request)
+
+    assert [item.tag for item in result.items] == ["dog"]
+    assert result.total == 1
+
+
 def test_register_tag_delegates():
     service = DummyService()
     request = TagRegisterRequest(

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -106,6 +106,8 @@ def test_tag_search_request_defaults():
     assert request.resolve_preferred is True
     assert request.include_aliases is True
     assert request.include_deprecated is False
+    assert request.limit is None
+    assert request.offset == 0
 
 
 @pytest.mark.db_tools

--- a/tests/unit/test_tag_repository.py
+++ b/tests/unit/test_tag_repository.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import StaticPool
 
 from genai_tag_db_tools.db.repository import MergedTagReader, TagReader, TagRepository
-from genai_tag_db_tools.db.schema import Base, Tag, TagFormat, TagTranslation
+from genai_tag_db_tools.db.schema import Base, Tag, TagFormat, TagStatus, TagTranslation, TagTypeFormatMapping, TagTypeName
 
 pytestmark = pytest.mark.db_tools
 
@@ -81,6 +81,34 @@ def test_get_tag_languages_returns_sorted_list(session_factory: Callable[[], Ses
     languages = repo.get_tag_languages()
 
     assert languages == ["chinese", "english", "japanese"]
+
+
+def test_search_tags_handles_large_candidate_set_without_sqlite_variable_overflow(
+    session_factory: Callable[[], Session],
+) -> None:
+    reader = TagReader(session_factory)
+
+    with session_factory() as session:
+        session.add(TagFormat(format_id=1, format_name="test"))
+        session.add(TagTypeName(type_name_id=0, type_name="general"))
+        session.add(TagTypeFormatMapping(format_id=1, type_id=0, type_name_id=0))
+
+        for tag_id in range(1, 1205):
+            tag_name = f"sample_{tag_id}"
+            session.add(Tag(tag_id=tag_id, source_tag=tag_name, tag=tag_name))
+            session.add(
+                TagStatus(
+                    tag_id=tag_id,
+                    format_id=1,
+                    type_id=0,
+                    alias=False,
+                    preferred_tag_id=tag_id,
+                )
+            )
+        session.commit()
+
+    rows = reader.search_tags("sa", partial=True, format_name="test")
+    assert len(rows) == 1204
 
 
 def test_get_next_type_id_returns_zero_for_empty_format(session_factory: Callable[[], Session]) -> None:


### PR DESCRIPTION
### Motivation
- Large wildcard searches could produce very large candidate ID sets and cause SQLite `.in_(...)` queries to exceed variable limits, leading to runtime failures. 
- The public search API also referenced pagination behavior in docs but the models and API lacked explicit `limit`/`offset` fields and consistent application.

### Description
- Add a defensive chunked query helper `_query_in_chunks()` in `TagSearchPreloader` to execute `.in_(...)` filters in <=900-ID chunks and return combined rows. 
- Add empty-input fast path to `TagSearchPreloader.load()` to avoid unnecessary queries when no IDs are provided. 
- Expose `limit` and `offset` on `TagSearchRequest` (with `ge` validation) and add matching parameters to `TagSearchQueryBuilder.initial_tag_ids()` and `TagReader.search_tags()` to enable caller-side pagination control. 
- Apply API-level pagination after filtering in `core_api.search_tags()` and keep search behavior stable while enabling future optimizations. 
- Add regression and unit tests: a large-candidate regression test that seeds 1204 matching tags, plus model and API tests for the new pagination fields and behavior.

### Testing
- Ran unit tests covering modified areas: `tests/unit/test_models.py`, `tests/unit/test_core_api.py`, and `tests/unit/test_tag_repository.py`. 
- Command used: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q tests/unit/test_models.py tests/unit/test_core_api.py tests/unit/test_tag_repository.py`, and the run completed with `49 passed`. 
- The changes were validated by the new regression test which ensures broad searches no longer fail due to SQLite variable limits.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd372ae2bc8329aea157b4b5cb1f70)