### PR TITLE
Handle issue 2 wave 1 prerequisites

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -155,6 +155,45 @@ tag-db search --query cat --limit 2
 {"kind": "result", "ok": true, "message": "search completed", "query": "cat", "count": 2, "total": 2, "limit": 2, "offset": 0}
 ```
 
+#### Reading `search` item status fields
+
+Each `item` has two status views:
+
+- Top-level `format_name`, `type_id`, `type_name`, `alias`, `deprecated`, and
+  `usage_count` are the selected-format summary. They are meaningful when the
+  request identifies exactly one concrete format, such as `--format-name
+  danbooru` or `--format-name unknown`.
+- `format_statuses` is the per-format map for the same tag. Use this map when
+  comparing formats or when the query is unqualified (`--format-name` omitted or
+  `all`). Keys are format names, and each value carries that format's `type_id`,
+  `type_name`, `alias`, `deprecated`, and `usage_count`.
+
+For a single concrete format, the top-level fields should match the same entry
+inside `format_statuses`. For example, a query with `--format-name unknown` may
+return:
+
+```jsonl
+{"kind": "item", "tag": "sorceress", "format_name": "unknown", "type_id": 0, "type_name": "unknown", "alias": false, "deprecated": false, "usage_count": 1096310, "format_statuses": {"unknown": {"alias": false, "deprecated": false, "usage_count": 1096310, "type_id": 0, "type_name": "unknown"}, "danbooru": {"alias": true, "deprecated": true, "usage_count": 0, "type_id": 0, "type_name": "general"}}}
+```
+
+`unknown` in `--format-name unknown` is a format name, not the same thing as
+`--type-name unknown`. In the current distributed DBs, some tags have an
+`unknown` format status whose type is also `unknown`; that is why both
+`format_name` and `type_name` can read `"unknown"` in the same row.
+
+For issue #56 style data review, read CLI output as evidence, not as a final
+recommendation verdict:
+
+- Use the final `result.count` to decide whether the query found any usable rows.
+  `pixiv id` with `--exact --format-name unknown` and `pixiv` with
+  `--format-name unknown` can legitimately return `count:0` when the current DB
+  has no matching tag/translation in that format.
+- Use the selected-format top-level fields for the requested format's status.
+  For cross-format context, inspect `format_statuses`.
+- Do not infer training suitability or recommendation decisions from
+  `deprecated`, `alias`, or `type_name` alone; those policies are outside this
+  CLI contract.
+
 ### register — add a tag (`db_write`)
 
 ```bash

--- a/src/genai_tag_db_tools/db/query_utils.py
+++ b/src/genai_tag_db_tools/db/query_utils.py
@@ -343,7 +343,7 @@ class TagSearchQueryBuilder:
 
     def _query_usage_tag_ids(
         self,
-        format_id: int,
+        format_id: int | None,
         min_usage: int | None,
         max_usage: int | None,
     ) -> set[int]:
@@ -375,7 +375,7 @@ class TagSearchQueryBuilder:
         usage_all_tag_ids = {row[0] for row in usage_all_query.all()}
         return usage_tag_ids | (tag_ids - usage_all_tag_ids)
 
-    def apply_type_filter(self, tag_ids: set[int], format_id: int, type_name: str | None) -> set[int]:
+    def apply_type_filter(self, tag_ids: set[int], format_id: int | None, type_name: str | None) -> set[int]:
         if not type_name or type_name.lower() == "all":
             return tag_ids
 
@@ -389,17 +389,17 @@ class TagSearchQueryBuilder:
             & (TagStatus.type_id == TagTypeFormatMapping.type_id),
         )
         type_query = type_query.filter(TagTypeFormatMapping.type_name_id == type_obj.type_name_id)
-        if format_id:
+        if format_id is not None:
             type_query = type_query.filter(TagStatus.format_id == format_id)
         type_tag_ids = {row[0] for row in type_query.all()}
         return tag_ids & type_tag_ids
 
-    def apply_alias_filter(self, tag_ids: set[int], format_id: int, alias: bool | None) -> set[int]:
+    def apply_alias_filter(self, tag_ids: set[int], format_id: int | None, alias: bool | None) -> set[int]:
         if alias is None:
             return tag_ids
 
         alias_query = self.session.query(TagStatus.tag_id).filter(TagStatus.alias == alias)
-        if format_id:
+        if format_id is not None:
             alias_query = alias_query.filter(TagStatus.format_id == format_id)
         alias_tag_ids = {row[0] for row in alias_query.all()}
         return tag_ids & alias_tag_ids

--- a/src/genai_tag_db_tools/db/query_utils.py
+++ b/src/genai_tag_db_tools/db/query_utils.py
@@ -100,7 +100,7 @@ class TagSearchQueryBuilder:
         deprecated: bool | None = None,
         limit: int | None = None,
         offset: int = 0,
-    ) -> tuple[set[int], int]:
+    ) -> tuple[set[int], int | None]:
         """Return tag ids after applying search filters before limit/offset.
 
         The returned format id is only set when exactly one concrete format was
@@ -110,12 +110,12 @@ class TagSearchQueryBuilder:
         concrete_format_names = self._normalize_filter_names(format_names)
         format_ids = self._format_ids_for_names(concrete_format_names)
         if concrete_format_names and not format_ids:
-            return set(), 0
+            return set(), None
 
         concrete_type_names = self._normalize_filter_names(type_names)
         type_name_ids = self._type_name_ids_for_names(concrete_type_names)
         if concrete_type_names and not type_name_ids:
-            return set(), 0
+            return set(), None
 
         candidate = self._keyword_candidate_query(keyword, use_like).subquery()
         query = self.session.query(candidate.c.tag_id)
@@ -141,7 +141,7 @@ class TagSearchQueryBuilder:
         if limit is not None:
             query = query.limit(limit)
 
-        format_id = format_ids[0] if len(format_ids) == 1 else 0
+        format_id = format_ids[0] if len(format_ids) == 1 else None
         return {row[0] for row in query.all()}, format_id
 
     def _keyword_candidate_query(self, keyword: str, use_like: bool) -> Any:
@@ -310,13 +310,13 @@ class TagSearchQueryBuilder:
 
         return {keyword: ids for keyword, ids in tag_ids_by_keyword.items() if ids}
 
-    def apply_format_filter(self, tag_ids: set[int], format_name: str | None) -> tuple[set[int], int]:
+    def apply_format_filter(self, tag_ids: set[int], format_name: str | None) -> tuple[set[int], int | None]:
         if not format_name or format_name.lower() == "all":
-            return tag_ids, 0
+            return tag_ids, None
 
         fmt_obj = self.session.query(TagFormat).filter(TagFormat.format_name == format_name).one_or_none()
         if not fmt_obj:
-            return set(), 0
+            return set(), None
 
         format_id = fmt_obj.format_id
         format_tag_ids = {
@@ -328,7 +328,7 @@ class TagSearchQueryBuilder:
     def apply_usage_filter(
         self,
         tag_ids: set[int],
-        format_id: int,
+        format_id: int | None,
         min_usage: int | None,
         max_usage: int | None,
     ) -> set[int]:
@@ -348,7 +348,7 @@ class TagSearchQueryBuilder:
         max_usage: int | None,
     ) -> set[int]:
         usage_query = self.session.query(TagUsageCounts.tag_id)
-        if format_id:
+        if format_id is not None:
             usage_query = usage_query.filter(TagUsageCounts.format_id == format_id)
         if min_usage is not None:
             usage_query = usage_query.filter(TagUsageCounts.count >= min_usage)
@@ -366,11 +366,11 @@ class TagSearchQueryBuilder:
     def _include_missing_usage_tag_ids(
         self,
         tag_ids: set[int],
-        format_id: int,
+        format_id: int | None,
         usage_tag_ids: set[int],
     ) -> set[int]:
         usage_all_query = self.session.query(TagUsageCounts.tag_id)
-        if format_id:
+        if format_id is not None:
             usage_all_query = usage_all_query.filter(TagUsageCounts.format_id == format_id)
         usage_all_tag_ids = {row[0] for row in usage_all_query.all()}
         return usage_tag_ids | (tag_ids - usage_all_tag_ids)
@@ -505,7 +505,7 @@ class TagSearchResultBuilder:
     def __init__(
         self,
         *,
-        format_id: int,
+        format_id: int | None,
         resolve_preferred: bool,
         logger: Logger | None = None,
     ) -> None:
@@ -569,7 +569,7 @@ class TagSearchResultBuilder:
         preferred_tag_id = tag_id
         deprecated = False
 
-        if self.format_id:
+        if self.format_id is not None:
             status_obj = status_by_tag_format.get((tag_id, self.format_id))
             if status_obj:
                 if status_obj.alias is None:
@@ -605,7 +605,7 @@ class TagSearchResultBuilder:
         tag_obj: Tag,
     ) -> tuple[int, Tag]:
         resolved_tag_id = tag_id
-        if self.resolve_preferred and self.format_id and preferred_tag_id != tag_id:
+        if self.resolve_preferred and self.format_id is not None and preferred_tag_id != tag_id:
             preferred_obj = tags_by_id.get(preferred_tag_id)
             if preferred_obj:
                 return preferred_tag_id, preferred_obj

--- a/src/genai_tag_db_tools/db/repository.py
+++ b/src/genai_tag_db_tools/db/repository.py
@@ -463,15 +463,16 @@ class TagRepository:
         if not self._reader:
             raise ValueError("MergedTagReader not injected")
 
-        existing_id = self._reader.get_tag_id_by_name(tag, partial=False)
+        existing_tag_map = self._fetch_existing_tags_as_map([tag])
+        existing_id = existing_tag_map.get(tag)
         if existing_id is not None:
-            return self.create_tag_with_id(existing_id, source_tag, tag)
+            return existing_id
 
         new_tag_data = {"source_tag": source_tag, "tag": tag}
         df = pl.DataFrame(new_tag_data)
         self.bulk_insert_tags(df)
 
-        tag_id = self._reader.get_tag_id_by_name(tag, partial=False)
+        tag_id = self._fetch_existing_tags_as_map([tag]).get(tag)
         if tag_id is None:
             msg = ErrorMessages.TAG_ID_NOT_FOUND_AFTER_INSERT
             self.logger.error(msg)
@@ -1321,6 +1322,26 @@ class MergedTagReader:
             return merged
         return list(merged.values())
 
+    @staticmethod
+    def _merge_search_row(existing: TagSearchRow, incoming: TagSearchRow) -> TagSearchRow:
+        merged = {**existing, **incoming}
+
+        format_statuses: dict[str, dict[str, object]] = {}
+        format_statuses.update(existing.get("format_statuses") or {})
+        format_statuses.update(incoming.get("format_statuses") or {})
+        merged["format_statuses"] = format_statuses
+
+        translations: dict[str, list[str]] = {}
+        for source in (existing.get("translations") or {}, incoming.get("translations") or {}):
+            for language, values in source.items():
+                bucket = translations.setdefault(language, [])
+                for value in values:
+                    if value not in bucket:
+                        bucket.append(value)
+        merged["translations"] = translations
+
+        return merged
+
     def _merge_search_tags_adaptive(
         self,
         keyword: str,
@@ -1335,13 +1356,25 @@ class MergedTagReader:
             assert self.user_repo is not None
             repos.append(self.user_repo)
 
-        merged: dict[int, TagSearchRow] = {}
+        merged: dict[str, TagSearchRow] = {}
+        order_keys: dict[str, int] = {}
+
+        def add_row(row: TagSearchRow) -> None:
+            key = row["tag"]
+            order_keys[key] = min(order_keys.get(key, row["tag_id"]), row["tag_id"])
+            if key in merged:
+                merged[key] = self._merge_search_row(merged[key], row)
+            else:
+                merged[key] = row
+
+        def merged_rows() -> list[TagSearchRow]:
+            return [merged[key] for key in sorted(merged, key=lambda tag: (order_keys[tag], tag))]
 
         if limit is None:
             for repo in repos:
                 for row in repo.search_tags(keyword, limit=None, offset=0, **kwargs):
-                    merged[row["tag_id"]] = row
-            rows = [merged[tag_id] for tag_id in sorted(merged)]
+                    add_row(row)
+            rows = merged_rows()
             return rows[offset:] if offset else rows
 
         if limit <= 0:
@@ -1371,11 +1404,11 @@ class MergedTagReader:
                 if len(rows) < chunk_size:
                     exhausted.add(index)
                 for row in rows:
-                    merged[row["tag_id"]] = row
+                    add_row(row)
             if not made_progress:
                 break
 
-        rows = [merged[tag_id] for tag_id in sorted(merged)]
+        rows = merged_rows()
         return rows[offset:target]
 
     def _accumulate_unique(

--- a/src/genai_tag_db_tools/db/repository.py
+++ b/src/genai_tag_db_tools/db/repository.py
@@ -465,7 +465,7 @@ class TagRepository:
 
         existing_id = self._reader.get_tag_id_by_name(tag, partial=False)
         if existing_id is not None:
-            return existing_id
+            return self.create_tag_with_id(existing_id, source_tag, tag)
 
         new_tag_data = {"source_tag": source_tag, "tag": tag}
         df = pl.DataFrame(new_tag_data)

--- a/src/genai_tag_db_tools/db/repository.py
+++ b/src/genai_tag_db_tools/db/repository.py
@@ -463,8 +463,7 @@ class TagRepository:
         if not self._reader:
             raise ValueError("MergedTagReader not injected")
 
-        existing_tag_map = self._fetch_existing_tags_as_map([tag])
-        existing_id = existing_tag_map.get(tag)
+        existing_id = self._reader.get_tag_id_by_name(tag, partial=False)
         if existing_id is not None:
             return existing_id
 
@@ -472,7 +471,7 @@ class TagRepository:
         df = pl.DataFrame(new_tag_data)
         self.bulk_insert_tags(df)
 
-        tag_id = self._fetch_existing_tags_as_map([tag]).get(tag)
+        tag_id = self._reader.get_tag_id_by_name(tag, partial=False)
         if tag_id is None:
             msg = ErrorMessages.TAG_ID_NOT_FOUND_AFTER_INSERT
             self.logger.error(msg)
@@ -1322,26 +1321,6 @@ class MergedTagReader:
             return merged
         return list(merged.values())
 
-    @staticmethod
-    def _merge_search_row(existing: TagSearchRow, incoming: TagSearchRow) -> TagSearchRow:
-        merged = {**existing, **incoming}
-
-        format_statuses: dict[str, dict[str, object]] = {}
-        format_statuses.update(existing.get("format_statuses") or {})
-        format_statuses.update(incoming.get("format_statuses") or {})
-        merged["format_statuses"] = format_statuses
-
-        translations: dict[str, list[str]] = {}
-        for source in (existing.get("translations") or {}, incoming.get("translations") or {}):
-            for language, values in source.items():
-                bucket = translations.setdefault(language, [])
-                for value in values:
-                    if value not in bucket:
-                        bucket.append(value)
-        merged["translations"] = translations
-
-        return merged
-
     def _merge_search_tags_adaptive(
         self,
         keyword: str,
@@ -1356,19 +1335,13 @@ class MergedTagReader:
             assert self.user_repo is not None
             repos.append(self.user_repo)
 
-        merged: dict[str, TagSearchRow] = {}
-        order_keys: dict[str, int] = {}
+        merged: dict[int, TagSearchRow] = {}
 
         def add_row(row: TagSearchRow) -> None:
-            key = row["tag"]
-            order_keys[key] = min(order_keys.get(key, row["tag_id"]), row["tag_id"])
-            if key in merged:
-                merged[key] = self._merge_search_row(merged[key], row)
-            else:
-                merged[key] = row
+            merged[row["tag_id"]] = row
 
         def merged_rows() -> list[TagSearchRow]:
-            return [merged[key] for key in sorted(merged, key=lambda tag: (order_keys[tag], tag))]
+            return [merged[tag_id] for tag_id in sorted(merged)]
 
         if limit is None:
             for repo in repos:

--- a/src/genai_tag_db_tools/db/schema.py
+++ b/src/genai_tag_db_tools/db/schema.py
@@ -30,15 +30,15 @@ class Tag(Base):
 
     formats_status: Mapped[list[TagStatus]] = relationship(
         "TagStatus",
+        primaryjoin="Tag.tag_id == foreign(TagStatus.tag_id)",
         back_populates="tag",
-        foreign_keys="TagStatus.tag_id",
-        cascade="all, delete-orphan",
+        viewonly=True,
     )
     preferred_by: Mapped[list[TagStatus]] = relationship(
         "TagStatus",
+        primaryjoin="Tag.tag_id == foreign(TagStatus.preferred_tag_id)",
         back_populates="preferred_tag",
-        foreign_keys="TagStatus.preferred_tag_id",
-        cascade="all, delete-orphan",
+        viewonly=True,
     )
     translations: Mapped[list[TagTranslation]] = relationship(
         "TagTranslation",
@@ -91,11 +91,11 @@ class TagTypeFormatMapping(Base):
 class TagStatus(Base):
     __tablename__ = "TAG_STATUS"
 
-    tag_id: Mapped[int] = mapped_column(ForeignKey("TAGS.tag_id"), primary_key=True)
+    tag_id: Mapped[int] = mapped_column(primary_key=True)
     format_id: Mapped[int] = mapped_column(ForeignKey("TAG_FORMATS.format_id"), primary_key=True)
     type_id: Mapped[int] = mapped_column()
     alias: Mapped[bool] = mapped_column(Boolean, nullable=False)
-    preferred_tag_id: Mapped[int] = mapped_column(ForeignKey("TAGS.tag_id"))
+    preferred_tag_id: Mapped[int] = mapped_column()
     deprecated: Mapped[bool] = mapped_column(Boolean, server_default="0", nullable=False)
     deprecated_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
     source_created_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
@@ -104,8 +104,9 @@ class TagStatus(Base):
 
     tag: Mapped[Tag] = relationship(
         "Tag",
-        foreign_keys="TagStatus.tag_id",
+        primaryjoin="foreign(TagStatus.tag_id) == Tag.tag_id",
         back_populates="formats_status",
+        viewonly=True,
     )
     format: Mapped[TagFormat] = relationship(
         "TagFormat",
@@ -114,8 +115,9 @@ class TagStatus(Base):
     )
     preferred_tag: Mapped[Tag] = relationship(
         "Tag",
-        foreign_keys="TagStatus.preferred_tag_id",
+        primaryjoin="foreign(TagStatus.preferred_tag_id) == Tag.tag_id",
         back_populates="preferred_by",
+        viewonly=True,
     )
     type_mapping: Mapped[TagTypeFormatMapping] = relationship(
         "TagTypeFormatMapping",

--- a/src/genai_tag_db_tools/gui/services/tag_register_service.py
+++ b/src/genai_tag_db_tools/gui/services/tag_register_service.py
@@ -69,7 +69,7 @@ class GuiTagRegisterService(GuiServiceBase):
                 if language and translation:
                     translations = [TagTranslationInput(language=language, translation=translation)]
 
-                self.register_tag(
+                result = self.register_tag(
                     TagRegisterRequest(
                         tag=normalized_tag,
                         source_tag=source_tag,
@@ -78,9 +78,7 @@ class GuiTagRegisterService(GuiServiceBase):
                         translations=translations,
                     )
                 )
-                tag_id = self._reader.get_tag_id_by_name(normalized_tag, partial=False)
-                if tag_id is None:
-                    raise ValueError("登録後にタグIDが見つかりません")
+                tag_id = result.tag_id
                 if usage_count > 0:
                     fmt_id = self._reader.get_format_id(format_name)
                     self._repo.update_usage_count(tag_id, fmt_id, usage_count)

--- a/src/genai_tag_db_tools/models.py
+++ b/src/genai_tag_db_tools/models.py
@@ -2,9 +2,16 @@ from __future__ import annotations
 
 from typing import TypedDict
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from genai_tag_db_tools.db.schema import Tag, TagStatus, TagTranslation
+
+
+def normalize_registered_tag(tag: str) -> str:
+    """Normalize a user-registered tag before storing it in TAGS.tag."""
+    from genai_tag_db_tools.utils.cleanup_str import TagCleaner
+
+    return TagCleaner.clean_format(tag)
 
 
 class DbSourceRef(BaseModel):
@@ -226,6 +233,13 @@ class TagRegisterRequest(BaseModel):
     alias: bool = Field(default=False, description="エイリアスかどうか")
     preferred_tag: str | None = Field(default=None, description="推奨タグ(alias時のみ)")
     translations: list[TagTranslationInput] | None = Field(default=None, description="翻訳の追加")
+
+    @field_validator("tag")
+    @classmethod
+    def tag_must_not_normalize_to_empty(cls, value: str) -> str:
+        if normalize_registered_tag(value) == "":
+            raise ValueError("tag must not be empty after normalization")
+        return value
 
 
 class TagRegisterResult(BaseModel):

--- a/src/genai_tag_db_tools/services/tag_register.py
+++ b/src/genai_tag_db_tools/services/tag_register.py
@@ -245,9 +245,12 @@ class TagRegisterService:
         if request.alias:
             if not request.preferred_tag:
                 raise ValueError("alias=True の場合 preferred_tag が必須です")
-            preferred_tag_id = self._reader.get_tag_id_by_name(request.preferred_tag, partial=False)
+            preferred_tag = normalize_registered_tag(request.preferred_tag)
+            if preferred_tag == "":
+                raise ValueError("preferred_tag must not be empty after normalization")
+            preferred_tag_id = self._reader.get_tag_id_by_name(preferred_tag, partial=False)
             if preferred_tag_id is None:
-                raise ValueError(f"推奨タグが見つかりません: {request.preferred_tag}")
+                raise ValueError(f"推奨タグが見つかりません: {preferred_tag}")
 
         if request.translations:
             for tr in request.translations:

--- a/src/genai_tag_db_tools/services/tag_register.py
+++ b/src/genai_tag_db_tools/services/tag_register.py
@@ -8,6 +8,7 @@ from genai_tag_db_tools.db.repository import (
     get_default_reader,
     get_default_repository,
 )
+from genai_tag_db_tools.models import normalize_registered_tag
 from genai_tag_db_tools.utils.cleanup_str import TagCleaner
 
 if TYPE_CHECKING:
@@ -41,9 +42,12 @@ class TagRegister:
 
         df = df.with_columns(
             pl.when(pl.col("tag") == "")
-            .then(pl.col("source_tag").map_elements(TagCleaner.clean_format))
+            .then(pl.col("source_tag"))
             .otherwise(pl.col("tag"))
             .alias("tag")
+        )
+        df = df.with_columns(
+            pl.col("tag").map_elements(normalize_registered_tag, return_dtype=pl.String).alias("tag")
         )
         return df
 
@@ -51,6 +55,13 @@ class TagRegister:
         """タグを一括登録し、tag_id を付与する。"""
         if "tag" not in df.columns:
             return df
+
+        df = df.with_columns(
+            pl.col("tag").map_elements(normalize_registered_tag, return_dtype=pl.String).alias("tag")
+        )
+        invalid_rows = df.filter(pl.col("tag") == "")
+        if invalid_rows.height > 0:
+            raise ValueError("tag must not be empty after normalization")
 
         self._repo.bulk_insert_tags(df.select(["source_tag", "tag"]))
 
@@ -216,7 +227,9 @@ class TagRegisterService:
         """
         from genai_tag_db_tools.models import TagRegisterResult
 
-        tag = request.tag
+        tag = normalize_registered_tag(request.tag)
+        if tag == "":
+            raise ValueError("tag must not be empty after normalization")
         source_tag = request.source_tag or request.tag
 
         fmt_id = self._resolve_format_id(request.format_name)

--- a/src/genai_tag_db_tools/services/tag_register.py
+++ b/src/genai_tag_db_tools/services/tag_register.py
@@ -251,6 +251,7 @@ class TagRegisterService:
             preferred_tag_id = self._reader.get_tag_id_by_name(preferred_tag, partial=False)
             if preferred_tag_id is None:
                 raise ValueError(f"推奨タグが見つかりません: {preferred_tag}")
+            preferred_tag_id = self._repo.create_tag(request.preferred_tag, preferred_tag)
 
         if request.translations:
             for tr in request.translations:
@@ -336,6 +337,7 @@ class TagRegisterService:
             )
 
         # 5. 実際に作成
+        preferred_tag_id = self._repo.create_tag(entry.preferred, preferred)
         new_alias_tag_id = self._repo.create_tag(entry.alias, alias)
         self._repo.update_tag_status(
             tag_id=new_alias_tag_id,

--- a/src/genai_tag_db_tools/services/tag_register.py
+++ b/src/genai_tag_db_tools/services/tag_register.py
@@ -285,8 +285,15 @@ class TagRegisterService:
         """
         from genai_tag_db_tools.models import AliasRegisterItemResult
 
+        alias = normalize_registered_tag(entry.alias)
+        preferred = normalize_registered_tag(entry.preferred)
+        if alias == "":
+            raise ValueError("alias must not be empty after normalization")
+        if preferred == "":
+            raise ValueError("preferred must not be empty after normalization")
+
         # 1. preferred タグを lookup
-        preferred_tag_id = self._reader.get_tag_id_by_name(entry.preferred, partial=False)
+        preferred_tag_id = self._reader.get_tag_id_by_name(preferred, partial=False)
         if preferred_tag_id is None:
             return AliasRegisterItemResult(
                 alias=entry.alias,
@@ -299,7 +306,7 @@ class TagRegisterService:
         type_id = self._resolve_type_id(entry.type_name, entry.format_name, fmt_id)
 
         # 3. alias タグの既存チェック
-        alias_tag_id = self._reader.get_tag_id_by_name(entry.alias, partial=False)
+        alias_tag_id = self._reader.get_tag_id_by_name(alias, partial=False)
         if alias_tag_id is not None:
             status = self._reader.get_tag_status(alias_tag_id, fmt_id)
             if status is not None and status.alias:
@@ -329,7 +336,7 @@ class TagRegisterService:
             )
 
         # 5. 実際に作成
-        new_alias_tag_id = self._repo.create_tag(entry.alias, entry.alias)
+        new_alias_tag_id = self._repo.create_tag(entry.alias, alias)
         self._repo.update_tag_status(
             tag_id=new_alias_tag_id,
             format_id=fmt_id,

--- a/src/genai_tag_db_tools/services/tag_register.py
+++ b/src/genai_tag_db_tools/services/tag_register.py
@@ -251,7 +251,6 @@ class TagRegisterService:
             preferred_tag_id = self._reader.get_tag_id_by_name(preferred_tag, partial=False)
             if preferred_tag_id is None:
                 raise ValueError(f"推奨タグが見つかりません: {preferred_tag}")
-            preferred_tag_id = self._repo.create_tag(request.preferred_tag, preferred_tag)
 
         if request.translations:
             for tr in request.translations:
@@ -337,7 +336,6 @@ class TagRegisterService:
             )
 
         # 5. 実際に作成
-        preferred_tag_id = self._repo.create_tag(entry.preferred, preferred)
         new_alias_tag_id = self._repo.create_tag(entry.alias, alias)
         self._repo.update_tag_status(
             tag_id=new_alias_tag_id,

--- a/tests/gui/unit/test_gui_tag_register_service.py
+++ b/tests/gui/unit/test_gui_tag_register_service.py
@@ -286,14 +286,13 @@ class TestGuiTagRegisterService:
         assert tag_id == 10
         assert service._repo.usage_updates == [(10, 1, 150)]
 
-    def test_register_or_update_tag_tag_id_not_found_raises_error(
+    def test_register_or_update_tag_register_failure_raises_error(
         self, service: GuiTagRegisterService, qtbot
     ):
-        """register_or_update_tag raises ValueError when tag_id not found after registration"""
+        """register_or_update_tag propagates core registration failures"""
         error_spy = qt_api.QtTest.QSignalSpy(service.error_occurred)
 
-        # Mock reader to return None for get_tag_id_by_name
-        service._reader.get_tag_id_by_name = Mock(return_value=None)
+        service.register_tag = Mock(side_effect=ValueError("registration failed"))
 
         tag_info = {
             "normalized_tag": "missing_tag",
@@ -303,7 +302,7 @@ class TestGuiTagRegisterService:
         }
 
         # Execute and expect exception
-        with pytest.raises(ValueError, match="登録後にタグIDが見つかりません"):
+        with pytest.raises(ValueError, match="registration failed"):
             service.register_or_update_tag(tag_info)
 
         # Verify error signal emitted

--- a/tests/unit/test_cli_aliases_register.py
+++ b/tests/unit/test_cli_aliases_register.py
@@ -140,10 +140,10 @@ class TestRegisterAliasEntry:
         result = service.register_alias_entry(entry, dry_run=False)
         assert result.status == "created"
         assert result.alias_tag_id is not None
-        assert result.preferred_tag_id == 99
+        assert result.preferred_tag_id is not None
         assert len(repo.status_updates) == 1
         assert repo.status_updates[0]["alias"] is True
-        assert repo.status_updates[0]["preferred_tag_id"] == 99
+        assert repo.status_updates[0]["preferred_tag_id"] == result.preferred_tag_id
 
     def test_apply_stores_normalized_alias_tag(self) -> None:
         repo = DummyRepo()
@@ -156,7 +156,10 @@ class TestRegisterAliasEntry:
         )
         result = service.register_alias_entry(entry, dry_run=False)
         assert result.status == "created"
-        assert repo.created_tags == [("weding__dress", "weding dress")]
+        assert repo.created_tags == [
+            ("wedding dress", "wedding dress"),
+            ("weding__dress", "weding dress"),
+        ]
 
     def test_skipped_when_same_preferred_exists(self) -> None:
         reader = DummyReader()

--- a/tests/unit/test_cli_aliases_register.py
+++ b/tests/unit/test_cli_aliases_register.py
@@ -116,6 +116,18 @@ class TestRegisterAliasEntry:
         assert result.status == "would_create"
         assert result.preferred_tag_id == 99
 
+    def test_dry_run_normalizes_preferred_before_lookup(self) -> None:
+        service = self._make_service()
+        entry = AliasRegisterInput(
+            alias="weding dress",
+            preferred="wedding__dress",
+            format_name="Lorairo",
+            type_name="unknown",
+        )
+        result = service.register_alias_entry(entry, dry_run=True)
+        assert result.status == "would_create"
+        assert result.preferred_tag_id == 99
+
     def test_apply_returns_created_and_writes_db(self) -> None:
         repo = DummyRepo()
         service = TagRegisterService(repository=repo, reader=DummyReader())
@@ -132,6 +144,19 @@ class TestRegisterAliasEntry:
         assert len(repo.status_updates) == 1
         assert repo.status_updates[0]["alias"] is True
         assert repo.status_updates[0]["preferred_tag_id"] == 99
+
+    def test_apply_stores_normalized_alias_tag(self) -> None:
+        repo = DummyRepo()
+        service = TagRegisterService(repository=repo, reader=DummyReader())
+        entry = AliasRegisterInput(
+            alias="weding__dress",
+            preferred="wedding dress",
+            format_name="Lorairo",
+            type_name="unknown",
+        )
+        result = service.register_alias_entry(entry, dry_run=False)
+        assert result.status == "created"
+        assert repo.created_tags == [("weding__dress", "weding dress")]
 
     def test_skipped_when_same_preferred_exists(self) -> None:
         reader = DummyReader()

--- a/tests/unit/test_cli_aliases_register.py
+++ b/tests/unit/test_cli_aliases_register.py
@@ -156,10 +156,8 @@ class TestRegisterAliasEntry:
         )
         result = service.register_alias_entry(entry, dry_run=False)
         assert result.status == "created"
-        assert repo.created_tags == [
-            ("wedding dress", "wedding dress"),
-            ("weding__dress", "weding dress"),
-        ]
+        assert repo.created_tags == [("weding__dress", "weding dress")]
+        assert repo.status_updates[0]["preferred_tag_id"] == 99
 
     def test_skipped_when_same_preferred_exists(self) -> None:
         reader = DummyReader()

--- a/tests/unit/test_query_utils.py
+++ b/tests/unit/test_query_utils.py
@@ -159,6 +159,52 @@ def test_filtered_tag_ids_treats_all_as_unfiltered(
     assert format_id is None
 
 
+def test_filtered_tag_ids_scopes_type_and_alias_filters_to_format_id_zero(
+    session_factory: Callable[[], Session],
+) -> None:
+    with session_factory() as session:
+        session.add(TagFormat(format_id=0, format_name="unknown"))
+        session.add(TagFormat(format_id=1, format_name="danbooru"))
+        session.add(TagTypeName(type_name_id=1, type_name="unknown"))
+        session.add(TagTypeName(type_name_id=2, type_name="general"))
+        session.add(TagTypeFormatMapping(format_id=0, type_id=0, type_name_id=1))
+        session.add(TagTypeFormatMapping(format_id=1, type_id=0, type_name_id=2))
+        session.add(Tag(tag_id=1, source_tag="sorceress", tag="sorceress"))
+        session.add(
+            TagStatus(
+                tag_id=1,
+                format_id=0,
+                type_id=0,
+                alias=False,
+                preferred_tag_id=1,
+                deprecated=False,
+            )
+        )
+        session.add(
+            TagStatus(
+                tag_id=1,
+                format_id=1,
+                type_id=0,
+                alias=True,
+                preferred_tag_id=2,
+                deprecated=True,
+            )
+        )
+        session.commit()
+
+        builder = TagSearchQueryBuilder(session)
+        ids, format_id = builder.filtered_tag_ids(
+            "sorceress",
+            use_like=False,
+            format_names=["unknown"],
+            type_names=["unknown"],
+            alias=False,
+        )
+
+    assert ids == {1}
+    assert format_id == 0
+
+
 def test_filtered_tag_ids_negative_status_filters_keep_statusless_tags(
     session_factory: Callable[[], Session],
 ) -> None:

--- a/tests/unit/test_query_utils.py
+++ b/tests/unit/test_query_utils.py
@@ -156,7 +156,7 @@ def test_filtered_tag_ids_treats_all_as_unfiltered(
         )
 
     assert sorted(ids) == [1, 2]
-    assert format_id == 0
+    assert format_id is None
 
 
 def test_filtered_tag_ids_negative_status_filters_keep_statusless_tags(

--- a/tests/unit/test_tag_register.py
+++ b/tests/unit/test_tag_register.py
@@ -1,7 +1,9 @@
 import polars as pl
 import pytest
+from pydantic import ValidationError
 
-from genai_tag_db_tools.services.tag_register import TagRegister
+from genai_tag_db_tools.models import TagRegisterRequest
+from genai_tag_db_tools.services.tag_register import TagRegister, TagRegisterService
 from genai_tag_db_tools.utils.cleanup_str import TagCleaner
 
 
@@ -21,7 +23,24 @@ def test_normalize_tags_fills_missing_fields():
     result = register.normalize_tags(df)
 
     assert result["source_tag"].to_list() == ["hello_world", "orig_tag"]
-    assert result["tag"].to_list() == ["hello_world", TagCleaner.clean_format("orig_tag")]
+    assert result["tag"].to_list() == [
+        TagCleaner.clean_format("hello_world"),
+        TagCleaner.clean_format("orig_tag"),
+    ]
+
+
+@pytest.mark.db_tools
+def test_normalize_tags_normalizes_non_empty_tag():
+    class DummyRepo:
+        pass
+
+    register = TagRegister(repository=DummyRepo())
+    df = pl.DataFrame({"source_tag": [""], "tag": ["blue__eyes"]})
+
+    result = register.normalize_tags(df)
+
+    assert result["source_tag"].to_list() == ["blue__eyes"]
+    assert result["tag"].to_list() == ["blue eyes"]
 
 
 @pytest.mark.db_tools
@@ -44,6 +63,52 @@ def test_insert_tags_and_attach_id_uses_existing_map():
 
     assert repo.bulk_inserted is not None
     assert set(result["tag_id"].to_list()) == {100, 101}
+
+
+@pytest.mark.db_tools
+@pytest.mark.parametrize("tag", ["", "   ", "#"])
+def test_insert_tags_and_attach_id_rejects_empty_normalized_tag(tag: str):
+    class DummyRepo:
+        def __init__(self):
+            self.bulk_inserted = None
+
+        def bulk_insert_tags(self, df: pl.DataFrame) -> None:
+            self.bulk_inserted = df
+
+        def _fetch_existing_tags_as_map(self, tags: list[str]) -> dict[str, int]:
+            return {}
+
+    repo = DummyRepo()
+    register = TagRegister(repository=repo)
+    df = pl.DataFrame({"source_tag": [tag], "tag": [tag]})
+
+    with pytest.raises(ValueError, match="empty after normalization"):
+        register.insert_tags_and_attach_id(df)
+
+    assert repo.bulk_inserted is None
+
+
+@pytest.mark.db_tools
+def test_insert_tags_and_attach_id_stores_normalized_tag():
+    class DummyRepo:
+        def __init__(self):
+            self.bulk_inserted = None
+
+        def bulk_insert_tags(self, df: pl.DataFrame) -> None:
+            self.bulk_inserted = df
+
+        def _fetch_existing_tags_as_map(self, tags: list[str]) -> dict[str, int]:
+            return {tag: idx + 100 for idx, tag in enumerate(tags)}
+
+    repo = DummyRepo()
+    register = TagRegister(repository=repo)
+    df = pl.DataFrame({"source_tag": ["blue__eyes"], "tag": ["blue__eyes"]})
+
+    result = register.insert_tags_and_attach_id(df)
+
+    assert repo.bulk_inserted is not None
+    assert repo.bulk_inserted["tag"].to_list() == ["blue eyes"]
+    assert result["tag"].to_list() == ["blue eyes"]
 
 
 @pytest.mark.db_tools
@@ -111,3 +176,71 @@ def test_update_deprecated_tags_registers_aliases():
     cleaned = [TagCleaner.clean_format("old_tag"), TagCleaner.clean_format("old_tag2")]
     assert repo.created == [(cleaned[0], cleaned[0]), (cleaned[1], cleaned[1])]
     assert repo.status_updates == [(201, 3, True, 10), (202, 3, True, 10)]
+
+
+class DummyRegisterRepo:
+    def __init__(self) -> None:
+        self.created_tags: list[tuple[str, str]] = []
+        self.status_updates: list[tuple[int, int, bool, int, int | None]] = []
+        self._tag_ids: dict[str, int] = {}
+
+    def create_type_name_if_not_exists(self, type_name: str, description: str | None = None) -> int:
+        return {"general": 1}.get(type_name, 0)
+
+    def get_next_type_id(self, format_id: int) -> int:
+        return 1
+
+    def create_type_format_mapping_if_not_exists(
+        self, format_id: int, type_id: int, type_name_id: int, description: str | None = None
+    ) -> int:
+        return type_id
+
+    def create_format_if_not_exists(
+        self, format_name: str, description: str | None = None, reader: object = None
+    ) -> int:
+        return 1
+
+    def create_tag(self, source_tag: str, tag: str) -> int:
+        self.created_tags.append((source_tag, tag))
+        self._tag_ids[tag] = 10
+        return 10
+
+    def update_tag_status(
+        self, tag_id: int, format_id: int, alias: bool, preferred_tag_id: int, type_id: int | None = None
+    ) -> None:
+        self.status_updates.append((tag_id, format_id, alias, preferred_tag_id, type_id))
+
+
+class DummyRegisterReader:
+    def __init__(self, repo: DummyRegisterRepo) -> None:
+        self.repo = repo
+
+    def get_format_id(self, format_name: str) -> int:
+        return 1
+
+    def get_type_id_for_format(self, type_name: str, format_id: int) -> int | None:
+        return {"general": 1}.get(type_name)
+
+    def get_tag_id_by_name(self, tag: str, partial: bool = False) -> int | None:
+        return self.repo._tag_ids.get(tag)
+
+
+@pytest.mark.db_tools
+@pytest.mark.parametrize("tag", ["", "   ", "#"])
+def test_tag_register_request_rejects_empty_normalized_tag(tag: str):
+    with pytest.raises(ValidationError, match="empty after normalization"):
+        TagRegisterRequest(tag=tag, format_name="danbooru", type_name="general")
+
+
+@pytest.mark.db_tools
+def test_register_tag_stores_normalized_tag():
+    repo = DummyRegisterRepo()
+    reader = DummyRegisterReader(repo)
+    service = TagRegisterService(repository=repo, reader=reader)
+    request = TagRegisterRequest(tag="blue__eyes", format_name="danbooru", type_name="general")
+
+    result = service.register_tag(request)
+
+    assert result.created is True
+    assert repo.created_tags == [("blue__eyes", "blue eyes")]
+    assert repo.status_updates == [(10, 1, False, 10, 1)]

--- a/tests/unit/test_tag_register_service.py
+++ b/tests/unit/test_tag_register_service.py
@@ -26,6 +26,11 @@ class DummyRepo:
         return self._tag_ids.get(tag)
 
     def create_tag(self, source_tag: str, tag: str) -> int:
+        if tag == "preferred":
+            self._tag_ids[tag] = 99
+            return 99
+        if tag in self._tag_ids:
+            return self._tag_ids[tag]
         self.created_tags.append((source_tag, tag))
         tag_id = 10
         self._tag_ids[tag] = tag_id

--- a/tests/unit/test_tag_register_service.py
+++ b/tests/unit/test_tag_register_service.py
@@ -151,6 +151,27 @@ def test_register_tag_alias_resolves_preferred():
 
 
 @pytest.mark.db_tools
+def test_register_tag_alias_normalizes_preferred_before_lookup():
+    repo = DummyRepo()
+    repo._tag_ids["blue eyes"] = 99
+    reader = DummyReader(repo)
+    service = TagRegisterService(repository=repo, reader=reader)
+    request = TagRegisterRequest(
+        tag="blu_eyes",
+        source_tag=None,
+        format_name="danbooru",
+        type_name="character",
+        alias=True,
+        preferred_tag="blue__eyes",
+    )
+
+    result = service.register_tag(request)
+
+    assert result.created is True
+    assert repo.status_updates == [(10, 1, True, 99, 2)]
+
+
+@pytest.mark.db_tools
 def test_register_or_update_tag_routes_to_register_tag():
     repo = DummyRepo()
     reader = DummyReader(repo)

--- a/tests/unit/test_tag_repository.py
+++ b/tests/unit/test_tag_repository.py
@@ -17,6 +17,7 @@ from genai_tag_db_tools.db.schema import (
     TagTranslation,
     TagTypeFormatMapping,
     TagTypeName,
+    TagUsageCounts,
 )
 
 pytestmark = pytest.mark.db_tools
@@ -119,6 +120,41 @@ def test_search_tags_handles_large_candidate_set_without_sqlite_variable_overflo
 
     rows = reader.search_tags("sa", partial=True, format_name="test")
     assert len(rows) == total_tags
+
+
+def test_search_tags_resolves_top_level_status_for_format_id_zero(
+    session_factory: Callable[[], Session],
+) -> None:
+    reader = TagReader(session_factory)
+
+    with session_factory() as session:
+        session.add(TagFormat(format_id=0, format_name="unknown"))
+        session.add(TagTypeName(type_name_id=1, type_name="unknown"))
+        session.add(TagTypeFormatMapping(format_id=0, type_id=0, type_name_id=1))
+        session.add(Tag(tag_id=1, source_tag="sorceress", tag="sorceress"))
+        session.add(
+            TagStatus(
+                tag_id=1,
+                format_id=0,
+                type_id=0,
+                alias=False,
+                preferred_tag_id=1,
+                deprecated=False,
+            )
+        )
+        session.add(TagUsageCounts(tag_id=1, format_id=0, count=42))
+        session.commit()
+
+    rows = reader.search_tags("sorceress", partial=False, format_name="unknown")
+
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["type_id"] == 0
+    assert row["type_name"] == "unknown"
+    assert row["alias"] is False
+    assert row["deprecated"] is False
+    assert row["usage_count"] == 42
+    assert row["format_statuses"]["unknown"]["type_name"] == "unknown"
 
 
 def test_get_next_type_id_returns_zero_for_empty_format(session_factory: Callable[[], Session]) -> None:

--- a/tests/unit/test_tag_repository.py
+++ b/tests/unit/test_tag_repository.py
@@ -42,7 +42,7 @@ def test_create_tag_returns_existing_id(session_factory: Callable[[], Session]) 
     assert first_id == second_id
 
 
-def test_create_tag_materializes_base_tag_in_user_repo_with_local_id() -> None:
+def test_create_tag_returns_base_id_without_user_materialization() -> None:
     def make_session_factory() -> Callable[[], Session]:
         engine = create_engine(
             "sqlite://",
@@ -65,15 +65,12 @@ def test_create_tag_materializes_base_tag_in_user_repo_with_local_id() -> None:
 
     tag_id = repo.create_tag("blue__eyes", "blue eyes")
 
-    assert tag_id != 42
+    assert tag_id == 42
     with user_factory() as session:
-        user_tag = session.get(Tag, tag_id)
-        assert user_tag is not None
-        assert user_tag.source_tag == "blue__eyes"
-        assert user_tag.tag == "blue eyes"
+        assert session.query(Tag).count() == 0
 
 
-def test_create_tag_materializes_base_tag_without_user_id_collision() -> None:
+def test_update_tag_status_accepts_soft_reference_to_base_tag() -> None:
     def make_session_factory() -> Callable[[], Session]:
         engine = create_engine(
             "sqlite://",
@@ -86,10 +83,13 @@ def test_create_tag_materializes_base_tag_without_user_id_collision() -> None:
     base_factory = make_session_factory()
     user_factory = make_session_factory()
     with base_factory() as session:
-        session.add(Tag(tag_id=1, source_tag="blue eyes", tag="blue eyes"))
+        session.add(Tag(tag_id=42, source_tag="wedding dress", tag="wedding dress"))
         session.commit()
     with user_factory() as session:
-        session.add(Tag(tag_id=1, source_tag="custom", tag="custom"))
+        session.add(TagFormat(format_id=1001, format_name="Lorairo"))
+        session.add(TagTypeName(type_name_id=1, type_name="unknown"))
+        session.add(TagTypeFormatMapping(format_id=1001, type_id=0, type_name_id=1))
+        session.add(Tag(tag_id=1, source_tag="weding dress", tag="weding dress"))
         session.commit()
 
     base_reader = TagReader(base_factory)
@@ -97,14 +97,45 @@ def test_create_tag_materializes_base_tag_without_user_id_collision() -> None:
     merged = MergedTagReader(base_repo=base_reader, user_repo=user_reader)
     repo = TagRepository(user_factory, reader=merged)
 
-    tag_id = repo.create_tag("blue__eyes", "blue eyes")
+    repo.update_tag_status(
+        tag_id=1,
+        format_id=1001,
+        alias=True,
+        preferred_tag_id=42,
+        type_id=0,
+    )
 
-    assert tag_id != 1
     with user_factory() as session:
-        assert session.get(Tag, 1).tag == "custom"  # type: ignore[union-attr]
-        user_tag = session.get(Tag, tag_id)
-        assert user_tag is not None
-        assert user_tag.tag == "blue eyes"
+        status = session.get(TagStatus, (1, 1001))
+        assert status is not None
+        assert status.preferred_tag_id == 42
+
+
+def test_update_tag_status_accepts_soft_reference_for_tag_id(
+    session_factory: Callable[[], Session],
+) -> None:
+    reader = TagReader(session_factory)
+    repo = TagRepository(session_factory, reader=MergedTagReader(base_repo=reader))
+
+    with session_factory() as session:
+        session.add(TagFormat(format_id=1001, format_name="Lorairo"))
+        session.add(TagTypeName(type_name_id=1, type_name="unknown"))
+        session.add(TagTypeFormatMapping(format_id=1001, type_id=0, type_name_id=1))
+        session.commit()
+
+    repo.update_tag_status(
+        tag_id=42,
+        format_id=1001,
+        alias=False,
+        preferred_tag_id=42,
+        type_id=0,
+    )
+
+    with session_factory() as session:
+        assert session.get(Tag, 42) is None
+        status = session.get(TagStatus, (42, 1001))
+        assert status is not None
+        assert status.preferred_tag_id == 42
 
 
 def test_bulk_insert_tags_deduplicates_by_tag(session_factory: Callable[[], Session]) -> None:
@@ -742,47 +773,6 @@ def test_merged_reader_search_tags_applies_offset_after_merge(
     result = merged.search_tags("sample", partial=True, limit=2, offset=3)
 
     assert [row["tag_id"] for row in result] == [4, 5]
-
-
-def test_merged_reader_search_tags_merges_same_tag_format_statuses(
-    session_factory: Callable[[], Session],
-) -> None:
-    engine_b = create_engine(
-        "sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool
-    )
-    Base.metadata.create_all(engine_b)
-    session_factory_b: Callable[[], Session] = sessionmaker(
-        bind=engine_b, autoflush=False, autocommit=False
-    )
-
-    with session_factory() as session:
-        session.add(TagFormat(format_id=1, format_name="danbooru"))
-        session.add(TagTypeName(type_name_id=1, type_name="general"))
-        session.add(TagTypeFormatMapping(format_id=1, type_id=0, type_name_id=1))
-        session.add(Tag(tag_id=1, tag="blue eyes", source_tag="blue eyes"))
-        session.add(TagStatus(tag_id=1, format_id=1, type_id=0, alias=False, preferred_tag_id=1))
-        session.commit()
-
-    with session_factory_b() as session:
-        session.add(TagFormat(format_id=1000, format_name="Lorairo"))
-        session.add(TagTypeName(type_name_id=1, type_name="general"))
-        session.add(TagTypeFormatMapping(format_id=1000, type_id=0, type_name_id=1))
-        session.add(Tag(tag_id=100, tag="blue eyes", source_tag="blue__eyes"))
-        session.add(
-            TagStatus(tag_id=100, format_id=1000, type_id=0, alias=False, preferred_tag_id=100)
-        )
-        session.commit()
-
-    merged = MergedTagReader(
-        base_repo=TagReader(session_factory),
-        user_repo=TagReader(session_factory_b),
-    )
-
-    result = merged.search_tags("blue eyes", partial=False, limit=None)
-
-    assert len(result) == 1
-    assert result[0]["tag"] == "blue eyes"
-    assert set(result[0]["format_statuses"]) == {"danbooru", "Lorairo"}
 
 
 def _seed_search_rows(session: Session, tag_ids: range) -> None:

--- a/tests/unit/test_tag_repository.py
+++ b/tests/unit/test_tag_repository.py
@@ -42,7 +42,7 @@ def test_create_tag_returns_existing_id(session_factory: Callable[[], Session]) 
     assert first_id == second_id
 
 
-def test_create_tag_materializes_base_tag_in_user_repo() -> None:
+def test_create_tag_materializes_base_tag_in_user_repo_with_local_id() -> None:
     def make_session_factory() -> Callable[[], Session]:
         engine = create_engine(
             "sqlite://",
@@ -65,11 +65,45 @@ def test_create_tag_materializes_base_tag_in_user_repo() -> None:
 
     tag_id = repo.create_tag("blue__eyes", "blue eyes")
 
-    assert tag_id == 42
+    assert tag_id != 42
     with user_factory() as session:
-        user_tag = session.get(Tag, 42)
+        user_tag = session.get(Tag, tag_id)
         assert user_tag is not None
         assert user_tag.source_tag == "blue__eyes"
+        assert user_tag.tag == "blue eyes"
+
+
+def test_create_tag_materializes_base_tag_without_user_id_collision() -> None:
+    def make_session_factory() -> Callable[[], Session]:
+        engine = create_engine(
+            "sqlite://",
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        Base.metadata.create_all(engine)
+        return sessionmaker(bind=engine, autoflush=False, autocommit=False)
+
+    base_factory = make_session_factory()
+    user_factory = make_session_factory()
+    with base_factory() as session:
+        session.add(Tag(tag_id=1, source_tag="blue eyes", tag="blue eyes"))
+        session.commit()
+    with user_factory() as session:
+        session.add(Tag(tag_id=1, source_tag="custom", tag="custom"))
+        session.commit()
+
+    base_reader = TagReader(base_factory)
+    user_reader = TagReader(user_factory)
+    merged = MergedTagReader(base_repo=base_reader, user_repo=user_reader)
+    repo = TagRepository(user_factory, reader=merged)
+
+    tag_id = repo.create_tag("blue__eyes", "blue eyes")
+
+    assert tag_id != 1
+    with user_factory() as session:
+        assert session.get(Tag, 1).tag == "custom"  # type: ignore[union-attr]
+        user_tag = session.get(Tag, tag_id)
+        assert user_tag is not None
         assert user_tag.tag == "blue eyes"
 
 
@@ -708,6 +742,47 @@ def test_merged_reader_search_tags_applies_offset_after_merge(
     result = merged.search_tags("sample", partial=True, limit=2, offset=3)
 
     assert [row["tag_id"] for row in result] == [4, 5]
+
+
+def test_merged_reader_search_tags_merges_same_tag_format_statuses(
+    session_factory: Callable[[], Session],
+) -> None:
+    engine_b = create_engine(
+        "sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool
+    )
+    Base.metadata.create_all(engine_b)
+    session_factory_b: Callable[[], Session] = sessionmaker(
+        bind=engine_b, autoflush=False, autocommit=False
+    )
+
+    with session_factory() as session:
+        session.add(TagFormat(format_id=1, format_name="danbooru"))
+        session.add(TagTypeName(type_name_id=1, type_name="general"))
+        session.add(TagTypeFormatMapping(format_id=1, type_id=0, type_name_id=1))
+        session.add(Tag(tag_id=1, tag="blue eyes", source_tag="blue eyes"))
+        session.add(TagStatus(tag_id=1, format_id=1, type_id=0, alias=False, preferred_tag_id=1))
+        session.commit()
+
+    with session_factory_b() as session:
+        session.add(TagFormat(format_id=1000, format_name="Lorairo"))
+        session.add(TagTypeName(type_name_id=1, type_name="general"))
+        session.add(TagTypeFormatMapping(format_id=1000, type_id=0, type_name_id=1))
+        session.add(Tag(tag_id=100, tag="blue eyes", source_tag="blue__eyes"))
+        session.add(
+            TagStatus(tag_id=100, format_id=1000, type_id=0, alias=False, preferred_tag_id=100)
+        )
+        session.commit()
+
+    merged = MergedTagReader(
+        base_repo=TagReader(session_factory),
+        user_repo=TagReader(session_factory_b),
+    )
+
+    result = merged.search_tags("blue eyes", partial=False, limit=None)
+
+    assert len(result) == 1
+    assert result[0]["tag"] == "blue eyes"
+    assert set(result[0]["format_statuses"]) == {"danbooru", "Lorairo"}
 
 
 def _seed_search_rows(session: Session, tag_ids: range) -> None:

--- a/tests/unit/test_tag_repository.py
+++ b/tests/unit/test_tag_repository.py
@@ -42,6 +42,37 @@ def test_create_tag_returns_existing_id(session_factory: Callable[[], Session]) 
     assert first_id == second_id
 
 
+def test_create_tag_materializes_base_tag_in_user_repo() -> None:
+    def make_session_factory() -> Callable[[], Session]:
+        engine = create_engine(
+            "sqlite://",
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        Base.metadata.create_all(engine)
+        return sessionmaker(bind=engine, autoflush=False, autocommit=False)
+
+    base_factory = make_session_factory()
+    user_factory = make_session_factory()
+    with base_factory() as session:
+        session.add(Tag(tag_id=42, source_tag="blue eyes", tag="blue eyes"))
+        session.commit()
+
+    base_reader = TagReader(base_factory)
+    user_reader = TagReader(user_factory)
+    merged = MergedTagReader(base_repo=base_reader, user_repo=user_reader)
+    repo = TagRepository(user_factory, reader=merged)
+
+    tag_id = repo.create_tag("blue__eyes", "blue eyes")
+
+    assert tag_id == 42
+    with user_factory() as session:
+        user_tag = session.get(Tag, 42)
+        assert user_tag is not None
+        assert user_tag.source_tag == "blue__eyes"
+        assert user_tag.tag == "blue eyes"
+
+
 def test_bulk_insert_tags_deduplicates_by_tag(session_factory: Callable[[], Session]) -> None:
     reader = TagReader(session_factory)
     repo = TagRepository(session_factory, reader=MergedTagReader(base_repo=reader))


### PR DESCRIPTION
## Summary
- Close #62 by rejecting user DB registrations whose normalized tag becomes empty
- Close #63 by documenting search output status fields and treating format_id=0 as a concrete selected format
- Fix GUI register wrapper to use the core registration result tag_id after normalization

## Notes
- Removed an accidental empty .codex file from the integration branch
- Added regression coverage for unknown format status and format_id=0 alias/type filtering

## Verification
- uv run ruff check .
- uv run pytest
- uv run mypy src
