### PR TITLE
fix: preserve unqualified search filter semantics

### DIFF
--- a/src/genai_tag_db_tools/core_api.py
+++ b/src/genai_tag_db_tools/core_api.py
@@ -124,8 +124,8 @@ def initialize_databases(
 
 def _filter_rows(rows: list[TagSearchRow], request: TagSearchRequest) -> list[TagSearchRow]:
     filtered: list[TagSearchRow] = []
-    format_names = set(request.format_names or [])
-    type_names = set(request.type_names or [])
+    format_names = set(_concrete_filter_names(request.format_names))
+    type_names = set(_concrete_filter_names(request.type_names))
 
     for row in rows:
         usage_count = row["usage_count"] or 0
@@ -147,18 +147,23 @@ def _filter_rows(rows: list[TagSearchRow], request: TagSearchRequest) -> list[Ta
     return filtered
 
 
+def _concrete_filter_names(names: list[str] | None) -> list[str]:
+    if not names:
+        return []
+    return [name for name in names if name and name.lower() != "all"]
+
+
 def search_tags(repo: MergedTagReader, request: TagSearchRequest) -> TagSearchResult:
-    format_name = (
-        request.format_names[0] if request.format_names and len(request.format_names) == 1 else None
-    )
-    push_status_filters = bool(request.format_names or request.type_names)
+    format_names = _concrete_filter_names(request.format_names)
+    type_names = _concrete_filter_names(request.type_names)
+    format_name = format_names[0] if len(format_names) == 1 else None
 
     common_kwargs = {
         "partial": request.partial,
-        "format_names": request.format_names,
-        "type_names": request.type_names,
-        "alias": False if push_status_filters and not request.include_aliases else None,
-        "deprecated": False if push_status_filters and not request.include_deprecated else None,
+        "format_names": format_names or None,
+        "type_names": type_names or None,
+        "alias": None if request.include_aliases else False,
+        "deprecated": None if request.include_deprecated else False,
         "min_usage": request.min_usage,
         "max_usage": request.max_usage,
         "resolve_preferred": request.resolve_preferred,

--- a/src/genai_tag_db_tools/core_api.py
+++ b/src/genai_tag_db_tools/core_api.py
@@ -151,13 +151,14 @@ def search_tags(repo: MergedTagReader, request: TagSearchRequest) -> TagSearchRe
     format_name = (
         request.format_names[0] if request.format_names and len(request.format_names) == 1 else None
     )
+    push_status_filters = bool(request.format_names or request.type_names)
 
     common_kwargs = {
         "partial": request.partial,
         "format_names": request.format_names,
         "type_names": request.type_names,
-        "alias": None if request.include_aliases else False,
-        "deprecated": None if request.include_deprecated else False,
+        "alias": False if push_status_filters and not request.include_aliases else None,
+        "deprecated": False if push_status_filters and not request.include_deprecated else None,
         "min_usage": request.min_usage,
         "max_usage": request.max_usage,
         "resolve_preferred": request.resolve_preferred,

--- a/src/genai_tag_db_tools/db/query_utils.py
+++ b/src/genai_tag_db_tools/db/query_utils.py
@@ -187,6 +187,28 @@ class TagSearchQueryBuilder:
         if not format_ids and not type_name_ids and alias is None and deprecated is None:
             return query
 
+        if not format_ids and not type_name_ids:
+            if alias is True or deprecated is True:
+                status_select = select(TagStatus.tag_id).where(TagStatus.tag_id == tag_id_column)
+                if alias is True:
+                    status_select = status_select.where(TagStatus.alias == alias)
+                if deprecated is True:
+                    status_select = status_select.where(TagStatus.deprecated == deprecated)
+                query = query.filter(exists(status_select))
+            if alias is False:
+                alias_select = select(TagStatus.tag_id).where(
+                    TagStatus.tag_id == tag_id_column,
+                    TagStatus.alias.is_(True),
+                )
+                query = query.filter(not_(exists(alias_select)))
+            if deprecated is False:
+                deprecated_select = select(TagStatus.tag_id).where(
+                    TagStatus.tag_id == tag_id_column,
+                    TagStatus.deprecated.is_(True),
+                )
+                query = query.filter(not_(exists(deprecated_select)))
+            return query
+
         status_select = select(TagStatus.tag_id).where(TagStatus.tag_id == tag_id_column)
         if type_name_ids:
             status_select = status_select.join(

--- a/src/genai_tag_db_tools/db/query_utils.py
+++ b/src/genai_tag_db_tools/db/query_utils.py
@@ -103,12 +103,14 @@ class TagSearchQueryBuilder:
         requested; result row construction uses that to expose format-specific
         status fields.
         """
-        format_ids = self._format_ids_for_names(format_names)
-        if format_names and not format_ids:
+        concrete_format_names = self._normalize_filter_names(format_names)
+        format_ids = self._format_ids_for_names(concrete_format_names)
+        if concrete_format_names and not format_ids:
             return set(), 0
 
-        type_name_ids = self._type_name_ids_for_names(type_names)
-        if type_names and not type_name_ids:
+        concrete_type_names = self._normalize_filter_names(type_names)
+        type_name_ids = self._type_name_ids_for_names(concrete_type_names)
+        if concrete_type_names and not type_name_ids:
             return set(), 0
 
         candidate = self._keyword_candidate_query(keyword, use_like).subquery()

--- a/tests/unit/test_core_api.py
+++ b/tests/unit/test_core_api.py
@@ -270,10 +270,36 @@ def test_search_tags_plain_keyword_bounds_repo_query():
     assert repo.calls[0].get("limit") == 2
     assert repo.calls[0].get("offset") == 1
     assert repo.calls[0].get("alias") is None
-    assert repo.calls[0].get("deprecated") is None
+    assert repo.calls[0].get("deprecated") is False
     assert [item.tag_id for item in result.items] == [2, 3]
     # bounded fetch のため total は不明 (None)
     assert result.total is None
+
+
+def test_search_tags_treats_all_filters_as_unqualified():
+    rows = [
+        {
+            "tag": "cat",
+            "source_tag": "cat",
+            "tag_id": 1,
+            "format_name": None,
+            "type_id": None,
+            "type_name": "",
+            "alias": False,
+            "deprecated": False,
+            "usage_count": 0,
+            "translations": None,
+            "format_statuses": {"danbooru": {"status": "active"}},
+        }
+    ]
+    repo = DummyRepo(rows)
+    request = TagSearchRequest(query="cat", format_names=["all"], type_names=["all"], limit=1)
+
+    result = core_api.search_tags(repo, request)
+
+    assert repo.calls[0]["format_names"] is None
+    assert repo.calls[0]["type_names"] is None
+    assert [item.tag_id for item in result.items] == [1]
 
 
 def test_search_tags_passes_none_limit_when_not_set():

--- a/tests/unit/test_core_api.py
+++ b/tests/unit/test_core_api.py
@@ -196,6 +196,8 @@ def test_search_tags_filters_and_maps():
     )
     result = core_api.search_tags(repo, request)
     assert repo.calls[0]["partial"] is False
+    assert repo.calls[0]["alias"] is False
+    assert repo.calls[0]["deprecated"] is False
     assert result.items == [
         TagRecordPublic(
             tag="bunny",
@@ -267,6 +269,8 @@ def test_search_tags_plain_keyword_bounds_repo_query():
     # offset/limit は MergedTagReader が merge 後に扱うため core_api はそのまま渡す。
     assert repo.calls[0].get("limit") == 2
     assert repo.calls[0].get("offset") == 1
+    assert repo.calls[0].get("alias") is None
+    assert repo.calls[0].get("deprecated") is None
     assert [item.tag_id for item in result.items] == [2, 3]
     # bounded fetch のため total は不明 (None)
     assert result.total is None

--- a/tests/unit/test_query_utils.py
+++ b/tests/unit/test_query_utils.py
@@ -117,6 +117,24 @@ def test_filtered_tag_ids_filters_alias_and_deprecated_before_limit(
     assert sorted(ids) == [3, 4]
 
 
+def test_filtered_tag_ids_treats_all_as_unfiltered(
+    session_factory: Callable[[], Session],
+) -> None:
+    with session_factory() as session:
+        _seed_minimal_schema(session, total_tags=4)
+        builder = TagSearchQueryBuilder(session)
+        ids, format_id = builder.filtered_tag_ids(
+            "%sample_%",
+            use_like=True,
+            format_names=["all"],
+            type_names=["all"],
+            limit=2,
+        )
+
+    assert sorted(ids) == [1, 2]
+    assert format_id == 0
+
+
 def test_preloader_load_handles_large_id_sets_with_chunking(
     session_factory: Callable[[], Session],
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/test_query_utils.py
+++ b/tests/unit/test_query_utils.py
@@ -135,6 +135,49 @@ def test_filtered_tag_ids_treats_all_as_unfiltered(
     assert format_id == 0
 
 
+def test_filtered_tag_ids_negative_status_filters_keep_statusless_tags(
+    session_factory: Callable[[], Session],
+) -> None:
+    with session_factory() as session:
+        session.add(Tag(tag_id=1, source_tag="sample_statusless", tag="sample_statusless"))
+        session.add(TagFormat(format_id=1, format_name="test"))
+        session.add(TagTypeName(type_name_id=1, type_name="general"))
+        session.add(TagTypeFormatMapping(format_id=1, type_id=0, type_name_id=1))
+        session.add(Tag(tag_id=2, source_tag="sample_active", tag="sample_active"))
+        session.add(
+            TagStatus(
+                tag_id=2,
+                format_id=1,
+                type_id=0,
+                alias=False,
+                preferred_tag_id=2,
+                deprecated=False,
+            )
+        )
+        session.add(Tag(tag_id=3, source_tag="sample_deprecated", tag="sample_deprecated"))
+        session.add(
+            TagStatus(
+                tag_id=3,
+                format_id=1,
+                type_id=0,
+                alias=False,
+                preferred_tag_id=3,
+                deprecated=True,
+            )
+        )
+        session.commit()
+
+        builder = TagSearchQueryBuilder(session)
+        ids, _ = builder.filtered_tag_ids(
+            "%sample_%",
+            use_like=True,
+            alias=False,
+            deprecated=False,
+        )
+
+    assert sorted(ids) == [1, 2]
+
+
 def test_preloader_load_handles_large_id_sets_with_chunking(
     session_factory: Callable[[], Session],
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- preserve `format_name="all"` / `type_name="all"` as unfiltered repository search choices
- avoid pushing alias/deprecated status filters for unqualified core API searches so tags without status rows remain visible
- add regression coverage for both PR #43 review findings

Follow-up to #43 review comments:
- https://github.com/NEXTAltair/genai-tag-db-tools/pull/43#discussion_r3345536826
- https://github.com/NEXTAltair/genai-tag-db-tools/pull/43#discussion_r3345536830

## Verification
- `UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run --no-sync pytest tests/unit/test_query_utils.py tests/unit/test_core_api.py tests/unit/test_tag_repository.py -q`
- `UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run --no-sync ruff check src/genai_tag_db_tools/core_api.py src/genai_tag_db_tools/db/query_utils.py tests/unit/test_core_api.py tests/unit/test_query_utils.py`
- `UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run --no-sync mypy src/genai_tag_db_tools`
- `QT_QPA_PLATFORM=offscreen UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run --no-sync pytest -q`