### PR TITLE
fix: correct+bounded search (dedup-before-limit + conditional pushdown) (#37)

### DIFF
--- a/src/genai_tag_db_tools/core_api.py
+++ b/src/genai_tag_db_tools/core_api.py
@@ -147,28 +147,41 @@ def _filter_rows(rows: list[TagSearchRow], request: TagSearchRequest) -> list[Ta
     return filtered
 
 
+# bounded over-fetch parameters (Issue #37 暫定対応 / autocomplete typeahead を bound する)。
+# post-filter (_filter_rows: alias/deprecated/usage/複数 format・type) は repository クエリの
+# 「後」に Python 側で走るため、SQL LIMIT をそのまま limit 件にすると post-filter で落ちた分だけ
+# 結果が不足する。一方 SQL LIMIT を完全に外すと autocomplete のような typeahead が毎回全一致を
+# materialize して劣化する。そこで「(offset+limit) * FACTOR + BUFFER」だけ over-fetch して
+# post-filter のドロップを吸収しつつ、repository クエリを bound したままにする。
+_SEARCH_OVERFETCH_FACTOR = 4
+_SEARCH_OVERFETCH_BUFFER = 50
+
+
 def search_tags(repo: MergedTagReader, request: TagSearchRequest) -> TagSearchResult:
     format_name = (
         request.format_names[0] if request.format_names and len(request.format_names) == 1 else None
     )
     type_name = request.type_names[0] if request.type_names and len(request.type_names) == 1 else None
 
-    # post-filter (_filter_rows: alias / deprecated / usage / 複数 format・type) は
-    # repository クエリの「後」に Python 側で走る。ここで SQL LIMIT を先にかけると、
-    # 先頭 N 件が alias/deprecated だった場合に有効な一致を取りこぼし、total も raw 件数で
-    # キャップされてしまう。そのため SQL LIMIT は使わず、全一致を取得 → filter →
-    # Python 側で offset/limit を適用する。これにより limit/offset は filter 後の行を数え、
-    # total は filter 後の全件数になる。
+    if request.limit is None:
+        sql_limit: int | None = None
+    else:
+        # over-fetch で post-filter のドロップを吸収しつつ repository クエリを bound する。
+        sql_limit = (request.offset + request.limit) * _SEARCH_OVERFETCH_FACTOR + _SEARCH_OVERFETCH_BUFFER
+
     rows = repo.search_tags(
         request.query,
         partial=request.partial,
         format_name=format_name,
         type_name=type_name,
         resolve_preferred=request.resolve_preferred,
-        limit=None,
+        limit=sql_limit,
     )
+    # over-fetch 窓を取り切っていない (rows == sql_limit) 場合は全件を見ていないため total 不明 (None)。
+    # 窓に収まった (rows < sql_limit) か無制限なら total は filter 後の正確な件数。
+    exhausted = sql_limit is None or len(rows) < sql_limit
     rows = _filter_rows(rows, request)
-    total = len(rows)
+    total: int | None = len(rows) if exhausted else None
     if request.offset:
         rows = rows[request.offset :]
     if request.limit is not None:

--- a/src/genai_tag_db_tools/core_api.py
+++ b/src/genai_tag_db_tools/core_api.py
@@ -170,16 +170,19 @@ def search_tags(repo: MergedTagReader, request: TagSearchRequest) -> TagSearchRe
 
     if request.limit is not None and not constrained:
         # plain keyword: repository クエリを bound する (preload も page 件数に限定される)。
+        # offset は repository に渡さない。MergedTagReader は offset を各 backing DB に転送して
+        # から merge する (merge 後に再適用しない) ため、per-DB offset は不正なページングになる。
+        # 代わりに limit+offset 件を取得し、merge 後に Python で offset/limit をスライスする。
         rows = repo.search_tags(
             request.query,
             partial=request.partial,
             format_name=None,
             type_name=None,
             resolve_preferred=request.resolve_preferred,
-            limit=request.limit,
-            offset=request.offset,
+            limit=request.limit + request.offset,
         )
-        page = _filter_rows(rows, request)[: request.limit]
+        filtered_rows = _filter_rows(rows, request)
+        page = filtered_rows[request.offset : request.offset + request.limit]
         total: int | None = None  # bounded fetch のため全件数は不明
     else:
         rows = repo.search_tags(

--- a/src/genai_tag_db_tools/core_api.py
+++ b/src/genai_tag_db_tools/core_api.py
@@ -147,45 +147,55 @@ def _filter_rows(rows: list[TagSearchRow], request: TagSearchRequest) -> list[Ta
     return filtered
 
 
-# bounded over-fetch parameters (Issue #37 暫定対応 / autocomplete typeahead を bound する)。
-# post-filter (_filter_rows: alias/deprecated/usage/複数 format・type) は repository クエリの
-# 「後」に Python 側で走るため、SQL LIMIT をそのまま limit 件にすると post-filter で落ちた分だけ
-# 結果が不足する。一方 SQL LIMIT を完全に外すと autocomplete のような typeahead が毎回全一致を
-# materialize して劣化する。そこで「(offset+limit) * FACTOR + BUFFER」だけ over-fetch して
-# post-filter のドロップを吸収しつつ、repository クエリを bound したままにする。
-_SEARCH_OVERFETCH_FACTOR = 4
-_SEARCH_OVERFETCH_BUFFER = 50
-
-
 def search_tags(repo: MergedTagReader, request: TagSearchRequest) -> TagSearchResult:
     format_name = (
         request.format_names[0] if request.format_names and len(request.format_names) == 1 else None
     )
     type_name = request.type_names[0] if request.type_names and len(request.type_names) == 1 else None
 
-    if request.limit is None:
-        sql_limit: int | None = None
-    else:
-        # over-fetch で post-filter のドロップを吸収しつつ repository クエリを bound する。
-        sql_limit = (request.offset + request.limit) * _SEARCH_OVERFETCH_FACTOR + _SEARCH_OVERFETCH_BUFFER
-
-    rows = repo.search_tags(
-        request.query,
-        partial=request.partial,
-        format_name=format_name,
-        type_name=type_name,
-        resolve_preferred=request.resolve_preferred,
-        limit=sql_limit,
+    # post-filter がドロップしうるのは format/type/usage 制約がある場合のみ。
+    # alias/deprecated/usage/type は format 未指定時に全行デフォルト (False/0/"") になり
+    # (TagSearchResultBuilder._resolve_status_info は format_id がある時だけ解決する)、
+    # _filter_rows は何も落とさない。repository 側の format/type フィルタも SQL LIMIT の後に
+    # 走るため、制約がある検索は limit を pushdown すると取りこぼす。
+    # よって「plain keyword 検索 (制約なし)」のときだけ limit/offset を repository に渡して
+    # bound する (autocomplete/typeahead 経路)。制約付きは全件取得 → filter → Python paging
+    # で正確性を優先する。
+    constrained = bool(
+        request.format_names
+        or request.type_names
+        or request.min_usage is not None
+        or request.max_usage is not None
     )
-    # over-fetch 窓を取り切っていない (rows == sql_limit) 場合は全件を見ていないため total 不明 (None)。
-    # 窓に収まった (rows < sql_limit) か無制限なら total は filter 後の正確な件数。
-    exhausted = sql_limit is None or len(rows) < sql_limit
-    rows = _filter_rows(rows, request)
-    total: int | None = len(rows) if exhausted else None
-    if request.offset:
-        rows = rows[request.offset :]
-    if request.limit is not None:
-        rows = rows[: request.limit]
+
+    if request.limit is not None and not constrained:
+        # plain keyword: repository クエリを bound する (preload も page 件数に限定される)。
+        rows = repo.search_tags(
+            request.query,
+            partial=request.partial,
+            format_name=None,
+            type_name=None,
+            resolve_preferred=request.resolve_preferred,
+            limit=request.limit,
+            offset=request.offset,
+        )
+        page = _filter_rows(rows, request)[: request.limit]
+        total: int | None = None  # bounded fetch のため全件数は不明
+    else:
+        rows = repo.search_tags(
+            request.query,
+            partial=request.partial,
+            format_name=format_name,
+            type_name=type_name,
+            resolve_preferred=request.resolve_preferred,
+            limit=None,
+        )
+        filtered = _filter_rows(rows, request)
+        total = len(filtered)
+        page = filtered[request.offset :] if request.offset else filtered
+        if request.limit is not None:
+            page = page[: request.limit]
+
     items = [
         TagRecordPublic(
             tag=row["tag"],
@@ -200,7 +210,7 @@ def search_tags(repo: MergedTagReader, request: TagSearchRequest) -> TagSearchRe
             translations=row["translations"],
             format_statuses=row["format_statuses"],
         )
-        for row in rows
+        for row in page
     ]
     return TagSearchResult(items=items, total=total)
 

--- a/src/genai_tag_db_tools/db/query_utils.py
+++ b/src/genai_tag_db_tools/db/query_utils.py
@@ -2,7 +2,7 @@ from logging import Logger
 from typing import Any, TypedDict
 
 from sqlalchemy.orm import Session
-from sqlalchemy.sql import or_
+from sqlalchemy.sql import literal_column, or_
 
 from genai_tag_db_tools.db.schema import (
     Tag,
@@ -56,30 +56,30 @@ class TagSearchQueryBuilder:
         limit: int | None = None,
         offset: int = 0,
     ) -> set[int]:
-        tag_query = self.session.query(Tag.tag_id)
-        translation_query = self.session.query(TagTranslation.tag_id)
-
         tag_conditions = or_(
             Tag.tag.like(keyword) if use_like else Tag.tag == keyword,
             Tag.source_tag.like(keyword) if use_like else Tag.source_tag == keyword,
         )
-        tag_query = tag_query.filter(tag_conditions)
-
         translation_condition = (
             TagTranslation.translation.like(keyword) if use_like else TagTranslation.translation == keyword
         )
-        translation_query = translation_query.filter(translation_condition)
 
+        tag_query = self.session.query(Tag.tag_id.label("tag_id")).filter(tag_conditions)
+        translation_query = self.session.query(TagTranslation.tag_id.label("tag_id")).filter(
+            translation_condition
+        )
+
+        # tag と translation の一致を UNION で重複排除してから limit/offset を適用する。
+        # 各クエリ個別に limit すると、同一タグの多言語 translation 行が窓を食い潰し
+        # ユニークな tag_id 数が limit に満たなくなる (重複排除が limit の後になる問題)。
+        # ページングを決定的にするため tag_id 昇順で order_by する。
+        union_query = tag_query.union(translation_query).order_by(literal_column("tag_id"))
         if offset:
-            tag_query = tag_query.offset(offset)
-            translation_query = translation_query.offset(offset)
+            union_query = union_query.offset(offset)
         if limit is not None:
-            tag_query = tag_query.limit(limit)
-            translation_query = translation_query.limit(limit)
+            union_query = union_query.limit(limit)
 
-        tag_ids = {row[0] for row in tag_query.all()}
-        translation_ids = {row[0] for row in translation_query.all()}
-        return tag_ids | translation_ids
+        return {row[0] for row in union_query.all()}
 
     def initial_tag_ids_for_keywords(self, keywords: list[str]) -> dict[str, set[int]]:
         if not keywords:

--- a/tests/unit/test_core_api.py
+++ b/tests/unit/test_core_api.py
@@ -73,62 +73,46 @@ def test_ensure_databases_returns_cached_status_per_spec(monkeypatch, tmp_path):
     assert results[1].sha256 == _hash_bytes(b"bb")
 
 
-def test_search_tags_paginates_after_post_filters():
-    """limit/offset は post-filter 後の行に適用し、SQL LIMIT は使わない (Codex review)."""
+def _usage_row(tag_id: int, usage: int) -> dict[str, object]:
+    return {
+        "tag": f"t{tag_id}",
+        "source_tag": None,
+        "tag_id": tag_id,
+        "format_name": None,
+        "type_id": 1,
+        "type_name": "general",
+        "alias": False,
+        "deprecated": False,
+        "usage_count": usage,
+        "translations": None,
+        "format_statuses": {},
+    }
 
-    def _row(tag_id: int, *, deprecated: bool = False) -> dict:
-        return {
-            "tag": f"t{tag_id}",
-            "source_tag": None,
-            "tag_id": tag_id,
-            "format_name": None,
-            "type_id": 1,
-            "type_name": "general",
-            "alias": False,
-            "deprecated": deprecated,
-            "usage_count": 1,
-            "translations": None,
-            "format_statuses": {},
-        }
 
-    # 先頭 2 件は deprecated (既定 include_deprecated=False で除外される)
-    rows = [_row(1, deprecated=True), _row(2, deprecated=True), _row(3), _row(4), _row(5)]
+def test_search_tags_constrained_paginates_after_filter():
+    """制約付き検索は unbounded fetch → filter → Python paging。total は filter 後の正確な件数。"""
+    # min_usage=10 で usage<10 の先頭 2 件が落ちる
+    rows = [_usage_row(1, 1), _usage_row(2, 1), _usage_row(3, 50), _usage_row(4, 60), _usage_row(5, 70)]
     repo = DummyRepo(rows=rows)
 
-    result = core_api.search_tags(repo, TagSearchRequest(query="t", limit=2, offset=0))
+    result = core_api.search_tags(repo, TagSearchRequest(query="t", limit=2, offset=0, min_usage=10))
 
-    # bounded over-fetch: SQL には (offset+limit)*4+50 = 58 を渡す (post-filter ドロップ吸収)
-    assert repo.calls[-1]["limit"] == 58
-    # deprecated 2 件除外後の active 3 件中、limit=2 で先頭 2 件 (tag_id 3, 4)
+    # 制約あり → SQL LIMIT は使わず全件取得
+    assert repo.calls[-1]["limit"] is None
+    # usage>=10 の active 3 件 (3,4,5) 中、limit=2 → (3,4)
     assert [item.tag_id for item in result.items] == [3, 4]
-    # over-fetch 窓に収まった (rows < sql_limit) ので total は filter 後の全件数 (3)
+    # total は filter 後の全件数 (3)、limit でキャップされない
     assert result.total == 3
 
 
-def test_search_tags_offset_after_filter_returns_later_rows():
-    """offset も filter 後の行に対して適用される (先頭が落ちても空にならない)."""
-
-    def _row(tag_id: int, *, deprecated: bool = False) -> dict:
-        return {
-            "tag": f"t{tag_id}",
-            "source_tag": None,
-            "tag_id": tag_id,
-            "format_name": None,
-            "type_id": 1,
-            "type_name": "general",
-            "alias": False,
-            "deprecated": deprecated,
-            "usage_count": 1,
-            "translations": None,
-            "format_statuses": {},
-        }
-
-    rows = [_row(1, deprecated=True), _row(2), _row(3), _row(4)]
+def test_search_tags_constrained_offset_returns_later_rows():
+    """制約付き検索でも offset は filter 後の行に適用される (先頭が落ちても空にならない)。"""
+    rows = [_usage_row(1, 1), _usage_row(2, 50), _usage_row(3, 60), _usage_row(4, 70)]
     repo = DummyRepo(rows=rows)
 
-    result = core_api.search_tags(repo, TagSearchRequest(query="t", limit=2, offset=1))
+    result = core_api.search_tags(repo, TagSearchRequest(query="t", limit=2, offset=1, min_usage=10))
 
-    # active 3 件 (2,3,4) を offset=1 → (3,4)
+    # usage>=10 の (2,3,4) を offset=1 → (3,4)
     assert [item.tag_id for item in result.items] == [3, 4]
     assert result.total == 3
 
@@ -235,88 +219,43 @@ def test_search_tags_applies_offset_and_limit_preserves_total():
         for i in range(1, 6)
     ]
     repo = DummyRepo(rows)
+    # min_usage=1 は全行 (usage=100) を通すが、制約付きパス (unbounded fetch → Python paging)
+    # を通すことで offset/limit が Python 側で適用され total が保持されることを検証する。
     request = TagSearchRequest(
         query="tag",
         partial=True,
         include_aliases=True,
         include_deprecated=True,
+        min_usage=1,
         offset=1,
         limit=2,
     )
 
     result = core_api.search_tags(repo, request)
 
+    # 制約付き → unbounded fetch、Python で offset/limit、total は filter 後の全件数
+    assert repo.calls[-1]["limit"] is None
     assert [item.tag_id for item in result.items] == [2, 3]
     assert result.total == 5
 
 
-def test_search_tags_uses_bounded_overfetch_limit():
-    """limit 指定時は bounded over-fetch (= (offset+limit)*4+50) を repo に渡す (Codex review)。
+def test_search_tags_plain_keyword_bounds_repo_query():
+    """plain keyword + limit は limit/offset を repository に pushdown して bound する (autocomplete)。
 
-    autocomplete 等の typeahead が毎回全件 materialize しないよう repository クエリを bound
-    したまま、post-filter のドロップを over-fetch で吸収する。
+    format/type/usage 制約が無い検索では post-filter が何も落とさないため、SQL LIMIT を
+    そのまま渡して repository クエリ (および preload) を bound できる。
     """
-    rows = [
-        {
-            "tag": f"sample_{i}",
-            "source_tag": None,
-            "tag_id": i,
-            "format_name": "danbooru",
-            "type_id": 1,
-            "type_name": "general",
-            "alias": False,
-            "deprecated": False,
-            "usage_count": 100,
-            "translations": None,
-            "format_statuses": {},
-        }
-        for i in range(1, 6)
-    ]
+    rows = [_usage_row(i, 100) for i in range(1, 6)]
     repo = DummyRepo(rows)
-    request = TagSearchRequest(query="tag", partial=True, limit=2)
+    request = TagSearchRequest(query="tag", partial=True, limit=2, offset=1)
     result = core_api.search_tags(repo, request)
 
-    # bounded over-fetch: (0+2)*4+50 = 58
-    assert repo.calls[0].get("limit") == 58
-    # limit は Python 側で適用 (items は 2 件)、over-fetch 窓内なので total は全件数 (5)
-    assert len(result.items) == 2
-    assert result.total == 5
-
-
-def test_search_tags_total_unknown_when_overfetch_window_full():
-    """over-fetch 窓を取り切った (rows == sql_limit) 場合、全件未走査なので total は None。"""
-
-    class _FullWindowRepo:
-        def __init__(self) -> None:
-            self.calls: list[dict] = []
-
-        def search_tags(self, keyword: str, **kwargs) -> list[dict]:
-            self.calls.append({"keyword": keyword, **kwargs})
-            limit = kwargs["limit"]
-            # 窓ぴったりの active 行を返す (=全件は走査しきれていない状況)
-            return [
-                {
-                    "tag": f"t{i}",
-                    "source_tag": None,
-                    "tag_id": i,
-                    "format_name": None,
-                    "type_id": 1,
-                    "type_name": "general",
-                    "alias": False,
-                    "deprecated": False,
-                    "usage_count": 1,
-                    "translations": None,
-                    "format_statuses": {},
-                }
-                for i in range(limit)
-            ]
-
-    repo = _FullWindowRepo()
-    result = core_api.search_tags(repo, TagSearchRequest(query="t", limit=2, offset=0))
-
-    assert len(result.items) == 2
-    # 窓を取り切ったため全件不明 → total は None
+    # limit/offset をそのまま repository に渡す (over-fetch しない)
+    assert repo.calls[0].get("limit") == 2
+    assert repo.calls[0].get("offset") == 1
+    # bounded fetch のため total は不明 (None)
     assert result.total is None
+    assert len(result.items) == 2
 
 
 def test_search_tags_passes_none_limit_when_not_set():

--- a/tests/unit/test_core_api.py
+++ b/tests/unit/test_core_api.py
@@ -97,11 +97,11 @@ def test_search_tags_paginates_after_post_filters():
 
     result = core_api.search_tags(repo, TagSearchRequest(query="t", limit=2, offset=0))
 
-    # post-filter があるため SQL LIMIT は渡さない (全件取得 → filter → Python paging)
-    assert repo.calls[-1]["limit"] is None
+    # bounded over-fetch: SQL には (offset+limit)*4+50 = 58 を渡す (post-filter ドロップ吸収)
+    assert repo.calls[-1]["limit"] == 58
     # deprecated 2 件除外後の active 3 件中、limit=2 で先頭 2 件 (tag_id 3, 4)
     assert [item.tag_id for item in result.items] == [3, 4]
-    # total は filter 後の全件数 (3)。limit でキャップされない
+    # over-fetch 窓に収まった (rows < sql_limit) ので total は filter 後の全件数 (3)
     assert result.total == 3
 
 
@@ -250,8 +250,12 @@ def test_search_tags_applies_offset_and_limit_preserves_total():
     assert result.total == 5
 
 
-def test_search_tags_does_not_push_limit_to_repo():
-    """limit は SQL に pushdown せず Python 側で適用する (post-filter との整合, Codex review)。"""
+def test_search_tags_uses_bounded_overfetch_limit():
+    """limit 指定時は bounded over-fetch (= (offset+limit)*4+50) を repo に渡す (Codex review)。
+
+    autocomplete 等の typeahead が毎回全件 materialize しないよう repository クエリを bound
+    したまま、post-filter のドロップを over-fetch で吸収する。
+    """
     rows = [
         {
             "tag": f"sample_{i}",
@@ -272,11 +276,47 @@ def test_search_tags_does_not_push_limit_to_repo():
     request = TagSearchRequest(query="tag", partial=True, limit=2)
     result = core_api.search_tags(repo, request)
 
-    # SQL LIMIT は渡さない (全件取得 → filter → Python paging)
-    assert repo.calls[0].get("limit") is None
-    # limit は Python 側で適用 (items は 2 件)、total は全件数 (5)
+    # bounded over-fetch: (0+2)*4+50 = 58
+    assert repo.calls[0].get("limit") == 58
+    # limit は Python 側で適用 (items は 2 件)、over-fetch 窓内なので total は全件数 (5)
     assert len(result.items) == 2
     assert result.total == 5
+
+
+def test_search_tags_total_unknown_when_overfetch_window_full():
+    """over-fetch 窓を取り切った (rows == sql_limit) 場合、全件未走査なので total は None。"""
+
+    class _FullWindowRepo:
+        def __init__(self) -> None:
+            self.calls: list[dict] = []
+
+        def search_tags(self, keyword: str, **kwargs) -> list[dict]:
+            self.calls.append({"keyword": keyword, **kwargs})
+            limit = kwargs["limit"]
+            # 窓ぴったりの active 行を返す (=全件は走査しきれていない状況)
+            return [
+                {
+                    "tag": f"t{i}",
+                    "source_tag": None,
+                    "tag_id": i,
+                    "format_name": None,
+                    "type_id": 1,
+                    "type_name": "general",
+                    "alias": False,
+                    "deprecated": False,
+                    "usage_count": 1,
+                    "translations": None,
+                    "format_statuses": {},
+                }
+                for i in range(limit)
+            ]
+
+    repo = _FullWindowRepo()
+    result = core_api.search_tags(repo, TagSearchRequest(query="t", limit=2, offset=0))
+
+    assert len(result.items) == 2
+    # 窓を取り切ったため全件不明 → total は None
+    assert result.total is None
 
 
 def test_search_tags_passes_none_limit_when_not_set():

--- a/tests/unit/test_core_api.py
+++ b/tests/unit/test_core_api.py
@@ -250,12 +250,13 @@ def test_search_tags_plain_keyword_bounds_repo_query():
     request = TagSearchRequest(query="tag", partial=True, limit=2, offset=1)
     result = core_api.search_tags(repo, request)
 
-    # limit/offset をそのまま repository に渡す (over-fetch しない)
-    assert repo.calls[0].get("limit") == 2
-    assert repo.calls[0].get("offset") == 1
+    # offset は repo に渡さず (MergedReader の per-DB offset 不正を回避)、limit+offset を渡す。
+    assert repo.calls[0].get("limit") == 3
+    assert repo.calls[0].get("offset", 0) == 0
+    # offset/limit は merge 後に Python でスライス: DummyRepo の全 5 件中 [1:3] = tag_id 2,3
+    assert [item.tag_id for item in result.items] == [2, 3]
     # bounded fetch のため total は不明 (None)
     assert result.total is None
-    assert len(result.items) == 2
 
 
 def test_search_tags_passes_none_limit_when_not_set():


### PR DESCRIPTION
## 概要

LoRAIro#602 の pin bump レビューで Codex が指摘した autocomplete 退行と、本 PR レビューで指摘された format/translation のページング不正を、**根本原因2点の修正**で解決する(当初の over-fetch ヒューリスティックは撤回)。

## 根本原因と修正

深掘りで判明した事実: `TagSearchResultBuilder._resolve_status_info` は **format 指定時のみ** alias/deprecated/usage/type を解決し、format 無指定では全行が `alias=False, deprecated=False, usage=0`。つまり **plain keyword 検索(制約なし)では `_filter_rows` は何も落とさない**。post-filter がドロップするのは format/type/usage 制約があるときだけ。

1. **`initial_tag_ids`: dedup してから limit** — tag/translation の id クエリを UNION(DISTINCT)+ `order_by(tag_id)` してから limit/offset。従来は各クエリを個別に limit して set union していたため、同一タグの多言語 translation 行が窓を食い潰しユニーク tag_id 数が limit 未満になっていた(**#38 B 解消**)。

2. **`core_api.search_tags`: plain keyword のときだけ limit/offset を repository に pushdown** — 制約なし検索は post-filter が何も落とさないので SQL LIMIT が安全で、typeahead/autocomplete(と preload)を bound できる。format/type/usage 制約付きは unbounded fetch → filter → Python paging で正確性を優先(**#38 A 解消**)。`total` は制約付きパスで正確、bounded パスで None。

## 効果

- **LoRAIro#602 の autocomplete 退行を解消**(plain keyword は再び bound、preload も page 件数に限定)。
- format フィルタ検索・多言語 translation 検索の取りこぼしを解消。
- over-fetch のような近似なし。

CI-EQUIV-TESTED: genai-tag-db-tools `-m "not slow and not network"` **314 passed**(実 DB の repo/searcher テスト含む)。Ruff/mypy クリーン。LoRAIro 側 autocomplete/tag suggestion **66 passed**。

Refs #23 #37