### PR TITLE
fix: SQLite IN句変数上限超過を防ぐチャンク分割とページネーション追加

### DIFF
--- a/src/genai_tag_db_tools/core_api.py
+++ b/src/genai_tag_db_tools/core_api.py
@@ -161,6 +161,11 @@ def search_tags(repo: MergedTagReader, request: TagSearchRequest) -> TagSearchRe
         resolve_preferred=request.resolve_preferred,
     )
     rows = _filter_rows(rows, request)
+    total = len(rows)
+    if request.offset:
+        rows = rows[request.offset :]
+    if request.limit is not None:
+        rows = rows[: request.limit]
     items = [
         TagRecordPublic(
             tag=row["tag"],
@@ -177,7 +182,7 @@ def search_tags(repo: MergedTagReader, request: TagSearchRequest) -> TagSearchRe
         )
         for row in rows
     ]
-    return TagSearchResult(items=items, total=len(items))
+    return TagSearchResult(items=items, total=total)
 
 
 def register_tag(service: TagRegisterService, request: TagRegisterRequest) -> TagRegisterResult:

--- a/src/genai_tag_db_tools/db/query_utils.py
+++ b/src/genai_tag_db_tools/db/query_utils.py
@@ -1,5 +1,5 @@
 from logging import Logger
-from typing import TypedDict
+from typing import Any, TypedDict
 
 from sqlalchemy.orm import Session
 from sqlalchemy.sql import or_
@@ -48,7 +48,14 @@ class TagSearchQueryBuilder:
     def __init__(self, session: Session) -> None:
         self.session = session
 
-    def initial_tag_ids(self, keyword: str, use_like: bool) -> set[int]:
+    def initial_tag_ids(
+        self,
+        keyword: str,
+        use_like: bool,
+        *,
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> set[int]:
         tag_query = self.session.query(Tag.tag_id)
         translation_query = self.session.query(TagTranslation.tag_id)
 
@@ -62,6 +69,13 @@ class TagSearchQueryBuilder:
             TagTranslation.translation.like(keyword) if use_like else TagTranslation.translation == keyword
         )
         translation_query = translation_query.filter(translation_condition)
+
+        if offset:
+            tag_query = tag_query.offset(offset)
+            translation_query = translation_query.offset(offset)
+        if limit is not None:
+            tag_query = tag_query.limit(limit)
+            translation_query = translation_query.limit(limit)
 
         tag_ids = {row[0] for row in tag_query.all()}
         translation_ids = {row[0] for row in translation_query.all()}
@@ -201,38 +215,72 @@ class TagSearchQueryBuilder:
 class TagSearchPreloader:
     """Preload related tag data to avoid N+1 queries during search."""
 
+    SQLITE_IN_LIMIT = 900
+
     def __init__(self, session: Session) -> None:
         self.session = session
 
+    def _query_in_chunks(self, query: Any, column: Any, ids: set[int]) -> list:
+        """SQLite の IN 句変数上限を避けるため、ids をチャンク分割してクエリを実行する。"""
+        if not ids:
+            return []
+
+        id_list = sorted(ids)
+        rows: list = []
+        for i in range(0, len(id_list), self.SQLITE_IN_LIMIT):
+            chunk = id_list[i : i + self.SQLITE_IN_LIMIT]
+            rows.extend(query.filter(column.in_(chunk)).all())
+        return rows
+
     def load(self, tag_ids: set[int]) -> PreloadedData:
-        initial_status_rows = self.session.query(TagStatus).filter(TagStatus.tag_id.in_(tag_ids)).all()
+        if not tag_ids:
+            return PreloadedData(
+                format_name_by_id={},
+                type_name_by_key={},
+                usage_by_key={},
+                tags_by_id={},
+                trans_by_tag_id={},
+                status_by_tag_format={},
+                statuses_by_tag_id={},
+            )
+
+        initial_status_rows = self._query_in_chunks(
+            self.session.query(TagStatus), TagStatus.tag_id, tag_ids
+        )
         preferred_ids = {
             row.preferred_tag_id for row in initial_status_rows if row.preferred_tag_id is not None
         }
         status_tag_ids = set(tag_ids) | preferred_ids
-        status_rows = self.session.query(TagStatus).filter(TagStatus.tag_id.in_(status_tag_ids)).all()
+        status_rows = self._query_in_chunks(
+            self.session.query(TagStatus), TagStatus.tag_id, status_tag_ids
+        )
         format_ids = {row.format_id for row in status_rows}
         format_name_by_id = {
             fmt.format_id: fmt.format_name
-            for fmt in self.session.query(TagFormat).filter(TagFormat.format_id.in_(format_ids)).all()
+            for fmt in self._query_in_chunks(
+                self.session.query(TagFormat), TagFormat.format_id, format_ids
+            )
         }
         type_name_by_key = {
             (mapping.format_id, mapping.type_id): (mapping.type_name.type_name if mapping.type_name else "")
-            for mapping in self.session.query(TagTypeFormatMapping)
-            .filter(TagTypeFormatMapping.format_id.in_(format_ids))
-            .all()
+            for mapping in self._query_in_chunks(
+                self.session.query(TagTypeFormatMapping),
+                TagTypeFormatMapping.format_id,
+                format_ids,
+            )
         }
         usage_by_key = {
             (usage.tag_id, usage.format_id): usage.count
-            for usage in self.session.query(TagUsageCounts)
-            .filter(TagUsageCounts.tag_id.in_(status_tag_ids))
-            .all()
+            for usage in self._query_in_chunks(
+                self.session.query(TagUsageCounts), TagUsageCounts.tag_id, status_tag_ids
+            )
         }
         tags_by_id = {
-            t.tag_id: t for t in self.session.query(Tag).filter(Tag.tag_id.in_(status_tag_ids)).all()
+            t.tag_id: t
+            for t in self._query_in_chunks(self.session.query(Tag), Tag.tag_id, status_tag_ids)
         }
-        all_translations = (
-            self.session.query(TagTranslation).filter(TagTranslation.tag_id.in_(status_tag_ids)).all()
+        all_translations = self._query_in_chunks(
+            self.session.query(TagTranslation), TagTranslation.tag_id, status_tag_ids
         )
         trans_by_tag_id: dict[int, list[TagTranslation]] = {}
         for tr in all_translations:

--- a/src/genai_tag_db_tools/db/repository.py
+++ b/src/genai_tag_db_tools/db/repository.py
@@ -220,12 +220,14 @@ class TagReader:
         max_usage: int | None = None,
         alias: bool | None = None,
         resolve_preferred: bool = False,
+        limit: int | None = None,
+        offset: int = 0,
     ) -> list[TagSearchRow]:
         keyword, use_like = normalize_search_keyword(keyword, partial)
 
         with self.session_factory() as session:
             builder = TagSearchQueryBuilder(session)
-            tag_ids = builder.initial_tag_ids(keyword, use_like)
+            tag_ids = builder.initial_tag_ids(keyword, use_like, limit=limit, offset=offset)
             if not tag_ids:
                 return []
 
@@ -1413,6 +1415,8 @@ class MergedTagReader:
         max_usage: int | None = None,
         alias: bool | None = None,
         resolve_preferred: bool = False,
+        limit: int | None = None,
+        offset: int = 0,
     ) -> list[TagSearchRow]:
         return self._merge_by_key(
             "search_tags",
@@ -1426,6 +1430,8 @@ class MergedTagReader:
             max_usage=max_usage,
             alias=alias,
             resolve_preferred=resolve_preferred,
+            limit=limit,
+            offset=offset,
         )
 
     def search_tags_bulk(

--- a/src/genai_tag_db_tools/models.py
+++ b/src/genai_tag_db_tools/models.py
@@ -93,6 +93,8 @@ class TagSearchRequest(BaseModel):
     include_deprecated: bool = Field(default=False, description="Include deprecated tags")
     min_usage: int | None = Field(default=None, description="Minimum usage count")
     max_usage: int | None = Field(default=None, description="Maximum usage count")
+    limit: int | None = Field(default=None, ge=1, description="Maximum number of items to return")
+    offset: int = Field(default=0, ge=0, description="Number of items to skip")
 
 
 class TagIdRef(BaseModel):

--- a/tests/unit/test_core_api.py
+++ b/tests/unit/test_core_api.py
@@ -157,6 +157,39 @@ def test_search_tags_filters_and_maps():
     assert result.total == 1
 
 
+def test_search_tags_applies_offset_and_limit_preserves_total():
+    rows = [
+        {
+            "tag": f"tag{i}",
+            "source_tag": f"tag{i}",
+            "tag_id": i,
+            "format_name": "danbooru",
+            "type_id": 1,
+            "type_name": "general",
+            "alias": False,
+            "deprecated": False,
+            "usage_count": 100,
+            "translations": None,
+            "format_statuses": {"danbooru": {"status": "active"}},
+        }
+        for i in range(1, 6)
+    ]
+    repo = DummyRepo(rows)
+    request = TagSearchRequest(
+        query="tag",
+        partial=True,
+        include_aliases=True,
+        include_deprecated=True,
+        offset=1,
+        limit=2,
+    )
+
+    result = core_api.search_tags(repo, request)
+
+    assert [item.tag_id for item in result.items] == [2, 3]
+    assert result.total == 5
+
+
 def test_register_tag_delegates():
     service = DummyService()
     request = TagRegisterRequest(

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -106,6 +106,8 @@ def test_tag_search_request_defaults():
     assert request.resolve_preferred is True
     assert request.include_aliases is True
     assert request.include_deprecated is False
+    assert request.limit is None
+    assert request.offset == 0
 
 
 @pytest.mark.db_tools

--- a/tests/unit/test_query_utils.py
+++ b/tests/unit/test_query_utils.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from genai_tag_db_tools.db.query_utils import TagSearchPreloader, TagSearchQueryBuilder
+from genai_tag_db_tools.db.schema import (
+    Base,
+    Tag,
+    TagFormat,
+    TagStatus,
+    TagTypeFormatMapping,
+    TagTypeName,
+)
+
+pytestmark = pytest.mark.db_tools
+
+
+@pytest.fixture()
+def session_factory() -> Callable[[], Session]:
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine, autoflush=False, autocommit=False)
+
+
+def _seed_minimal_schema(session: Session, total_tags: int) -> None:
+    session.add(TagFormat(format_id=1, format_name="test"))
+    session.add(TagTypeName(type_name_id=1, type_name="general"))
+    session.add(TagTypeFormatMapping(format_id=1, type_id=0, type_name_id=1))
+    for tag_id in range(1, total_tags + 1):
+        tag_name = f"sample_{tag_id}"
+        session.add(Tag(tag_id=tag_id, source_tag=tag_name, tag=tag_name))
+        session.add(
+            TagStatus(
+                tag_id=tag_id,
+                format_id=1,
+                type_id=0,
+                alias=False,
+                preferred_tag_id=tag_id,
+                deprecated=False,
+            )
+        )
+    session.commit()
+
+
+def test_initial_tag_ids_respects_limit_and_offset(session_factory: Callable[[], Session]) -> None:
+    with session_factory() as session:
+        _seed_minimal_schema(session, total_tags=20)
+        builder = TagSearchQueryBuilder(session)
+        ids = builder.initial_tag_ids("%sample_%", use_like=True, limit=5, offset=3)
+        assert len(ids) == 5
+
+
+def test_preloader_load_handles_large_id_sets_with_chunking(
+    session_factory: Callable[[], Session],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SQLITE_IN_LIMIT を小さい値に上書きして、チャンク分割が正しく動作することを確認する。"""
+    with session_factory() as session:
+        _seed_minimal_schema(session, total_tags=1200)
+        preloader = TagSearchPreloader(session)
+        monkeypatch.setattr(preloader, "SQLITE_IN_LIMIT", 200)
+
+        preloaded = preloader.load(set(range(1, 1201)))
+
+        assert len(preloaded.tags_by_id) == 1200
+        assert len(preloaded.statuses_by_tag_id) == 1200
+
+
+def test_preloader_load_returns_empty_for_empty_input(session_factory: Callable[[], Session]) -> None:
+    with session_factory() as session:
+        preloader = TagSearchPreloader(session)
+        preloaded = preloader.load(set())
+
+    assert preloaded.tags_by_id == {}
+    assert preloaded.statuses_by_tag_id == {}

--- a/tests/unit/test_tag_repository.py
+++ b/tests/unit/test_tag_repository.py
@@ -9,7 +9,15 @@ from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import StaticPool
 
 from genai_tag_db_tools.db.repository import MergedTagReader, TagReader, TagRepository
-from genai_tag_db_tools.db.schema import Base, Tag, TagFormat, TagTranslation
+from genai_tag_db_tools.db.schema import (
+    Base,
+    Tag,
+    TagFormat,
+    TagStatus,
+    TagTranslation,
+    TagTypeFormatMapping,
+    TagTypeName,
+)
 
 pytestmark = pytest.mark.db_tools
 
@@ -81,6 +89,36 @@ def test_get_tag_languages_returns_sorted_list(session_factory: Callable[[], Ses
     languages = repo.get_tag_languages()
 
     assert languages == ["chinese", "english", "japanese"]
+
+
+def test_search_tags_handles_large_candidate_set_without_sqlite_variable_overflow(
+    session_factory: Callable[[], Session],
+) -> None:
+    """1000件超のタグが一致する検索で SQLite 変数上限エラーが発生しないことを確認するリグレッションテスト。"""
+    reader = TagReader(session_factory)
+    total_tags = 1200
+
+    with session_factory() as session:
+        session.add(TagFormat(format_id=1, format_name="test"))
+        session.add(TagTypeName(type_name_id=0, type_name="general"))
+        session.add(TagTypeFormatMapping(format_id=1, type_id=0, type_name_id=0))
+
+        for tag_id in range(1, total_tags + 1):
+            tag_name = f"sample_{tag_id}"
+            session.add(Tag(tag_id=tag_id, source_tag=tag_name, tag=tag_name))
+            session.add(
+                TagStatus(
+                    tag_id=tag_id,
+                    format_id=1,
+                    type_id=0,
+                    alias=False,
+                    preferred_tag_id=tag_id,
+                )
+            )
+        session.commit()
+
+    rows = reader.search_tags("sa", partial=True, format_name="test")
+    assert len(rows) == total_tags
 
 
 def test_get_next_type_id_returns_zero_for_empty_format(session_factory: Callable[[], Session]) -> None:


### PR DESCRIPTION
## 概要

PR #17〜#20のいいとこ取りで、Issue #16（`too many SQL variables`エラー）を修正。

## 採用した実装の根拠

| 要素 | 採用元 | 理由 |
|------|--------|------|
| `SQLITE_IN_LIMIT = 900` クラス定数 | #18 | `monkeypatch` でテスト可能 |
| `_query_in_chunks(query, column, ids)` | #18 | クエリオブジェクトを受け取るクリーンなAPI |
| empty-input fast path in `load()` | #17 | 不要なクエリを防ぐ |
| `initial_tag_ids()` limit/offset | #17/#19 | SQL レベルで早期絞り込み |
| `MergedTagReader.search_tags()` limit/offset 伝搬 | #19のみ | 最も完全な実装 |
| `total = len(rows)` をスライス前に保持 | #18/#20 | 正しいページネーションセマンティクス（#17 はバグあり） |
| `test_query_utils.py` | #19 | `_seed_minimal_schema` ヘルパー＋両方のテストを含む |

## 変更内容

### `db/query_utils.py`
- `TagSearchPreloader.SQLITE_IN_LIMIT = 900` を追加（テスト可能な定数）
- `_query_in_chunks()` で全 `.in_()` クエリをチャンク分割（TagStatus×2、TagFormat、TagTypeFormatMapping、TagUsageCounts、Tag、TagTranslation）
- `load()` の empty-input fast path 追加
- `initial_tag_ids()` に `limit`/`offset` パラメータ追加

### `db/repository.py`
- `TagReader.search_tags()` に `limit`/`offset` 追加
- `MergedTagReader.search_tags()` に `limit`/`offset` 追加して伝搬

### `models.py`
- `TagSearchRequest` に `limit: int | None = None` (ge=1) と `offset: int = 0` (ge=0) を追加（docstring に記述済みだったが未実装だったフィールド）

### `core_api.py`
- `_filter_rows()` 直後に `total = len(rows)` を確定してからスライス
- `TagSearchResult(items=items, total=total)` に修正

## テスト

- `test_query_utils.py` (新規): `initial_tag_ids` limit/offset テスト、チャンク分割テスト（`SQLITE_IN_LIMIT=200` にmonkeypatch）、empty-input テスト
- `test_tag_repository.py`: 1200件タグのリグレッションテスト追加
- `test_core_api.py`: ページネーション `total=5`（スライス前件数）の正確性テスト追加
- `test_models.py`: `limit`/`offset` デフォルト値アサーション追加

```
141 passed, 1 error (既存のqtbot fixture issue - PYTEST_DISABLE_PLUGIN_AUTOLOAD=1使用時の既知問題)
```

Closes #16