### PR TITLE
fix: allow ensure-dbs to use default sources

### DIFF
--- a/docs/decisions/0001-cli-default-database-source-policy.md
+++ b/docs/decisions/0001-cli-default-database-source-policy.md
@@ -1,0 +1,56 @@
+# ADR 0001: CLI Default Database Source Policy
+
+- **日付**: 2026-06-02
+- **ステータス**: Accepted
+
+## Context
+
+`tag-db ensure-dbs` is the command users and automation should run when preparing the base tag
+databases. The project already has three default base database sources:
+
+- CC0 database
+- MIT database
+- CC4 database
+
+However, the CLI currently requires at least one `--source` value for `ensure-dbs`. This makes the
+default setup path harder than necessary: users must know the source identifiers before they can
+prepare the standard database set.
+
+Issue #27 tracks making `ensure-dbs` usable without explicit source arguments. Issue #24 remains
+focused on the separate `--base-db` parser bug.
+
+## Decision
+
+`tag-db ensure-dbs` with no `--source` arguments will download or reuse all default base databases:
+CC0, MIT, and CC4.
+
+When one or more `--source` arguments are provided, the command will use only the explicitly
+specified sources.
+
+The CLI contract is:
+
+- `tag-db ensure-dbs`: prepare the standard default source set.
+- `tag-db ensure-dbs --source repo/file.sqlite`: prepare only the specified source.
+- `tag-db ensure-dbs --source repo/a.sqlite --source repo/b.sqlite`: prepare only the specified
+  sources.
+
+## Rationale
+
+Defaulting to all standard sources gives first-time users and automation a simple setup command.
+This matches the existing runtime behavior where omitted base DB paths can fall back to default
+database initialization.
+
+Keeping explicit `--source` values exclusive avoids surprising users who ask for a specific
+database. If explicit sources were added on top of defaults, users could unintentionally download
+or use more databases than requested.
+
+The alternative of keeping `--source` required preserves the current parser behavior but leaves the
+most common setup path unnecessarily verbose and pushes internal source knowledge onto users.
+
+## Consequences
+
+- `tag-db ensure-dbs` becomes a useful zero-argument setup command.
+- Explicit `--source` remains available for targeted downloads, testing, and custom datasets.
+- Help text and tests must describe the default-vs-explicit behavior.
+- The implementation should share the default source list with the core initialization path rather
+  than duplicating source definitions in the CLI.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -1,0 +1,32 @@
+# Architecture Decision Records
+
+genai-tag-db-tools の重要な設計判断を記録するドキュメント群。
+
+| ADR | タイトル | 日付 | ステータス |
+|-----|---------|------|-----------|
+| [0001](0001-cli-default-database-source-policy.md) | CLI Default Database Source Policy | 2026-06-02 | Accepted |
+
+## ADR テンプレート
+
+```markdown
+# ADR XXXX: タイトル
+
+- **日付**: YYYY-MM-DD
+- **ステータス**: Proposed | Accepted | Deprecated | Superseded by [XXXX]
+
+## Context
+
+なぜこの決定が必要だったか。問題の背景と制約。
+
+## Decision
+
+何を決定したか。
+
+## Rationale
+
+なぜこの選択をしたか。他の選択肢との比較。
+
+## Consequences
+
+この決定による影響。良い点・悪い点・トレードオフ。
+```

--- a/src/genai_tag_db_tools/cli.py
+++ b/src/genai_tag_db_tools/cli.py
@@ -4,6 +4,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 
 from genai_tag_db_tools.core_api import (
+    default_sources,
     ensure_databases,
     get_statistics,
     initialize_databases,
@@ -104,17 +105,19 @@ def _build_register_service() -> TagRegisterService:
 
 def cmd_ensure_dbs(args: argparse.Namespace) -> None:
     cache = _build_cache_config(args)
-    requests = [
-        EnsureDbRequest(
-            source=DbSourceRef(
+    if args.source:
+        sources = [
+            DbSourceRef(
                 repo_id=parsed.repo_id,
                 filename=parsed.filename,
                 revision=parsed.revision,
-            ),
-            cache=cache,
-        )
-        for parsed in (_parse_source(value) for value in args.source)
-    ]
+            )
+            for parsed in (_parse_source(value) for value in args.source)
+        ]
+    else:
+        sources = default_sources()
+
+    requests = [EnsureDbRequest(source=source, cache=cache) for source in sources]
     results = ensure_databases(requests)
     _dump(results)
 
@@ -202,8 +205,7 @@ def main() -> None:
     ensure_many_parser.add_argument(
         "--source",
         action="append",
-        required=True,
-        help="repo_id/filename[@revision]. Repeat for multiple sources.",
+        help="repo_id/filename[@revision]. Repeat for multiple sources. Omit to use default sources.",
     )
     ensure_many_parser.add_argument(
         "--user-db-dir", help="User database directory (defaults to OS-specific cache)"

--- a/src/genai_tag_db_tools/core_api.py
+++ b/src/genai_tag_db_tools/core_api.py
@@ -44,7 +44,7 @@ def build_downloaded_at_utc() -> str:
     return datetime.now(UTC).isoformat()
 
 
-def _default_sources() -> list[DbSourceRef]:
+def default_sources() -> list[DbSourceRef]:
     return [
         DbSourceRef(
             repo_id="NEXTAltair/genai-image-tag-db",
@@ -108,7 +108,7 @@ def initialize_databases(
 
     cache_dir = resolved_user_db_dir or hf_downloader.default_cache_dir()
     cache = DbCacheConfig(cache_dir=str(cache_dir), token=token)
-    requested_sources = sources or _default_sources()
+    requested_sources = sources or default_sources()
     requests = [EnsureDbRequest(source=source, cache=cache) for source in requested_sources]
 
     results = ensure_databases(requests)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -25,6 +25,7 @@ from genai_tag_db_tools.cli import (
     _dump,
     _parse_source,
     _set_db_paths,
+    cmd_ensure_dbs,
     main,
 )
 from genai_tag_db_tools.db import runtime
@@ -161,6 +162,72 @@ class TestBuildCacheConfig:
         assert config.token is None
 
 
+class TestCmdEnsureDbs:
+    """Test ensure-dbs command behavior."""
+
+    def test_ensure_dbs_without_source_uses_default_sources(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        captured_requests = []
+
+        def fake_ensure_databases(requests):
+            captured_requests.extend(requests)
+            return []
+
+        monkeypatch.setattr("genai_tag_db_tools.cli.ensure_databases", fake_ensure_databases)
+
+        args = argparse.Namespace(source=None, user_db_dir=str(tmp_path), token="test-token")
+        cmd_ensure_dbs(args)
+
+        assert [request.source.repo_id for request in captured_requests] == [
+            "NEXTAltair/genai-image-tag-db",
+            "NEXTAltair/genai-image-tag-db-mit",
+            "NEXTAltair/genai-image-tag-db-CC4",
+        ]
+        assert [request.source.filename for request in captured_requests] == [
+            "genai-image-tag-db-cc0.sqlite",
+            "genai-image-tag-db-mit.sqlite",
+            "genai-image-tag-db-cc4.sqlite",
+        ]
+        assert {request.cache.cache_dir for request in captured_requests} == {str(tmp_path)}
+        assert {request.cache.token for request in captured_requests} == {"test-token"}
+        assert json.loads(capsys.readouterr().out) == []
+
+    def test_ensure_dbs_with_source_uses_only_explicit_sources(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        captured_requests = []
+
+        def fake_ensure_databases(requests):
+            captured_requests.extend(requests)
+            return []
+
+        monkeypatch.setattr("genai_tag_db_tools.cli.ensure_databases", fake_ensure_databases)
+
+        args = argparse.Namespace(
+            source=["org/repo/custom-a.sqlite@main", "org/repo/custom-b.sqlite"],
+            user_db_dir=str(tmp_path),
+            token=None,
+        )
+        cmd_ensure_dbs(args)
+
+        explicit_sources = [
+            (request.source.repo_id, request.source.filename, request.source.revision)
+            for request in captured_requests
+        ]
+        assert explicit_sources == [
+            ("org/repo", "custom-a.sqlite", "main"),
+            ("org/repo", "custom-b.sqlite", None),
+        ]
+        assert json.loads(capsys.readouterr().out) == []
+
+
 class TestSetDbPaths:
     """Test _set_db_paths function."""
 
@@ -289,6 +356,17 @@ class TestMainParser:
         handler.assert_called_once()
         args = handler.call_args.args[0]
         assert args.base_db == ["/tmp/base-a.sqlite", "/tmp/base-b.sqlite"]
+
+    def test_ensure_dbs_accepts_no_source(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        handler = MagicMock()
+        monkeypatch.setattr(cli, "cmd_ensure_dbs", handler)
+        monkeypatch.setattr(sys, "argv", ["tag-db", "ensure-dbs"])
+
+        main()
+
+        handler.assert_called_once()
+        args = handler.call_args.args[0]
+        assert args.source is None
 
 
 class TestBuildRegisterService:


### PR DESCRIPTION
## Summary
- add ADR 0001 documenting the CLI default database source policy
- allow `tag-db ensure-dbs` to run without `--source` by using the standard CC0/MIT/CC4 database sources
- keep explicit `--source` values exclusive, so custom invocations download only requested sources

## Verification
- `QT_QPA_PLATFORM=offscreen UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run --no-sync pytest tests/unit/test_cli.py tests/unit/test_core_api.py -q`
- `UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run --no-sync ruff check src/genai_tag_db_tools/core_api.py src/genai_tag_db_tools/cli.py tests/unit/test_cli.py tests/unit/test_core_api.py`

Closes #27