### PR TITLE
fix: remove redundant core_api _filter_rows (single source of truth) (#45)

### DIFF
--- a/docs/decisions/0006-search-filter-pushdown-and-merged-pagination.md
+++ b/docs/decisions/0006-search-filter-pushdown-and-merged-pagination.md
@@ -26,3 +26,19 @@ ADR 0004 では plain keyword 検索だけを bounded にし、format/type/usage
 autocomplete/typeahead は bounded のまま、制約付き検索も full candidate materialize を避けられる。
 複数DB検索では既存の `TagReader(session_factory)` 構成を維持するため、SQLite `ATTACH DATABASE`
 ではなく adaptive fetch を採用する。
+
+## Amendment (2026-06-03, #45)
+
+フィルタの正本を repository 層 (`filtered_tag_ids`) に一元化し、`core_api.search_tags` の
+Python 側再フィルタ (`_filter_rows`) を撤去した。
+
+`_filter_rows` は `row["usage_count"]` / `row["deprecated"]` 等で再判定していたが、
+`TagSearchResultBuilder.build_row` はこれらを**単一 concrete format のときだけ**埋める
+(無/複数 format = `format_id=0` では `usage_count=0` / `deprecated=False` / `type_name=""`)。
+そのため `tag-db search --query x --min-usage N`(format 無し)で、repository が `EXISTS` で
+正しく拾った行を `_filter_rows` が `usage_count(0) < N` で全 drop し、空を返していた (#45)。
+
+repository は本 ADR の `EXISTS` push-down で format/type/usage/alias/deprecated を既に適用済みの
+ため、`_filter_rows` は冗長かつ format 依存値で誤判定する。撤去により正本は repository 単一に
+なる。回帰テストでは `DummyRepo` を `build_row` 同様にゼロ詰め(無/複数 format で format 依存
+フィールドを 0/False/"")して、二重フィルタが再導入されたら落ちるようにした。

--- a/src/genai_tag_db_tools/core_api.py
+++ b/src/genai_tag_db_tools/core_api.py
@@ -17,7 +17,6 @@ from genai_tag_db_tools.models import (
     TagRegisterResult,
     TagSearchRequest,
     TagSearchResult,
-    TagSearchRow,
     TagStatisticsResult,
 )
 from genai_tag_db_tools.services.tag_register import TagRegisterService
@@ -122,31 +121,6 @@ def initialize_databases(
     return results
 
 
-def _filter_rows(rows: list[TagSearchRow], request: TagSearchRequest) -> list[TagSearchRow]:
-    filtered: list[TagSearchRow] = []
-    format_names = set(_concrete_filter_names(request.format_names))
-    type_names = set(_concrete_filter_names(request.type_names))
-
-    for row in rows:
-        usage_count = row["usage_count"] or 0
-        if not request.include_aliases and row["alias"] is True:
-            continue
-        if not request.include_deprecated and row["deprecated"] is True:
-            continue
-        if format_names:
-            format_statuses = row.get("format_statuses") or {}
-            if not any(fmt in format_statuses for fmt in format_names):
-                continue
-        if type_names and row["type_name"] not in type_names:
-            continue
-        if request.min_usage is not None and usage_count < request.min_usage:
-            continue
-        if request.max_usage is not None and usage_count > request.max_usage:
-            continue
-        filtered.append(row)
-    return filtered
-
-
 def _concrete_filter_names(names: list[str] | None) -> list[str]:
     if not names:
         return []
@@ -169,14 +143,16 @@ def search_tags(repo: MergedTagReader, request: TagSearchRequest) -> TagSearchRe
         "resolve_preferred": request.resolve_preferred,
     }
 
+    # フィルタの正本は repository (filtered_tag_ids) に一元化する。core_api 側で行を再フィルタ
+    # しない: build_row は単一 format でないと usage_count/deprecated 等を 0/False で返すため、
+    # Python 側で再判定すると repository が正しく拾った行を落としてしまう (#45)。
     if request.limit is not None:
-        rows = repo.search_tags(
+        page = repo.search_tags(
             request.query,
             **common_kwargs,
             limit=request.limit,
             offset=request.offset,
         )
-        page = _filter_rows(rows, request)
         total: int | None = None  # bounded fetch のため全件数は不明
     else:
         rows = repo.search_tags(
@@ -185,9 +161,8 @@ def search_tags(repo: MergedTagReader, request: TagSearchRequest) -> TagSearchRe
             limit=None,
             offset=0,
         )
-        filtered = _filter_rows(rows, request)
-        total = len(filtered)
-        page = filtered[request.offset :] if request.offset else filtered
+        total = len(rows)
+        page = rows[request.offset :] if request.offset else rows
 
     items = [
         TagRecordPublic(

--- a/tests/unit/test_core_api.py
+++ b/tests/unit/test_core_api.py
@@ -23,6 +23,7 @@ class DummyRepo:
     def search_tags(self, keyword: str, **kwargs) -> list[dict]:
         self.calls.append({"keyword": keyword, **kwargs})
         rows = list(self._rows)
+        # repository は実 DB 値で SQL フィルタする
         if kwargs.get("min_usage") is not None:
             rows = [row for row in rows if (row["usage_count"] or 0) >= kwargs["min_usage"]]
         if kwargs.get("max_usage") is not None:
@@ -31,6 +32,20 @@ class DummyRepo:
             rows = [row for row in rows if row["alias"] is kwargs["alias"]]
         if kwargs.get("deprecated") is not None:
             rows = [row for row in rows if row["deprecated"] is kwargs["deprecated"]]
+        if kwargs.get("format_names"):
+            fmts = set(kwargs["format_names"])
+            rows = [row for row in rows if any(f in (row.get("format_statuses") or {}) for f in fmts)]
+        if kwargs.get("type_names"):
+            types = set(kwargs["type_names"])
+            rows = [row for row in rows if row["type_name"] in types]
+        # build_row 相当の忠実化: 単一 concrete format でない呼び出しでは format 依存フィールドが
+        # 0/False/"" で返る (format_id=0)。これを再現しないと #45 の二重フィルタ不整合が
+        # テストで顕在化しない。
+        fmt_names = kwargs.get("format_names") or (
+            [kwargs["format_name"]] if kwargs.get("format_name") else []
+        )
+        if len(fmt_names) != 1:
+            rows = [{**row, "usage_count": 0, "deprecated": False, "type_name": ""} for row in rows]
         offset = kwargs.get("offset", 0)
         limit = kwargs.get("limit")
         rows = rows[offset:] if offset else rows
@@ -116,6 +131,25 @@ def test_search_tags_constrained_paginates_after_filter():
     assert [item.tag_id for item in result.items] == [3, 4]
     # bounded fetch のため total は不明
     assert result.total is None
+
+
+def test_search_tags_unqualified_usage_filter_not_dropped():
+    """#45: 無 format + min_usage で repository の一致が core_api 側で空にされない。
+
+    repository は実 DB 値で usage>=min を拾うが、無 format では build_row が usage_count=0 で
+    返す。core_api が Python で再フィルタすると usage_count(0) < min_usage で全 drop してしまう
+    ため、再フィルタしない (フィルタの正本は repository) ことを保証する回帰テスト。
+    """
+    rows = [_usage_row(1, 50), _usage_row(2, 80)]  # 実 usage は閾値以上
+    repo = DummyRepo(rows=rows)
+
+    result = core_api.search_tags(repo, TagSearchRequest(query="t", min_usage=10))
+
+    # repository の一致が保持され、空にならない
+    assert [item.tag_id for item in result.items] == [1, 2]
+    assert result.total == 2
+    # 無 format のため表示上の usage_count は 0 (build_row 既定) になる
+    assert all(item.usage_count == 0 for item in result.items)
 
 
 def test_search_tags_constrained_offset_returns_later_rows():


### PR DESCRIPTION
## 概要

`#43`/`#37` で repository が format/type/usage/alias/deprecated を SQL の `EXISTS` で LIMIT 前に適用するようになったが、`core_api.search_tags` は依然 Python 側で `_filter_rows` を再適用していた。`_filter_rows` は `row["usage_count"]` 等で判定するが、`build_row` はこれを**単一 concrete format のときだけ**埋める(無/複数 format=`format_id=0` では 0/False/"")。そのため:

```
tag-db search --query x --min-usage 10   # format 指定なし
→ repository は EXISTS で一致を拾うが、_filter_rows が usage_count(0) < 10 で全 drop → 空
```

## 修正

フィルタの正本を **repository 一本**に一元化し、`core_api` の `_filter_rows` を撤去:
- bounded path: repository の page をそのまま返す。
- unbounded path: repository 結果を数えて(total)ページングする。

repository は本来全フィルタを適用済みなので機能欠落なし(呼び出し元は core_api の2箇所のみ・検証済み)。

## テスト(回帰)

- `DummyRepo` を `build_row` に忠実化: 実 DB 値で format/type/usage/alias/deprecated を絞った**後**、単一 concrete format でない呼び出しでは format 依存フィールドを 0/False/"" にゼロ詰め。これで二重フィルタが再導入されたら既存の無 format min_usage テストが落ちる。
- `#45` 回帰 `test_search_tags_unqualified_usage_filter_not_dropped` を追加。

CI-EQUIV-TESTED: genai-tag-db-tools `-m "not slow and not network"` **330 passed**。Ruff/mypy クリーン。LoRAIro 側 autocomplete/tag suggestion **66 passed**(worktree コードを PYTHONPATH 優先で検証、退行なし)。

## なぜテストで炙り出せなかったか
`DummyRepo` が実 repo の「format_id=0 で format 依存フィールドをゼロ詰め」挙動を再現しておらず(usage_count を現実値のまま返す)、repo と `_filter_rows` が一致してしまっていた。本 PR の忠実化で再現・回帰化。

ADR 0006 に Amendment として記録。

Closes #45