### PR TITLE
Prevent SQLite variable overflow in tag search with chunked preloading and add pagination

### DIFF
--- a/src/genai_tag_db_tools/core_api.py
+++ b/src/genai_tag_db_tools/core_api.py
@@ -161,6 +161,11 @@ def search_tags(repo: MergedTagReader, request: TagSearchRequest) -> TagSearchRe
         resolve_preferred=request.resolve_preferred,
     )
     rows = _filter_rows(rows, request)
+    total = len(rows)
+    if request.offset:
+        rows = rows[request.offset :]
+    if request.limit is not None:
+        rows = rows[: request.limit]
     items = [
         TagRecordPublic(
             tag=row["tag"],
@@ -177,7 +182,7 @@ def search_tags(repo: MergedTagReader, request: TagSearchRequest) -> TagSearchRe
         )
         for row in rows
     ]
-    return TagSearchResult(items=items, total=len(items))
+    return TagSearchResult(items=items, total=total)
 
 
 def register_tag(service: TagRegisterService, request: TagRegisterRequest) -> TagRegisterResult:

--- a/src/genai_tag_db_tools/db/query_utils.py
+++ b/src/genai_tag_db_tools/db/query_utils.py
@@ -1,6 +1,7 @@
 from logging import Logger
 from typing import TypedDict
 
+from sqlalchemy import text
 from sqlalchemy.orm import Session
 from sqlalchemy.sql import or_
 
@@ -203,36 +204,95 @@ class TagSearchPreloader:
 
     def __init__(self, session: Session) -> None:
         self.session = session
+        self._max_in_clause_items = self._detect_max_in_clause_items()
+
+    def _detect_max_in_clause_items(self) -> int:
+        bind = self.session.get_bind()
+        if bind is None or bind.dialect.name != "sqlite":
+            return 5000
+
+        try:
+            rows = self.session.execute(text("PRAGMA compile_options")).all()
+        except Exception:
+            return 900
+
+        for row in rows:
+            option = row[0] if row else None
+            if not isinstance(option, str):
+                continue
+            if not option.startswith("MAX_VARIABLE_NUMBER="):
+                continue
+            value = option.split("=", 1)[1]
+            if not value.isdigit():
+                continue
+            detected = int(value)
+            return max(1, detected - 50)
+
+        return 900
+
+    def _query_all_in_chunks(self, query, column, values: set[int]) -> list:
+        if not values:
+            return []
+
+        value_list = sorted(values)
+        if len(value_list) <= self._max_in_clause_items:
+            return query.filter(column.in_(value_list)).all()
+
+        rows: list = []
+        chunk_size = self._max_in_clause_items
+        for start in range(0, len(value_list), chunk_size):
+            chunk = value_list[start : start + chunk_size]
+            rows.extend(query.filter(column.in_(chunk)).all())
+        return rows
 
     def load(self, tag_ids: set[int]) -> PreloadedData:
-        initial_status_rows = self.session.query(TagStatus).filter(TagStatus.tag_id.in_(tag_ids)).all()
+        initial_status_rows = self._query_all_in_chunks(
+            self.session.query(TagStatus),
+            TagStatus.tag_id,
+            tag_ids,
+        )
         preferred_ids = {
             row.preferred_tag_id for row in initial_status_rows if row.preferred_tag_id is not None
         }
         status_tag_ids = set(tag_ids) | preferred_ids
-        status_rows = self.session.query(TagStatus).filter(TagStatus.tag_id.in_(status_tag_ids)).all()
+        status_rows = self._query_all_in_chunks(
+            self.session.query(TagStatus),
+            TagStatus.tag_id,
+            status_tag_ids,
+        )
         format_ids = {row.format_id for row in status_rows}
-        format_name_by_id = {
-            fmt.format_id: fmt.format_name
-            for fmt in self.session.query(TagFormat).filter(TagFormat.format_id.in_(format_ids)).all()
-        }
+        format_rows = self._query_all_in_chunks(
+            self.session.query(TagFormat),
+            TagFormat.format_id,
+            format_ids,
+        )
+        format_name_by_id = {fmt.format_id: fmt.format_name for fmt in format_rows}
         type_name_by_key = {
             (mapping.format_id, mapping.type_id): (mapping.type_name.type_name if mapping.type_name else "")
-            for mapping in self.session.query(TagTypeFormatMapping)
-            .filter(TagTypeFormatMapping.format_id.in_(format_ids))
-            .all()
+            for mapping in self._query_all_in_chunks(
+                self.session.query(TagTypeFormatMapping),
+                TagTypeFormatMapping.format_id,
+                format_ids,
+            )
         }
         usage_by_key = {
             (usage.tag_id, usage.format_id): usage.count
-            for usage in self.session.query(TagUsageCounts)
-            .filter(TagUsageCounts.tag_id.in_(status_tag_ids))
-            .all()
+            for usage in self._query_all_in_chunks(
+                self.session.query(TagUsageCounts),
+                TagUsageCounts.tag_id,
+                status_tag_ids,
+            )
         }
-        tags_by_id = {
-            t.tag_id: t for t in self.session.query(Tag).filter(Tag.tag_id.in_(status_tag_ids)).all()
-        }
-        all_translations = (
-            self.session.query(TagTranslation).filter(TagTranslation.tag_id.in_(status_tag_ids)).all()
+        tag_rows = self._query_all_in_chunks(
+            self.session.query(Tag),
+            Tag.tag_id,
+            status_tag_ids,
+        )
+        tags_by_id = {t.tag_id: t for t in tag_rows}
+        all_translations = self._query_all_in_chunks(
+            self.session.query(TagTranslation),
+            TagTranslation.tag_id,
+            status_tag_ids,
         )
         trans_by_tag_id: dict[int, list[TagTranslation]] = {}
         for tr in all_translations:

--- a/src/genai_tag_db_tools/models.py
+++ b/src/genai_tag_db_tools/models.py
@@ -93,6 +93,8 @@ class TagSearchRequest(BaseModel):
     include_deprecated: bool = Field(default=False, description="Include deprecated tags")
     min_usage: int | None = Field(default=None, description="Minimum usage count")
     max_usage: int | None = Field(default=None, description="Maximum usage count")
+    limit: int | None = Field(default=None, ge=1, description="Maximum number of items")
+    offset: int = Field(default=0, ge=0, description="Offset for pagination")
 
 
 class TagIdRef(BaseModel):

--- a/tests/unit/test_core_api.py
+++ b/tests/unit/test_core_api.py
@@ -157,6 +157,39 @@ def test_search_tags_filters_and_maps():
     assert result.total == 1
 
 
+def test_search_tags_applies_offset_and_limit_but_keeps_total():
+    rows = [
+        {
+            "tag": f"tag{i}",
+            "source_tag": f"tag{i}",
+            "tag_id": i,
+            "format_name": "danbooru",
+            "type_id": 1,
+            "type_name": "general",
+            "alias": False,
+            "deprecated": False,
+            "usage_count": 100,
+            "translations": None,
+            "format_statuses": {"danbooru": {"status": "active"}},
+        }
+        for i in range(1, 6)
+    ]
+    repo = DummyRepo(rows)
+    request = TagSearchRequest(
+        query="tag",
+        partial=True,
+        include_aliases=True,
+        include_deprecated=True,
+        offset=1,
+        limit=2,
+    )
+
+    result = core_api.search_tags(repo, request)
+
+    assert [item.tag_id for item in result.items] == [2, 3]
+    assert result.total == 5
+
+
 def test_register_tag_delegates():
     service = DummyService()
     request = TagRegisterRequest(

--- a/tests/unit/test_tag_repository.py
+++ b/tests/unit/test_tag_repository.py
@@ -9,7 +9,15 @@ from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import StaticPool
 
 from genai_tag_db_tools.db.repository import MergedTagReader, TagReader, TagRepository
-from genai_tag_db_tools.db.schema import Base, Tag, TagFormat, TagTranslation
+from genai_tag_db_tools.db.schema import (
+    Base,
+    Tag,
+    TagFormat,
+    TagStatus,
+    TagTranslation,
+    TagTypeFormatMapping,
+    TagTypeName,
+)
 
 pytestmark = pytest.mark.db_tools
 
@@ -90,6 +98,40 @@ def test_get_next_type_id_returns_zero_for_empty_format(session_factory: Callabl
     next_type_id = repo.get_next_type_id(format_id=1000)
 
     assert next_type_id == 0
+
+
+def test_search_tags_handles_large_result_set_without_sqlite_variable_error(
+    session_factory: Callable[[], Session],
+) -> None:
+    reader = TagReader(session_factory)
+    total_tags = 1200
+
+    with session_factory() as session:
+        session.add(TagFormat(format_id=1, format_name="danbooru"))
+        session.add(TagTypeName(type_name_id=1, type_name="general"))
+        session.add(TagTypeFormatMapping(format_id=1, type_id=0, type_name_id=1))
+
+        for tag_id in range(1, total_tags + 1):
+            source_tag = f"sample_{tag_id}"
+            session.add(Tag(tag_id=tag_id, tag=source_tag, source_tag=source_tag))
+            session.add(
+                TagStatus(
+                    tag_id=tag_id,
+                    format_id=1,
+                    type_id=0,
+                    alias=False,
+                    preferred_tag_id=tag_id,
+                )
+            )
+        session.commit()
+
+    rows = reader.search_tags(
+        "sa",
+        partial=True,
+        resolve_preferred=False,
+    )
+
+    assert len(rows) == total_tags
 
 
 def test_get_next_type_id_returns_incremented_value(session_factory: Callable[[], Session]) -> None:


### PR DESCRIPTION
### Motivation
- Long-running `search_tags` calls can build very large `tag_id` sets which trigger SQLite "too many SQL variables" errors when used in `.in_(...)` queries. 
- The previous plan relied on callers to provide `limit`, which is not robust for callers that omit it, so preloading must be defensive. 
- Search API should also support simple pagination while preserving the total count for clients. 

### Description
- Added `TagSearchPreloader._detect_max_in_clause_items()` to detect SQLite `MAX_VARIABLE_NUMBER` via `PRAGMA compile_options` and compute a safe bind-variable limit. 
- Implemented `_query_all_in_chunks(query, column, values)` and switched all preloads in `TagSearchPreloader.load()` to chunked `.in_(...)` queries for `TagStatus`, `TagFormat`, `TagTypeFormatMapping`, `TagUsageCounts`, `Tag`, and `TagTranslation` to avoid bind-variable overflow. 
- Added `limit` and `offset` fields to `TagSearchRequest` (with validation `limit >= 1` and `offset >= 0`) and applied pagination in `core_api.search_tags()` while returning `total` as the pre-pagination count. 
- Added regression tests: a large-result test that creates 1200 tags to ensure no SQLite variable error, and a pagination behavior test that verifies `offset`/`limit` slicing while preserving `total`. 

### Testing
- Running targeted tests initially failed in some environments due to missing optional runtime deps (`polars`, `sqlalchemy`) or `libGL.so.1` causing `pytestqt` initialization errors, which are environment issues unrelated to the logic. 
- Executed the focused test run with plugin autoload disabled using `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest -q tests/unit/test_tag_repository.py::test_search_tags_handles_large_result_set_without_sqlite_variable_error tests/unit/test_core_api.py::test_search_tags_applies_offset_and_limit_but_keeps_total` and both tests passed (`2 passed`). 
- The added tests exercise the chunked preloading logic and pagination behavior and succeeded in the CI-like run above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd372ae2bc8329aea157b4b5cb1f70)