### PR TITLE
Chunk IN queries in TagSearchPreloader to avoid SQLite variable limit and add pagination

### DIFF
--- a/src/genai_tag_db_tools/core_api.py
+++ b/src/genai_tag_db_tools/core_api.py
@@ -161,6 +161,12 @@ def search_tags(repo: MergedTagReader, request: TagSearchRequest) -> TagSearchRe
         resolve_preferred=request.resolve_preferred,
     )
     rows = _filter_rows(rows, request)
+    total = len(rows)
+
+    start = request.offset
+    end = start + request.limit if request.limit is not None else None
+    rows = rows[start:end]
+
     items = [
         TagRecordPublic(
             tag=row["tag"],
@@ -177,7 +183,7 @@ def search_tags(repo: MergedTagReader, request: TagSearchRequest) -> TagSearchRe
         )
         for row in rows
     ]
-    return TagSearchResult(items=items, total=len(items))
+    return TagSearchResult(items=items, total=total)
 
 
 def register_tag(service: TagRegisterService, request: TagRegisterRequest) -> TagRegisterResult:

--- a/src/genai_tag_db_tools/db/query_utils.py
+++ b/src/genai_tag_db_tools/db/query_utils.py
@@ -201,38 +201,60 @@ class TagSearchQueryBuilder:
 class TagSearchPreloader:
     """Preload related tag data to avoid N+1 queries during search."""
 
+    SQLITE_IN_LIMIT = 900
+
     def __init__(self, session: Session) -> None:
         self.session = session
 
+    def _query_in_chunks(self, query, column, ids: set[int]) -> list:
+        if not ids:
+            return []
+
+        id_list = sorted(ids)
+        rows: list = []
+        for i in range(0, len(id_list), self.SQLITE_IN_LIMIT):
+            chunk = id_list[i : i + self.SQLITE_IN_LIMIT]
+            rows.extend(query.filter(column.in_(chunk)).all())
+        return rows
+
     def load(self, tag_ids: set[int]) -> PreloadedData:
-        initial_status_rows = self.session.query(TagStatus).filter(TagStatus.tag_id.in_(tag_ids)).all()
+        initial_status_rows = self._query_in_chunks(
+            self.session.query(TagStatus), TagStatus.tag_id, tag_ids
+        )
         preferred_ids = {
             row.preferred_tag_id for row in initial_status_rows if row.preferred_tag_id is not None
         }
         status_tag_ids = set(tag_ids) | preferred_ids
-        status_rows = self.session.query(TagStatus).filter(TagStatus.tag_id.in_(status_tag_ids)).all()
+        status_rows = self._query_in_chunks(
+            self.session.query(TagStatus), TagStatus.tag_id, status_tag_ids
+        )
         format_ids = {row.format_id for row in status_rows}
-        format_name_by_id = {
-            fmt.format_id: fmt.format_name
-            for fmt in self.session.query(TagFormat).filter(TagFormat.format_id.in_(format_ids)).all()
-        }
+        format_rows = self._query_in_chunks(
+            self.session.query(TagFormat), TagFormat.format_id, format_ids
+        )
+        format_name_by_id = {fmt.format_id: fmt.format_name for fmt in format_rows}
         type_name_by_key = {
             (mapping.format_id, mapping.type_id): (mapping.type_name.type_name if mapping.type_name else "")
-            for mapping in self.session.query(TagTypeFormatMapping)
-            .filter(TagTypeFormatMapping.format_id.in_(format_ids))
-            .all()
+            for mapping in self._query_in_chunks(
+                self.session.query(TagTypeFormatMapping),
+                TagTypeFormatMapping.format_id,
+                format_ids,
+            )
         }
         usage_by_key = {
             (usage.tag_id, usage.format_id): usage.count
-            for usage in self.session.query(TagUsageCounts)
-            .filter(TagUsageCounts.tag_id.in_(status_tag_ids))
-            .all()
+            for usage in self._query_in_chunks(
+                self.session.query(TagUsageCounts), TagUsageCounts.tag_id, status_tag_ids
+            )
         }
         tags_by_id = {
-            t.tag_id: t for t in self.session.query(Tag).filter(Tag.tag_id.in_(status_tag_ids)).all()
+            t.tag_id: t
+            for t in self._query_in_chunks(self.session.query(Tag), Tag.tag_id, status_tag_ids)
         }
-        all_translations = (
-            self.session.query(TagTranslation).filter(TagTranslation.tag_id.in_(status_tag_ids)).all()
+        all_translations = self._query_in_chunks(
+            self.session.query(TagTranslation),
+            TagTranslation.tag_id,
+            status_tag_ids,
         )
         trans_by_tag_id: dict[int, list[TagTranslation]] = {}
         for tr in all_translations:

--- a/src/genai_tag_db_tools/models.py
+++ b/src/genai_tag_db_tools/models.py
@@ -93,6 +93,8 @@ class TagSearchRequest(BaseModel):
     include_deprecated: bool = Field(default=False, description="Include deprecated tags")
     min_usage: int | None = Field(default=None, description="Minimum usage count")
     max_usage: int | None = Field(default=None, description="Maximum usage count")
+    limit: int | None = Field(default=None, ge=1, description="Maximum number of items to return")
+    offset: int = Field(default=0, ge=0, description="Number of items to skip")
 
 
 class TagIdRef(BaseModel):

--- a/tests/unit/test_core_api.py
+++ b/tests/unit/test_core_api.py
@@ -157,6 +157,32 @@ def test_search_tags_filters_and_maps():
     assert result.total == 1
 
 
+def test_search_tags_applies_offset_and_limit():
+    rows = [
+        {
+            "tag": f"tag{i}",
+            "source_tag": f"tag{i}",
+            "tag_id": i,
+            "format_name": "danbooru",
+            "type_id": 1,
+            "type_name": "general",
+            "alias": False,
+            "deprecated": False,
+            "usage_count": 100,
+            "translations": None,
+            "format_statuses": {"danbooru": {"status": "active"}},
+        }
+        for i in range(1, 6)
+    ]
+    repo = DummyRepo(rows)
+    request = TagSearchRequest(query="tag", partial=True, offset=1, limit=2)
+
+    result = core_api.search_tags(repo, request)
+
+    assert [item.tag for item in result.items] == ["tag2", "tag3"]
+    assert result.total == 5
+
+
 def test_register_tag_delegates():
     service = DummyService()
     request = TagRegisterRequest(

--- a/tests/unit/test_query_utils.py
+++ b/tests/unit/test_query_utils.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from genai_tag_db_tools.db.query_utils import TagSearchPreloader
+from genai_tag_db_tools.db.schema import Base, Tag, TagFormat, TagStatus, TagTypeFormatMapping, TagTypeName
+
+pytestmark = pytest.mark.db_tools
+
+
+@pytest.fixture()
+def session_factory() -> Callable[[], Session]:
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine, autoflush=False, autocommit=False)
+
+
+def test_preloader_load_chunks_large_in_queries(session_factory: Callable[[], Session], monkeypatch) -> None:
+    with session_factory() as session:
+        session.add(TagFormat(format_id=1, format_name="test"))
+        session.add(TagTypeName(type_name_id=0, type_name="general"))
+        session.add(TagTypeFormatMapping(format_id=1, type_id=0, type_name_id=0))
+        for tag_id in range(1, 8):
+            session.add(Tag(tag_id=tag_id, source_tag=f"s{tag_id}", tag=f"t{tag_id}"))
+            session.add(
+                TagStatus(
+                    tag_id=tag_id,
+                    format_id=1,
+                    type_id=0,
+                    alias=False,
+                    preferred_tag_id=tag_id,
+                )
+            )
+        session.commit()
+
+    monkeypatch.setattr(TagSearchPreloader, "SQLITE_IN_LIMIT", 2)
+
+    with session_factory() as session:
+        preloader = TagSearchPreloader(session)
+        loaded = preloader.load(set(range(1, 8)))
+
+    assert len(loaded.tags_by_id) == 7
+    assert len(loaded.status_by_tag_format) == 7


### PR DESCRIPTION
### Motivation

- Prevent search failures caused by SQLite "too many SQL variables" when preloading many IDs by making the preloader robust to large `IN (...)` queries.
- Provide API-level pagination support so callers can request slices of results without relying on external filtering.

### Description

- Add `TagSearchPreloader.SQLITE_IN_LIMIT` and implement `_query_in_chunks()` to split `.in_(...)` queries into safe-sized chunks and use it for all preloader queries in `src/genai_tag_db_tools/db/query_utils.py`.
- Add `limit` and `offset` fields to `TagSearchRequest` in `src/genai_tag_db_tools/models.py` with basic validation (`limit>=1`, `offset>=0`).
- Apply pagination in `core_api.search_tags()` by computing `total` before slicing and returning the page of `TagRecordPublic` items in `src/genai_tag_db_tools/core_api.py`.
- Add unit tests: `tests/unit/test_query_utils.py` exercises chunking behavior and `tests/unit/test_core_api.py` gained a test for `offset/limit` handling.

### Testing

- Ran `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q tests/unit/test_query_utils.py tests/unit/test_core_api.py` and all tests passed (`9 passed`).
- Running `uv run ruff check ...` on the changed files passed with no issues.
- Note: an initial `pytest` run without disabling plugin autoload failed in this environment due to missing system deps (`libGL.so.1`) and missing test-time imports, so the isolated runs above were used to validate the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd372ae2bc8329aea157b4b5cb1f70)