### PR TITLE
refactor(ruff): lint ignore を LoRAIro 側と統一

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,11 +60,14 @@ exclude = [
 ]
 
 ignore = [
-    "RUF002", # カタカナの `ノ` でのメッセージを無視
     "E501",   # Line too long (line-lengthで制御)
-    "F541",   # f-string in logging (同等のpylint警告W1203 - Ruffでは直接の対応がない)
     "C901",   # Function is too complex (複雑度チェックを無効化)
 ]
+
+# confusable 警告を許可する文字。日本語表記のカタカナ ノ (U+30CE)・全角括弧 （ ）・
+# UI/乗算で使う × (U+00D7)。残る全角記号は RUF001/002/003 で検出・半角化させる。
+allowed-confusables = ["ノ", "（", "）", "×"]
+
 fixable = ["ALL"]
 
 [tool.ruff.format]


### PR DESCRIPTION
## 概要

LoRAIro 本体・image-annotator-lib との Ruff lint ignore のズレを解消する3パッケージ統一の一環 (genai-tag 分)。

## 変更 (pyproject.toml のみ)

- **RUF002** の包括 ignore を解除し `allowed-confusables = ["ノ", "（", "）", "×"]` に統一。日本語表記として自然なカタカナ ノ・全角括弧・UI/乗算の × のみ許可。
- **F541** の ignore を削除。`src/genai_tag_db_tools` に実違反が無く、コメントの理由 (logging W1203 相当) も F541 (placeholder の無い f-string) の意味と食い違っていたため。
- **C901** の全体 ignore は現状維持 (本 PR スコープ外)。

`src` に F401 等の実違反は無く、source code の変更はありません。

## テスト

設定のみの変更で実行時挙動に影響なし。CI で検証。

🤖 Generated with [Claude Code](https://claude.com/claude-code)