### PR TITLE
feat(core-api): convert_tags を case-insensitive lookup + type 除外対応

### DIFF
--- a/src/genai_tag_db_tools/core_api.py
+++ b/src/genai_tag_db_tools/core_api.py
@@ -17,6 +17,7 @@ from genai_tag_db_tools.models import (
     TagRegisterResult,
     TagSearchRequest,
     TagSearchResult,
+    TagSearchRow,
     TagStatisticsResult,
 )
 from genai_tag_db_tools.services.tag_register import TagRegisterService
@@ -209,7 +210,21 @@ def _normalize_prompt_tags(tags: str) -> list[str]:
     return cleaned_tags
 
 
-def _lookup_tags(repo: MergedTagReader, tags: list[str], format_name: str) -> dict[str, str]:
+def _lookup_tag_rows(repo: MergedTagReader, tags: list[str], format_name: str) -> dict[str, TagSearchRow]:
+    """入力タグを DB で検索し、keyword → 検索結果行の辞書を返す。
+
+    完全一致検索 (partial=False) は repository 層で大文字小文字を無視する
+    (COLLATE NOCASE / lower 照合) ため、入力の case が DB と異なっても解決される。
+
+    Args:
+        repo: タグ検索に用いる MergedTagReader。
+        tags: 検索対象のタグ文字列リスト。
+        format_name: 変換先フォーマット名。
+
+    Returns:
+        ヒットしたタグについて keyword をキー、TagSearchRow を値とする辞書。
+        ``tag`` フィールドが空の行は除外する。
+    """
     unique_tags = list(dict.fromkeys(tags))
     if not unique_tags:
         return {}
@@ -221,23 +236,54 @@ def _lookup_tags(repo: MergedTagReader, tags: list[str], format_name: str) -> di
             resolve_preferred=True,
         )
         return {
-            tag: rows_by_tag[tag]["tag"]
+            tag: rows_by_tag[tag]
             for tag in unique_tags
             if tag in rows_by_tag and rows_by_tag[tag].get("tag")
         }
 
-    tag_map: dict[str, str] = {}
+    tag_rows: dict[str, TagSearchRow] = {}
     for tag in unique_tags:
         rows = repo.search_tags(tag, partial=False, format_name=format_name, resolve_preferred=True)
         if rows:
-            tag_map[tag] = rows[0]["tag"]
-    return tag_map
+            tag_rows[tag] = rows[0]
+    return tag_rows
 
 
-def convert_tags(repo: MergedTagReader, tags: str, format_name: str, separator: str = ", ") -> str:
+def _is_excluded_type(row: TagSearchRow, exclude_types_lower: set[str]) -> bool:
+    """検索結果行の type_name が除外対象なら True を返す。"""
+    if not exclude_types_lower:
+        return False
+    type_name = row.get("type_name")
+    if not type_name:
+        return False
+    return type_name.lower() in exclude_types_lower
+
+
+def convert_tags(
+    repo: MergedTagReader,
+    tags: str,
+    format_name: str,
+    separator: str = ", ",
+    *,
+    exclude_types: list[str] | None = None,
+) -> str:
     """Convert comma-separated tags to the specified format.
+
     - Normalize input before lookup
     - Use batch lookup when available
+    - Exact-match lookup is case-insensitive (see ``_lookup_tag_rows``)
+
+    Args:
+        repo: タグ検索に用いる MergedTagReader。
+        tags: カンマ区切りの入力タグ文字列。
+        format_name: 変換先フォーマット名 (例: "danbooru")。
+        separator: 出力タグの結合文字列。
+        exclude_types: 出力から除外する type_name のリスト (例: ["meta"])。
+            None の場合は除外しない (デフォルト挙動)。指定タグが該当 type に
+            解決された場合、そのタグは出力から取り除かれる。
+
+    Returns:
+        変換後のタグ文字列。
     """
     if not tags.strip():
         return tags
@@ -250,22 +296,33 @@ def convert_tags(repo: MergedTagReader, tags: str, format_name: str, separator: 
     if not normalized_tags:
         return tags
 
-    tag_map = _lookup_tags(repo, normalized_tags, format_name)
-    word_map: dict[str, str] = {}
+    exclude_types_lower = {t.lower() for t in exclude_types} if exclude_types else set()
+
+    tag_rows = _lookup_tag_rows(repo, normalized_tags, format_name)
+    word_rows: dict[str, TagSearchRow] = {}
     converted_list: list[str] = []
 
     for tag in normalized_tags:
-        converted = tag_map.get(tag)
-        if converted:
-            converted_list.append(converted)
+        row = tag_rows.get(tag)
+        if row is not None and row.get("tag"):
+            if _is_excluded_type(row, exclude_types_lower):
+                continue
+            converted_list.append(row["tag"])
             continue
 
         if " " in tag:
             words = [word for word in tag.split(" ") if word]
-            missing = [word for word in words if word not in word_map]
+            missing = [word for word in words if word not in word_rows]
             if missing:
-                word_map.update(_lookup_tags(repo, missing, format_name))
-            converted_list.extend([word_map.get(word, word) for word in words])
+                word_rows.update(_lookup_tag_rows(repo, missing, format_name))
+            for word in words:
+                word_row = word_rows.get(word)
+                if word_row is not None and word_row.get("tag"):
+                    if _is_excluded_type(word_row, exclude_types_lower):
+                        continue
+                    converted_list.append(word_row["tag"])
+                else:
+                    converted_list.append(word)
             continue
 
         converted_list.append(tag)

--- a/src/genai_tag_db_tools/db/query_utils.py
+++ b/src/genai_tag_db_tools/db/query_utils.py
@@ -1,7 +1,7 @@
 from logging import Logger
 from typing import Any, TypedDict
 
-from sqlalchemy import exists, not_, select
+from sqlalchemy import exists, func, not_, select
 from sqlalchemy.orm import Session
 from sqlalchemy.sql import literal_column, or_
 
@@ -57,12 +57,16 @@ class TagSearchQueryBuilder:
         limit: int | None = None,
         offset: int = 0,
     ) -> set[int]:
+        # 完全一致 (use_like=False) は大文字小文字を無視して照合する (COLLATE NOCASE)。
+        # LIKE は SQLite 既定で ASCII 大文字小文字を無視するため挙動は変えない。
         tag_conditions = or_(
-            Tag.tag.like(keyword) if use_like else Tag.tag == keyword,
-            Tag.source_tag.like(keyword) if use_like else Tag.source_tag == keyword,
+            Tag.tag.like(keyword) if use_like else Tag.tag.collate("NOCASE") == keyword,
+            Tag.source_tag.like(keyword) if use_like else Tag.source_tag.collate("NOCASE") == keyword,
         )
         translation_condition = (
-            TagTranslation.translation.like(keyword) if use_like else TagTranslation.translation == keyword
+            TagTranslation.translation.like(keyword)
+            if use_like
+            else TagTranslation.translation.collate("NOCASE") == keyword
         )
 
         tag_query = self.session.query(Tag.tag_id.label("tag_id")).filter(tag_conditions)
@@ -141,12 +145,15 @@ class TagSearchQueryBuilder:
         return {row[0] for row in query.all()}, format_id
 
     def _keyword_candidate_query(self, keyword: str, use_like: bool) -> Any:
+        # 完全一致 (use_like=False) は COLLATE NOCASE で大文字小文字を無視する。
         tag_conditions = or_(
-            Tag.tag.like(keyword) if use_like else Tag.tag == keyword,
-            Tag.source_tag.like(keyword) if use_like else Tag.source_tag == keyword,
+            Tag.tag.like(keyword) if use_like else Tag.tag.collate("NOCASE") == keyword,
+            Tag.source_tag.like(keyword) if use_like else Tag.source_tag.collate("NOCASE") == keyword,
         )
         translation_condition = (
-            TagTranslation.translation.like(keyword) if use_like else TagTranslation.translation == keyword
+            TagTranslation.translation.like(keyword)
+            if use_like
+            else TagTranslation.translation.collate("NOCASE") == keyword
         )
 
         tag_query = self.session.query(Tag.tag_id.label("tag_id")).filter(tag_conditions)
@@ -265,26 +272,41 @@ class TagSearchQueryBuilder:
             return {}
 
         keyword_set = set(keywords)
+        # 大文字小文字を無視して照合するため lower 化したキーで突き合わせる。
+        # 同一 lower 値を持つ keyword が複数あっても、それぞれに tag_id を割り当てる。
+        keywords_by_lower: dict[str, set[str]] = {}
+        for keyword in keyword_set:
+            keywords_by_lower.setdefault(keyword.lower(), set()).add(keyword)
+        lower_keys = list(keywords_by_lower.keys())
+
         tag_rows = (
             self.session.query(Tag.tag_id, Tag.tag, Tag.source_tag)
-            .filter(or_(Tag.tag.in_(keyword_set), Tag.source_tag.in_(keyword_set)))
+            .filter(
+                or_(
+                    func.lower(Tag.tag).in_(lower_keys),
+                    func.lower(Tag.source_tag).in_(lower_keys),
+                )
+            )
             .all()
         )
         trans_rows = (
             self.session.query(TagTranslation.tag_id, TagTranslation.translation)
-            .filter(TagTranslation.translation.in_(keyword_set))
+            .filter(func.lower(TagTranslation.translation).in_(lower_keys))
             .all()
         )
 
         tag_ids_by_keyword: dict[str, set[int]] = {keyword: set() for keyword in keyword_set}
         for tag_id, tag, source_tag in tag_rows:
-            if tag in tag_ids_by_keyword:
-                tag_ids_by_keyword[tag].add(tag_id)
-            if source_tag in tag_ids_by_keyword:
-                tag_ids_by_keyword[source_tag].add(tag_id)
+            for value in (tag, source_tag):
+                if value is None:
+                    continue
+                for keyword in keywords_by_lower.get(value.lower(), ()):
+                    tag_ids_by_keyword[keyword].add(tag_id)
         for tag_id, translation in trans_rows:
-            if translation in tag_ids_by_keyword:
-                tag_ids_by_keyword[translation].add(tag_id)
+            if translation is None:
+                continue
+            for keyword in keywords_by_lower.get(translation.lower(), ()):
+                tag_ids_by_keyword[keyword].add(tag_id)
 
         return {keyword: ids for keyword, ids in tag_ids_by_keyword.items() if ids}
 
@@ -430,15 +452,11 @@ class TagSearchPreloader:
             row.preferred_tag_id for row in initial_status_rows if row.preferred_tag_id is not None
         }
         status_tag_ids = set(tag_ids) | preferred_ids
-        status_rows = self._query_in_chunks(
-            self.session.query(TagStatus), TagStatus.tag_id, status_tag_ids
-        )
+        status_rows = self._query_in_chunks(self.session.query(TagStatus), TagStatus.tag_id, status_tag_ids)
         format_ids = {row.format_id for row in status_rows}
         format_name_by_id = {
             fmt.format_id: fmt.format_name
-            for fmt in self._query_in_chunks(
-                self.session.query(TagFormat), TagFormat.format_id, format_ids
-            )
+            for fmt in self._query_in_chunks(self.session.query(TagFormat), TagFormat.format_id, format_ids)
         }
         type_name_by_key = {
             (mapping.format_id, mapping.type_id): (mapping.type_name.type_name if mapping.type_name else "")
@@ -455,8 +473,7 @@ class TagSearchPreloader:
             )
         }
         tags_by_id = {
-            t.tag_id: t
-            for t in self._query_in_chunks(self.session.query(Tag), Tag.tag_id, status_tag_ids)
+            t.tag_id: t for t in self._query_in_chunks(self.session.query(Tag), Tag.tag_id, status_tag_ids)
         }
         all_translations = self._query_in_chunks(
             self.session.query(TagTranslation), TagTranslation.tag_id, status_tag_ids

--- a/tests/unit/test_core_api_convert_tags.py
+++ b/tests/unit/test_core_api_convert_tags.py
@@ -1,11 +1,21 @@
 from __future__ import annotations
 
+from collections.abc import Callable
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
 from genai_tag_db_tools import core_api
+from genai_tag_db_tools.db.repository import MergedTagReader, TagReader, TagRepository
+from genai_tag_db_tools.db.schema import Base, TagFormat, TagTypeFormatMapping, TagTypeName
 
 
 class FakeRepo:
-    def __init__(self, mapping: dict[str, str]) -> None:
+    def __init__(self, mapping: dict[str, str], types: dict[str, str] | None = None) -> None:
         self._mapping = mapping
+        self._types = types or {}
 
     def get_format_id(self, format_name: str) -> int | None:
         return 1 if format_name == "danbooru" else None
@@ -17,7 +27,62 @@ class FakeRepo:
         format_name: str | None = None,
         resolve_preferred: bool = False,
     ) -> dict[str, dict[str, str]]:
-        return {key: {"tag": self._mapping[key]} for key in keywords if key in self._mapping}
+        return {
+            key: {"tag": self._mapping[key], "type_name": self._types.get(key, "general")}
+            for key in keywords
+            if key in self._mapping
+        }
+
+
+@pytest.fixture()
+def danbooru_reader() -> MergedTagReader:
+    """grey hair(general) と highres(meta) を持つ danbooru 用の MergedTagReader を構築する。"""
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    factory: Callable[[], Session] = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+
+    reader = TagReader(factory)
+    merged = MergedTagReader(base_repo=reader)
+    repo = TagRepository(factory, reader=merged)
+
+    with factory() as session:
+        session.add(TagFormat(format_id=1, format_name="danbooru"))
+        session.add(TagTypeName(type_name_id=1, type_name="general"))
+        session.add(TagTypeName(type_name_id=2, type_name="meta"))
+        session.add(TagTypeFormatMapping(format_id=1, type_id=0, type_name_id=1))
+        session.add(TagTypeFormatMapping(format_id=1, type_id=1, type_name_id=2))
+        session.commit()
+
+    general_id = repo.create_tag("grey_hair", "grey hair")
+    repo.update_tag_status(general_id, format_id=1, alias=False, preferred_tag_id=general_id, type_id=0)
+    meta_id = repo.create_tag("highres", "highres")
+    repo.update_tag_status(meta_id, format_id=1, alias=False, preferred_tag_id=meta_id, type_id=1)
+
+    return merged
+
+
+def test_convert_tags_case_insensitive_lookup(danbooru_reader: MergedTagReader) -> None:
+    result = core_api.convert_tags(danbooru_reader, "Grey Hair", "danbooru")
+
+    assert result == "grey hair"
+
+
+def test_convert_tags_excludes_meta_types(danbooru_reader: MergedTagReader) -> None:
+    result = core_api.convert_tags(
+        danbooru_reader, "grey hair, highres", "danbooru", exclude_types=["meta"]
+    )
+
+    assert result == "grey hair"
+
+
+def test_convert_tags_keeps_meta_without_exclude(danbooru_reader: MergedTagReader) -> None:
+    result = core_api.convert_tags(danbooru_reader, "grey hair, highres", "danbooru")
+
+    assert result == "grey hair, highres"
 
 
 def test_convert_tags_normalizes_and_falls_back_to_words():
@@ -38,5 +103,16 @@ def test_convert_tags_unknown_format_returns_original():
     repo = FakeRepo({"blue hair": "blue hair"})
 
     result = core_api.convert_tags(repo, "blue hair", "unknown")
+
+    assert result == "blue hair"
+
+
+def test_convert_tags_exclude_types_drops_meta_tag():
+    repo = FakeRepo(
+        {"blue hair": "blue hair", "highres": "highres"},
+        types={"blue hair": "general", "highres": "meta"},
+    )
+
+    result = core_api.convert_tags(repo, "blue hair, highres", "danbooru", exclude_types=["meta"])
 
     assert result == "blue hair"

--- a/tests/unit/test_query_utils.py
+++ b/tests/unit/test_query_utils.py
@@ -60,6 +60,30 @@ def test_initial_tag_ids_respects_limit_and_offset(session_factory: Callable[[],
         assert len(ids) == 5
 
 
+def test_initial_tag_ids_exact_match_is_case_insensitive(
+    session_factory: Callable[[], Session],
+) -> None:
+    with session_factory() as session:
+        session.add(Tag(tag_id=1, source_tag="blue_hair", tag="blue hair"))
+        session.commit()
+        builder = TagSearchQueryBuilder(session)
+        ids = builder.initial_tag_ids("Blue Hair", use_like=False)
+
+    assert ids == {1}
+
+
+def test_initial_tag_ids_for_keywords_is_case_insensitive(
+    session_factory: Callable[[], Session],
+) -> None:
+    with session_factory() as session:
+        session.add(Tag(tag_id=1, source_tag="blue_hair", tag="blue hair"))
+        session.commit()
+        builder = TagSearchQueryBuilder(session)
+        result = builder.initial_tag_ids_for_keywords(["Blue Hair"])
+
+    assert result == {"Blue Hair": {1}}
+
+
 def test_filtered_tag_ids_applies_filters_before_limit(
     session_factory: Callable[[], Session],
 ) -> None:


### PR DESCRIPTION
## 背景

LoRAIro のタグ正規化責任を genai-tag-db-tools に集約する方針 (LoRAIro ADR 0067 / Issue #769)。その一環として tagdb 側の `convert_tags` を強化する。

関連: NEXTAltair/genai-tag-db-tools#2 / NEXTAltair/LoRAIro#769

## 変更内容

### 1. case-insensitive な完全一致 lookup

これまで完全一致検索 (`partial=False`) は SQLite の `==` で case-sensitive だった。このため `convert_tags` に `Grey hair` を渡しても danbooru の `grey hair` にマッチせず raw のまま返っていた。

- `query_utils.initial_tag_ids` / `_keyword_candidate_query` の完全一致比較を `COLLATE NOCASE` 化
- `query_utils.initial_tag_ids_for_keywords` (bulk lookup の正本) を `func.lower()` 照合 + 原キーワードへの逆引きへ変更（DB が小文字で返しても入力 keyword に正しく対応付ける）
- LIKE (`partial=True`) は SQLite 既定で ASCII 大文字小文字を無視するため**挙動を変えていない**
- LoRA 構文 `<lora:...>` の case 保護（`clean_format` の angle bracket 保護）は**従来通り維持**

### 2. `type=meta` 除外サポート

学習 export で danbooru の管理 meta タグ (`highres`, `bad_id`, `commentary_request` 等、`type_name='meta'`) を除外できるよう、`convert_tags` に keyword-only 引数 `exclude_types: list[str] | None = None` を追加。

- 指定 type に解決されたタグは出力から取り除かれる（単語分割フォールバック側でも適用）
- デフォルト `None` で**従来挙動は不変**（後方互換）
- `_lookup_tags` を `type_name` を保持する `_lookup_tag_rows` に置換し、`_is_excluded_type` ヘルパーで判定

## テスト

TDD で先に失敗テストを追加してから実装。

- `test_query_utils.py`: 完全一致 / bulk lookup の case-insensitive 化
- `test_core_api_convert_tags.py`: 実 SQLite を seed した `MergedTagReader` で `Grey Hair` → `grey hair` 変換、meta 除外あり/なし、FakeRepo での exclude_types 動作

### 検証 (CI-equivalent filter)

```
QT_QPA_PLATFORM=offscreen uv run pytest -m "not slow and not network"
# 348 passed
uv run mypy src/genai_tag_db_tools/core_api.py src/genai_tag_db_tools/db/query_utils.py  # Success
uv run ruff check / format  # All checks passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)