### PR TITLE
fix(cli): aliases register で --base-db が user DB と同一なら INVALID_INPUT で拒否 (Issue #49)

### DIFF
--- a/src/genai_tag_db_tools/cli.py
+++ b/src/genai_tag_db_tools/cli.py
@@ -276,12 +276,27 @@ def _parse_alias_file(file_path: str) -> list[AliasRegisterInput]:
 
 def cmd_aliases_register(args: argparse.Namespace) -> None:
     """aliases register サブコマンドのハンドラ。"""
+    from pathlib import Path
+
     if args.user_db_dir:
         user_db_dir = args.user_db_dir
     else:
         from genai_tag_db_tools.io.hf_downloader import default_cache_dir
 
         user_db_dir = str(default_cache_dir())
+
+    # --base-db が user DB と同一ファイルを指す場合は拒否 (Issue #49)
+    user_db_path = Path(user_db_dir).resolve() / "user_tags.sqlite"
+    if args.base_db:
+        for base_db in args.base_db:
+            if Path(base_db).resolve() == user_db_path:
+                emit_error(
+                    errors.INVALID_INPUT,
+                    "--base-db must not point to the same user_tags.sqlite as --user-db-dir for aliases register",
+                    retryable=False,
+                    user_action_required=True,
+                )
+                sys.exit(2)
 
     _set_db_paths(args.base_db, user_db_dir)
     service = _build_register_service()

--- a/tests/unit/test_cli_aliases_register.py
+++ b/tests/unit/test_cli_aliases_register.py
@@ -283,3 +283,62 @@ class TestCmdAliasesRegister:
         assert any(line["kind"] == "item" for line in lines)
         result = next(line for line in lines if line["kind"] == "result")
         assert result["total"] == 1
+
+    def test_rejects_when_base_db_is_same_as_user_db(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """--base-db が --user-db-dir/user_tags.sqlite と同一なら INVALID_INPUT で拒否 (Issue #49)。"""
+        from genai_tag_db_tools.cli import main
+
+        user_db = tmp_path / "user_tags.sqlite"
+        with pytest.raises(SystemExit) as exc_info:
+            main(
+                [
+                    "aliases",
+                    "register",
+                    "--file",
+                    str(tmp_path / "dummy.jsonl"),
+                    "--base-db",
+                    str(user_db),
+                    "--user-db-dir",
+                    str(tmp_path),
+                ]
+            )
+        assert exc_info.value.code == 2
+        out = capsys.readouterr().out
+        error_line = json.loads(out.strip())
+        assert error_line["kind"] == "error"
+        assert error_line["code"] == "INVALID_INPUT"
+        assert error_line["user_action_required"] is True
+
+    def test_allows_when_base_db_differs_from_user_db(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """--base-db が user_tags.sqlite と別パスなら通常通り動作する (Issue #49)。"""
+        from genai_tag_db_tools import cli
+        from genai_tag_db_tools.cli import main
+
+        mock_svc = self._make_mock_service("would_create")
+        monkeypatch.setattr(cli, "_build_register_service", lambda: mock_svc)
+        jsonl = self._make_jsonl_file(
+            tmp_path,
+            [{"alias": "weding dress", "preferred": "wedding dress", "format_name": "Lorairo", "type_name": "unknown"}],
+        )
+        base_db = tmp_path / "base.sqlite"
+        user_dir = tmp_path / "user"
+        user_dir.mkdir()
+        main(
+            [
+                "aliases",
+                "register",
+                "--file",
+                str(jsonl),
+                "--base-db",
+                str(base_db),
+                "--user-db-dir",
+                str(user_dir),
+            ]
+        )
+        out = capsys.readouterr().out
+        lines = [json.loads(line) for line in out.splitlines() if line.strip()]
+        assert any(line["kind"] == "result" for line in lines)


### PR DESCRIPTION
## Summary

- `aliases register` 実行前に `--base-db` と `--user-db-dir/user_tags.sqlite` が同一ファイルを指すか検証
- 一致する場合は `INVALID_INPUT`(exit 2) で早期拒否し、既存 TAG_STATUS の誤上書きを防止
- `Path.resolve()` による比較で相対パス・絶対パス・シンボリックリンクに対応
- 複数 `--base-db` のうち1つでも一致すれば拒否

## Changes

- `cli.py`: `cmd_aliases_register` に `_set_db_paths` 呼び出し前の同一DB検証を追加
- `tests/unit/test_cli_aliases_register.py`: 拒否ケース・正常通過ケースのテストを2件追加 (計12件)

## Test plan

- [x] `test_rejects_when_base_db_is_same_as_user_db` — exit 2 + INVALID_INPUT JSONL を確認
- [x] `test_allows_when_base_db_differs_from_user_db` — 別パス指定時は通常動作を確認
- [x] `pytest -m "not slow and not network"` で 221件全件PASS
- [x] `ruff check` エラーなし

Closes #49

🤖 Generated with [Claude Code](https://claude.ai/claude-code)