### PR TITLE
fix(#11): プロンプト正則化で LoRA 記法を保護

### DIFF
--- a/src/genai_tag_db_tools/utils/cleanup_str.py
+++ b/src/genai_tag_db_tools/utils/cleanup_str.py
@@ -60,6 +60,37 @@ class TagCleaner:
     def __init__(self) -> None:
         self.tag_searcher = TagSearcher()
 
+    @staticmethod
+    def _protect_angle_brackets(text: str) -> tuple[str, list[str]]:
+        """`<...>` 構文（LoRA / lyco / embedding 等）を正規化処理から保護する。
+
+        text 中の `<...>` パターンを連番 placeholder に置換し、
+        後で元の文字列に戻すための originals リストを返す。
+
+        Args:
+            text: 保護対象の入力テキスト。
+
+        Returns:
+            (placeholder 化済みテキスト, 復元用の元 `<...>` 文字列リスト)。
+        """
+        pattern = re.compile(r"<[^>]+>")
+        originals: list[str] = []
+
+        def store(match: re.Match[str]) -> str:
+            originals.append(match.group(0))
+            return f"@@@ANGLE{len(originals) - 1}@@@"
+
+        masked = pattern.sub(store, text)
+        return masked, originals
+
+    @staticmethod
+    def _restore_angle_brackets(text: str, originals: list[str]) -> str:
+        """`_protect_angle_brackets` で置換した placeholder を元の `<...>` に戻す。"""
+        result = text
+        for i, original in enumerate(originals):
+            result = result.replace(f"@@@ANGLE{i}@@@", original)
+        return result
+
     @cache
     @staticmethod
     def clean_format(text: str) -> str:
@@ -71,6 +102,10 @@ class TagCleaner:
         Returns:
             str: クリーニング後のテキスト。
         """
+        # `<lora:...>` 等の angle bracket 構文は case と underscore を保持する必要があるため
+        # 以降の正規化処理から退避させる
+        text, angle_originals = TagCleaner._protect_angle_brackets(text)
+
         text = TagCleaner._clean_underscore(text)  # アンダーバーをスペースへ置き換える
         text = re.sub(r"#", "", text)  # '#'を削除
         text = re.sub(r"\"", '"', text)  # ダブルクォートをエスケープ
@@ -83,7 +118,8 @@ class TagCleaner:
         text = re.sub(r"\(", r"\(", text)  # '(' をエスケープ
         text = re.sub(r"\)", r"\)", text)  # ')' をエスケープ
         text = TagCleaner._clean_repetition(text)  # 重複した記号を削除
-        return text.strip()  # 前後の空白を削除
+        text = text.strip()  # 前後の空白を削除
+        return TagCleaner._restore_angle_brackets(text, angle_originals)
 
     @staticmethod
     def _clean_repetition(text: str) -> str:
@@ -111,6 +147,9 @@ class TagCleaner:
         Returns:
             final_tags (str): クリーニング後のタグ
         """
+        # `<lora:...>` 等の angle bracket 構文を `_clean_style` 等の意味的処理から保護
+        tags, angle_originals = TagCleaner._protect_angle_brackets(tags)
+
         tags_dict = TagCleaner._tags_to_dict(tags)  # タグを辞書に変換
 
         # 複数の人物がいる場合は髪色等のタグを削除する
@@ -120,7 +159,8 @@ class TagCleaner:
         tags_dict = TagCleaner._clean_color_object(tags_dict)  # 重複タグを削除
         tags_dict = TagCleaner._clean_style(tags_dict)  # スタイルタグの統一
 
-        return ", ".join(tag for tag in tags_dict.values() if tag)
+        result = ", ".join(tag for tag in tags_dict.values() if tag)
+        return TagCleaner._restore_angle_brackets(result, angle_originals)
 
     @staticmethod
     def _tags_to_dict(tags: str) -> dict[int, str]:

--- a/tests/unit/test_cleanup_str.py
+++ b/tests/unit/test_cleanup_str.py
@@ -23,3 +23,48 @@ def test_clean_tags_deduplicates() -> None:
 
 def test_clean_caption_strips_spaces_and_commas() -> None:
     assert TagCleaner.clean_caption(" hello , ") == "hello"
+
+
+# ---- ISSUE #11: angle bracket 構文（LoRA 等）の保護 ----
+
+
+def test_clean_format_preserves_lora_case() -> None:
+    """LoRA 記法の大文字小文字が保持される。"""
+    assert TagCleaner.clean_format("<lora:CharacterName:0.8>") == "<lora:CharacterName:0.8>"
+
+
+def test_clean_format_preserves_lora_underscore() -> None:
+    """LoRA 記法のアンダースコアが保持される。"""
+    assert TagCleaner.clean_format("<lora:Character_v1:0.8>") == "<lora:Character_v1:0.8>"
+
+
+def test_clean_format_preserves_multiple_lora() -> None:
+    """複数の LoRA 記法が個別に保護される。"""
+    text = "masterpiece, <lora:A_v1:0.5>, <lora:B_v2:0.8>, blue eyes"
+    result = TagCleaner.clean_format(text)
+    assert "<lora:A_v1:0.5>" in result
+    assert "<lora:B_v2:0.8>" in result
+
+
+def test_clean_format_preserves_lyco_and_embedding() -> None:
+    """lyco/embedding 等の他の angle bracket 構文も保護される。"""
+    assert TagCleaner.clean_format("<lyco:Style_X:0.5>") == "<lyco:Style_X:0.5>"
+    assert TagCleaner.clean_format("<embedding:NegEmb_v1>") == "<embedding:NegEmb_v1>"
+
+
+def test_clean_format_protects_lora_with_anime_keyword() -> None:
+    """LoRA 内に anime/cartoon/manga が含まれても破壊されない。"""
+    assert TagCleaner.clean_format("<lora:AnimeStyle_v1:0.8>") == "<lora:AnimeStyle_v1:0.8>"
+
+
+def test_clean_tags_preserves_lora_in_mixed_tags() -> None:
+    """混在タグで LoRA が保持され通常タグは正規化される。"""
+    result = TagCleaner.clean_tags("<lora:Char_v1:0.8>, cat, cat")
+    assert "<lora:Char_v1:0.8>" in result
+    assert "cat" in result
+
+
+def test_clean_tags_lora_not_affected_by_style_unification() -> None:
+    """`_clean_style` の anime 統一が LoRA タグには影響しない。"""
+    result = TagCleaner.clean_tags("<lora:AnimeChar_v1:0.8>, anime art")
+    assert "<lora:AnimeChar_v1:0.8>" in result


### PR DESCRIPTION
## Summary

ISSUE #11 解決。プロンプトに含まれる `<lora:CharacterName_v1:0.8>` のような angle bracket 構文 (LoRA / lyco / embedding 等) が、`TagCleaner.clean_format()` および `clean_tags()` の正則化処理で破壊される問題を修正。

## 原因の精緻化

ISSUE 著者は `.lower()` を主犯と疑っていたが、実コード調査の結果、真の原因は以下の複合：

1. `_clean_underscore()` がアンダースコアをスペースへ置換 → `<lora:Char_v1:0.8>` → `<lora:Char v1:0.8>`
2. `clean_format()` が `(`/`)` をエスケープ、`#`/`**` を削除、ピリオド/改行をカンマに変換
3. `_clean_style()` の `STYLE_PATTERN` (anime|cartoon|manga, IGNORECASE) がマッチすると、タグ全体が `match.group().lower()` で置換される（→ `<lora:AnimeStyle:0.8>` がただの `"anime"` になる）

## 修正内容

- `_protect_angle_brackets()` / `_restore_angle_brackets()` 共通ヘルパーを追加
- `<...>` パターンを連番 placeholder (`@@@ANGLE0@@@` 等) に置換し、すべての処理が完了した後に元の文字列に戻す
- `clean_format()` と `clean_tags()` の冒頭・末尾で適用
- 既存の `^_^` 顔文字保護 (`^@@@^`) と同じ設計パターン

## Placeholder の安全性

`@@@ANGLE0@@@` は以下の処理から影響を受けない:
- アンダースコア置換 (`_` を含まない)
- `#`/`**`/`.` 削除や置換
- `(`/`)` エスケープ
- STYLE_PATTERN (anime|cartoon|manga) にマッチしない

## テスト

7 件の新規テストを追加。すべて pass:
- LoRA 記法の case 保持
- LoRA 記法の underscore 保持
- 複数 LoRA の個別保護
- lyco / embedding 等の他構文の保護
- LoRA 内の anime キーワードによる破壊防止
- 通常タグと混在時の正規化共存
- `_clean_style` の anime 統一が LoRA に影響しない

既存 5 テスト + 既存 `convert_tags` 2 テストもすべて pass、リグレッションなし。

## Test plan

- [x] `uv run pytest tests/unit/test_cleanup_str.py -v` → 12 passed
- [x] `uv run pytest tests/unit/test_core_api_convert_tags.py -v` → 2 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)