### PR TITLE
Fix SQLite bind-variable overflow in tag search; add pagination and chunked preloading

### DIFF
--- a/src/genai_tag_db_tools/core_api.py
+++ b/src/genai_tag_db_tools/core_api.py
@@ -159,6 +159,8 @@ def search_tags(repo: MergedTagReader, request: TagSearchRequest) -> TagSearchRe
         format_name=format_name,
         type_name=type_name,
         resolve_preferred=request.resolve_preferred,
+        limit=request.limit,
+        offset=request.offset,
     )
     rows = _filter_rows(rows, request)
     items = [

--- a/src/genai_tag_db_tools/db/query_utils.py
+++ b/src/genai_tag_db_tools/db/query_utils.py
@@ -48,7 +48,14 @@ class TagSearchQueryBuilder:
     def __init__(self, session: Session) -> None:
         self.session = session
 
-    def initial_tag_ids(self, keyword: str, use_like: bool) -> set[int]:
+    def initial_tag_ids(
+        self,
+        keyword: str,
+        use_like: bool,
+        *,
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> set[int]:
         tag_query = self.session.query(Tag.tag_id)
         translation_query = self.session.query(TagTranslation.tag_id)
 
@@ -62,6 +69,13 @@ class TagSearchQueryBuilder:
             TagTranslation.translation.like(keyword) if use_like else TagTranslation.translation == keyword
         )
         translation_query = translation_query.filter(translation_condition)
+
+        if offset:
+            tag_query = tag_query.offset(offset)
+            translation_query = translation_query.offset(offset)
+        if limit is not None:
+            tag_query = tag_query.limit(limit)
+            translation_query = translation_query.limit(limit)
 
         tag_ids = {row[0] for row in tag_query.all()}
         translation_ids = {row[0] for row in translation_query.all()}
@@ -204,13 +218,29 @@ class TagSearchPreloader:
     def __init__(self, session: Session) -> None:
         self.session = session
 
+    def _chunk_size(self) -> int:
+        if self.session.bind is not None and self.session.bind.dialect.name == "sqlite":
+            return 900
+        return 10_000
+
+    def _query_in_chunks(self, model: object, column: object, ids: set[int]) -> list[object]:
+        if not ids:
+            return []
+        ids_list = list(ids)
+        chunk_size = self._chunk_size()
+        rows: list[object] = []
+        for i in range(0, len(ids_list), chunk_size):
+            chunk = ids_list[i : i + chunk_size]
+            rows.extend(self.session.query(model).filter(column.in_(chunk)).all())
+        return rows
+
     def load(self, tag_ids: set[int]) -> PreloadedData:
-        initial_status_rows = self.session.query(TagStatus).filter(TagStatus.tag_id.in_(tag_ids)).all()
+        initial_status_rows = self._query_in_chunks(TagStatus, TagStatus.tag_id, tag_ids)
         preferred_ids = {
             row.preferred_tag_id for row in initial_status_rows if row.preferred_tag_id is not None
         }
         status_tag_ids = set(tag_ids) | preferred_ids
-        status_rows = self.session.query(TagStatus).filter(TagStatus.tag_id.in_(status_tag_ids)).all()
+        status_rows = self._query_in_chunks(TagStatus, TagStatus.tag_id, status_tag_ids)
         format_ids = {row.format_id for row in status_rows}
         format_name_by_id = {
             fmt.format_id: fmt.format_name
@@ -224,16 +254,12 @@ class TagSearchPreloader:
         }
         usage_by_key = {
             (usage.tag_id, usage.format_id): usage.count
-            for usage in self.session.query(TagUsageCounts)
-            .filter(TagUsageCounts.tag_id.in_(status_tag_ids))
-            .all()
+            for usage in self._query_in_chunks(TagUsageCounts, TagUsageCounts.tag_id, status_tag_ids)
         }
         tags_by_id = {
-            t.tag_id: t for t in self.session.query(Tag).filter(Tag.tag_id.in_(status_tag_ids)).all()
+            t.tag_id: t for t in self._query_in_chunks(Tag, Tag.tag_id, status_tag_ids)
         }
-        all_translations = (
-            self.session.query(TagTranslation).filter(TagTranslation.tag_id.in_(status_tag_ids)).all()
-        )
+        all_translations = self._query_in_chunks(TagTranslation, TagTranslation.tag_id, status_tag_ids)
         trans_by_tag_id: dict[int, list[TagTranslation]] = {}
         for tr in all_translations:
             trans_by_tag_id.setdefault(tr.tag_id, []).append(tr)

--- a/src/genai_tag_db_tools/db/repository.py
+++ b/src/genai_tag_db_tools/db/repository.py
@@ -220,12 +220,14 @@ class TagReader:
         max_usage: int | None = None,
         alias: bool | None = None,
         resolve_preferred: bool = False,
+        limit: int | None = None,
+        offset: int = 0,
     ) -> list[TagSearchRow]:
         keyword, use_like = normalize_search_keyword(keyword, partial)
 
         with self.session_factory() as session:
             builder = TagSearchQueryBuilder(session)
-            tag_ids = builder.initial_tag_ids(keyword, use_like)
+            tag_ids = builder.initial_tag_ids(keyword, use_like, limit=limit, offset=offset)
             if not tag_ids:
                 return []
 
@@ -1413,6 +1415,8 @@ class MergedTagReader:
         max_usage: int | None = None,
         alias: bool | None = None,
         resolve_preferred: bool = False,
+        limit: int | None = None,
+        offset: int = 0,
     ) -> list[TagSearchRow]:
         return self._merge_by_key(
             "search_tags",
@@ -1426,6 +1430,8 @@ class MergedTagReader:
             max_usage=max_usage,
             alias=alias,
             resolve_preferred=resolve_preferred,
+            limit=limit,
+            offset=offset,
         )
 
     def search_tags_bulk(

--- a/src/genai_tag_db_tools/models.py
+++ b/src/genai_tag_db_tools/models.py
@@ -93,6 +93,8 @@ class TagSearchRequest(BaseModel):
     include_deprecated: bool = Field(default=False, description="Include deprecated tags")
     min_usage: int | None = Field(default=None, description="Minimum usage count")
     max_usage: int | None = Field(default=None, description="Maximum usage count")
+    limit: int | None = Field(default=None, ge=1, description="Maximum number of rows to return")
+    offset: int = Field(default=0, ge=0, description="Offset for pagination")
 
 
 class TagIdRef(BaseModel):

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -106,6 +106,8 @@ def test_tag_search_request_defaults():
     assert request.resolve_preferred is True
     assert request.include_aliases is True
     assert request.include_deprecated is False
+    assert request.limit is None
+    assert request.offset == 0
 
 
 @pytest.mark.db_tools

--- a/tests/unit/test_query_utils.py
+++ b/tests/unit/test_query_utils.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from genai_tag_db_tools.db.query_utils import TagSearchPreloader, TagSearchQueryBuilder
+from genai_tag_db_tools.db.schema import Base, Tag, TagFormat, TagStatus, TagTypeFormatMapping, TagTypeName
+
+pytestmark = pytest.mark.db_tools
+
+
+@pytest.fixture()
+def session_factory() -> Callable[[], Session]:
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine, autoflush=False, autocommit=False)
+
+
+def _seed_minimal_schema(session: Session, total_tags: int) -> None:
+    session.add(TagFormat(format_id=1, format_name="test"))
+    session.add(TagTypeName(type_name_id=1, type_name="general"))
+    session.add(TagTypeFormatMapping(format_id=1, type_id=0, type_name_id=1))
+    for tag_id in range(1, total_tags + 1):
+        tag_name = f"sample_{tag_id}"
+        session.add(Tag(tag_id=tag_id, source_tag=tag_name, tag=tag_name))
+        session.add(
+            TagStatus(
+                tag_id=tag_id,
+                format_id=1,
+                type_id=0,
+                alias=False,
+                preferred_tag_id=tag_id,
+                deprecated=False,
+            )
+        )
+    session.commit()
+
+
+def test_initial_tag_ids_respects_limit_and_offset(session_factory: Callable[[], Session]) -> None:
+    with session_factory() as session:
+        _seed_minimal_schema(session, total_tags=20)
+        builder = TagSearchQueryBuilder(session)
+        ids = builder.initial_tag_ids("%sample_%", use_like=True, limit=5, offset=3)
+        assert len(ids) == 5
+
+
+def test_preloader_load_handles_large_id_sets_with_chunking(
+    session_factory: Callable[[], Session], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    with session_factory() as session:
+        _seed_minimal_schema(session, total_tags=1200)
+        preloader = TagSearchPreloader(session)
+        monkeypatch.setattr(preloader, "_chunk_size", lambda: 200)
+
+        preloaded = preloader.load(set(range(1, 1201)))
+
+        assert len(preloaded.tags_by_id) == 1200
+        assert len(preloaded.statuses_by_tag_id) == 1200


### PR DESCRIPTION
### Motivation

- Prevent runtime SQLite errors (`too many SQL variables`) when large candidate ID sets are used during tag search by making preloading robust and by enabling early candidate trimming via pagination.
- Expose pagination parameters so callers can limit the number of candidates produced by initial ID queries and keep API backward-compatible.

### Description

- Added `limit` and `offset` fields to `TagSearchRequest` and preserved sensible defaults (`limit=None`, `offset=0`) so existing callers remain compatible.
- Propagated `limit`/`offset` through `core_api.search_tags()` into repository search calls and extended `TagSearchQueryBuilder.initial_tag_ids()` to accept and apply `limit`/`offset` to the initial tag/translation queries.
- Reworked `TagSearchPreloader` to perform `.in_(...)` loads in chunks via new helpers `TagSearchPreloader._chunk_size()` and `TagSearchPreloader._query_in_chunks()`, using a safe default chunk size of `900` for SQLite and a larger default for other dialects, and replaced large single `.in_(...)` queries with chunked queries for `TagStatus`, `TagUsageCounts`, `Tag`, and `TagTranslation`.
- Added `tests/unit/test_query_utils.py` with regression tests for `initial_tag_ids` pagination and chunked preload behavior and updated `tests/unit/test_models.py` to assert the new `TagSearchRequest` defaults.

### Testing

- Ran `python -m compileall src tests/unit/test_query_utils.py` which completed successfully and confirmed modules compile with the changes.
- Attempted `pytest -q tests/unit/test_query_utils.py tests/unit/test_models.py tests/unit/test_core_api.py` but test collection failed due to missing environment dependencies (`sqlalchemy`, `pydantic`) in the execution environment so full test run could not be completed here.
- Added and committed the changes, including the new tests, for CI to run in the project environment where dependencies are available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd372ae2bc8329aea157b4b5cb1f70)