### PR TITLE
feat(schema): overlay DB schema と TagRef を定義する (Issue #70)

### DIFF
--- a/src/genai_tag_db_tools/db/runtime.py
+++ b/src/genai_tag_db_tools/db/runtime.py
@@ -5,7 +5,7 @@ from typing import Any
 from sqlalchemy import Engine, StaticPool, create_engine, event
 from sqlalchemy.orm import Session, sessionmaker
 
-from genai_tag_db_tools.db.schema import Base
+from genai_tag_db_tools.db.schema import Base, UserOverlayBase
 
 logger = logging.getLogger(__name__)
 
@@ -114,7 +114,8 @@ def init_user_db(user_db_dir: Path | None = None, *, format_name: str | None = N
 
     _user_db_path = user_db_path
     _user_engine = _create_engine(user_db_path)
-    Base.metadata.create_all(_user_engine)
+    Base.metadata.create_all(_user_engine)             # 旧テーブル（後方互換、#72 migration まで共存）
+    UserOverlayBase.metadata.create_all(_user_engine)  # overlay テーブル追加
     _UserSessionLocal = sessionmaker(bind=_user_engine, autoflush=False, autocommit=False)
 
     _initialize_default_user_mappings(_UserSessionLocal, format_name=format_name)

--- a/src/genai_tag_db_tools/db/schema.py
+++ b/src/genai_tag_db_tools/db/schema.py
@@ -9,6 +9,7 @@ from sqlalchemy import (
     DateTime,
     ForeignKey,
     ForeignKeyConstraint,
+    Index,
     UniqueConstraint,
     func,
 )
@@ -173,3 +174,80 @@ class DatabaseMetadata(Base):
 
     key: Mapped[str] = mapped_column(primary_key=True)
     value: Mapped[str] = mapped_column()
+
+
+# --- Overlay schema (user DB 専用) ---
+# Base とは別の DeclarativeBase を使い、user DB にのみ作成する。
+
+
+class UserOverlayBase(DeclarativeBase):
+    pass
+
+
+# user 独自タグの tag_id オフセット。base DB との ID 空間衝突を防ぐ。
+USER_TAG_ID_OFFSET = 1_000_000_000
+
+
+class UserTag(UserOverlayBase):
+    """user DB 独自タグ。base DB に存在しないユーザー定義タグを格納する。
+
+    tag_id は USER_TAG_ID_OFFSET (1_000_000_000) 以上で採番し、
+    base DB の tag_id との衝突を防ぐ。
+    """
+
+    __tablename__ = "USER_TAGS"
+
+    tag_id: Mapped[int] = mapped_column(primary_key=True)
+    source_tag: Mapped[str] = mapped_column()
+    tag: Mapped[str] = mapped_column()
+    created_at: Mapped[datetime | None] = mapped_column(DateTime, server_default=func.now(), nullable=True)
+    updated_at: Mapped[datetime | None] = mapped_column(DateTime, server_default=func.now(), nullable=True)
+
+    __table_args__ = (
+        UniqueConstraint("tag", name="uix_user_tag"),
+        CheckConstraint("tag_id >= 1000000000", name="ck_user_tag_id_offset"),
+    )
+
+
+class UserTagStatusPatch(UserOverlayBase):
+    """base / user タグへの差分パッチ。
+
+    target_scope + target_tag_id でパッチ対象タグを特定し、
+    preferred_scope + preferred_tag_id でエイリアス先を cross-DB で指定する。
+
+    複合 PK (target_scope, target_tag_id, format_id) により
+    「同一タグ × フォーマットに付けられるパッチは1行のみ」を保証する。
+    """
+
+    __tablename__ = "USER_TAG_STATUS_PATCH"
+
+    target_scope: Mapped[str] = mapped_column(primary_key=True)
+    target_tag_id: Mapped[int] = mapped_column(primary_key=True)
+    format_id: Mapped[int] = mapped_column(primary_key=True)
+    type_id: Mapped[int] = mapped_column()
+    alias: Mapped[bool] = mapped_column(Boolean, nullable=False)
+    preferred_scope: Mapped[str] = mapped_column()
+    preferred_tag_id: Mapped[int] = mapped_column()
+    deprecated: Mapped[bool] = mapped_column(Boolean, server_default="0", nullable=False)
+    deprecated_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    created_at: Mapped[datetime | None] = mapped_column(DateTime, server_default=func.now(), nullable=True)
+    updated_at: Mapped[datetime | None] = mapped_column(DateTime, server_default=func.now(), nullable=True)
+
+    __table_args__ = (
+        CheckConstraint(
+            "target_scope IN ('base', 'user')",
+            name="ck_patch_target_scope",
+        ),
+        CheckConstraint(
+            "preferred_scope IN ('base', 'user')",
+            name="ck_patch_preferred_scope",
+        ),
+        CheckConstraint(
+            "(alias = 0 AND preferred_scope = target_scope AND preferred_tag_id = target_tag_id)"
+            " OR "
+            "(alias = 1 AND NOT (preferred_scope = target_scope AND preferred_tag_id = target_tag_id))",
+            name="ck_patch_preferred_consistency",
+        ),
+        Index("ix_patch_target", "target_scope", "target_tag_id"),
+        Index("ix_patch_preferred", "preferred_scope", "preferred_tag_id"),
+    )

--- a/src/genai_tag_db_tools/models.py
+++ b/src/genai_tag_db_tools/models.py
@@ -1,10 +1,27 @@
 from __future__ import annotations
 
-from typing import TypedDict
+from typing import Literal, TypedDict
 
 from pydantic import BaseModel, Field
 
 from genai_tag_db_tools.db.schema import Tag, TagStatus, TagTranslation
+
+
+class TagRef(BaseModel):
+    """タグのスコープ付き内部参照。base DB / user DB を横断して一意にタグを指す。
+
+    Args:
+        scope: タグが属するDB種別。"base" = base DB、"user" = user DB。
+        tag_id: 対象DBにおけるタグID。
+
+    Note:
+        内部専用モデル。外部 API (TagRecordPublic 等) には露出しない。
+        user tag の tag_id は USER_TAG_ID_OFFSET (1_000_000_000) 以上が保証される。
+    """
+
+    scope: Literal["base", "user"]
+    tag_id: int
+    model_config = {"frozen": True}
 
 
 class DbSourceRef(BaseModel):

--- a/tests/unit/test_overlay_schema.py
+++ b/tests/unit/test_overlay_schema.py
@@ -1,0 +1,239 @@
+"""Tests for overlay DB schema: UserTag, UserTagStatusPatch, TagRef."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+from sqlalchemy import inspect, text
+from sqlalchemy.exc import IntegrityError
+
+from genai_tag_db_tools.db.schema import (
+    USER_TAG_ID_OFFSET,
+    UserOverlayBase,
+    UserTag,
+    UserTagStatusPatch,
+)
+from genai_tag_db_tools.db.runtime import _create_engine
+from genai_tag_db_tools.models import TagRef
+
+
+# --- fixtures ---
+
+
+@pytest.fixture()
+def overlay_engine(tmp_path: Path):
+    """インメモリ代わりに tmp_path の SQLite で overlay schema を作成する。"""
+    db_path = tmp_path / "overlay_test.sqlite"
+    engine = _create_engine(db_path)
+    UserOverlayBase.metadata.create_all(engine)
+    yield engine
+    engine.dispose()
+
+
+@pytest.fixture()
+def overlay_session(overlay_engine):
+    from sqlalchemy.orm import sessionmaker
+
+    Session = sessionmaker(bind=overlay_engine, autoflush=False, autocommit=False)
+    with Session() as session:
+        yield session
+
+
+# --- TagRef ---
+
+
+class TestTagRef:
+    def test_base_scope(self):
+        ref = TagRef(scope="base", tag_id=100)
+        assert ref.scope == "base"
+        assert ref.tag_id == 100
+
+    def test_user_scope(self):
+        ref = TagRef(scope="user", tag_id=USER_TAG_ID_OFFSET + 1)
+        assert ref.scope == "user"
+
+    def test_invalid_scope_raises(self):
+        with pytest.raises(ValidationError):
+            TagRef(scope="other", tag_id=1)
+
+    def test_frozen_prevents_mutation(self):
+        ref = TagRef(scope="base", tag_id=1)
+        with pytest.raises(ValidationError):
+            ref.tag_id = 999  # type: ignore[misc]
+
+    def test_hashable_as_dict_key(self):
+        ref = TagRef(scope="base", tag_id=42)
+        d = {ref: "value"}
+        assert d[ref] == "value"
+
+    def test_equality(self):
+        assert TagRef(scope="base", tag_id=1) == TagRef(scope="base", tag_id=1)
+        assert TagRef(scope="base", tag_id=1) != TagRef(scope="user", tag_id=1)
+
+
+# --- overlay schema 作成確認 ---
+
+
+class TestOverlaySchemaCreation:
+    def test_user_tags_table_exists(self, overlay_engine):
+        inspector = inspect(overlay_engine)
+        assert "USER_TAGS" in inspector.get_table_names()
+
+    def test_user_tag_status_patch_table_exists(self, overlay_engine):
+        inspector = inspect(overlay_engine)
+        assert "USER_TAG_STATUS_PATCH" in inspector.get_table_names()
+
+    def test_user_tags_columns(self, overlay_engine):
+        inspector = inspect(overlay_engine)
+        cols = {c["name"] for c in inspector.get_columns("USER_TAGS")}
+        assert {"tag_id", "source_tag", "tag", "created_at", "updated_at"} <= cols
+
+    def test_patch_columns(self, overlay_engine):
+        inspector = inspect(overlay_engine)
+        cols = {c["name"] for c in inspector.get_columns("USER_TAG_STATUS_PATCH")}
+        assert {
+            "target_scope", "target_tag_id", "format_id",
+            "type_id", "alias", "preferred_scope", "preferred_tag_id",
+            "deprecated",
+        } <= cols
+
+
+# --- USER_TAGS 制約 ---
+
+
+class TestUserTagConstraints:
+    def test_insert_valid_user_tag(self, overlay_session):
+        tag = UserTag(tag_id=USER_TAG_ID_OFFSET + 1, source_tag="my_tag", tag="my_tag")
+        overlay_session.add(tag)
+        overlay_session.commit()
+        assert overlay_session.get(UserTag, USER_TAG_ID_OFFSET + 1) is not None
+
+    def test_tag_id_below_offset_rejected(self, overlay_session):
+        tag = UserTag(tag_id=999, source_tag="x", tag="x")
+        overlay_session.add(tag)
+        with pytest.raises(IntegrityError):
+            overlay_session.commit()
+
+    def test_unique_tag_constraint(self, overlay_session):
+        overlay_session.add(UserTag(tag_id=USER_TAG_ID_OFFSET + 1, source_tag="a", tag="dup"))
+        overlay_session.add(UserTag(tag_id=USER_TAG_ID_OFFSET + 2, source_tag="b", tag="dup"))
+        with pytest.raises(IntegrityError):
+            overlay_session.commit()
+
+
+# --- USER_TAG_STATUS_PATCH 制約 ---
+
+
+class TestUserTagStatusPatchConstraints:
+    def _non_alias_patch(self, **kwargs) -> UserTagStatusPatch:
+        base = dict(
+            target_scope="base",
+            target_tag_id=100,
+            format_id=1000,
+            type_id=0,
+            alias=False,
+            preferred_scope="base",
+            preferred_tag_id=100,
+            deprecated=False,
+        )
+        base.update(kwargs)
+        return UserTagStatusPatch(**base)
+
+    def _alias_patch(self, **kwargs) -> UserTagStatusPatch:
+        base = dict(
+            target_scope="base",
+            target_tag_id=100,
+            format_id=1000,
+            type_id=0,
+            alias=True,
+            preferred_scope="base",
+            preferred_tag_id=200,
+            deprecated=False,
+        )
+        base.update(kwargs)
+        return UserTagStatusPatch(**base)
+
+    def test_insert_valid_non_alias_patch(self, overlay_session):
+        overlay_session.add(self._non_alias_patch())
+        overlay_session.commit()
+
+    def test_insert_valid_alias_patch(self, overlay_session):
+        overlay_session.add(self._alias_patch())
+        overlay_session.commit()
+
+    def test_insert_cross_scope_alias_patch(self, overlay_session):
+        """user tag が base tag を preferred に持つ cross-scope alias。"""
+        patch = UserTagStatusPatch(
+            target_scope="user",
+            target_tag_id=USER_TAG_ID_OFFSET + 1,
+            format_id=1000,
+            type_id=0,
+            alias=True,
+            preferred_scope="base",
+            preferred_tag_id=100,
+            deprecated=False,
+        )
+        overlay_session.add(patch)
+        overlay_session.commit()
+
+    def test_composite_pk_duplicate_rejected(self, overlay_session):
+        overlay_session.add(self._non_alias_patch())
+        overlay_session.commit()
+        overlay_session.add(self._non_alias_patch())
+        with pytest.raises(IntegrityError):
+            overlay_session.commit()
+
+    def test_invalid_target_scope_rejected(self, overlay_session):
+        patch = self._non_alias_patch(target_scope="other")
+        overlay_session.add(patch)
+        with pytest.raises(IntegrityError):
+            overlay_session.commit()
+
+    def test_non_alias_with_different_preferred_rejected(self, overlay_session):
+        """非 alias なのに preferred が自分自身でない場合は拒否される。"""
+        patch = self._non_alias_patch(alias=False, preferred_tag_id=999)
+        overlay_session.add(patch)
+        with pytest.raises(IntegrityError):
+            overlay_session.commit()
+
+    def test_alias_pointing_to_self_rejected(self, overlay_session):
+        """alias なのに preferred が自分自身を指す場合は拒否される。"""
+        patch = self._alias_patch(alias=True, preferred_tag_id=100)
+        overlay_session.add(patch)
+        with pytest.raises(IntegrityError):
+            overlay_session.commit()
+
+
+# --- init_user_db でも overlay が作成される ---
+
+
+class TestInitUserDbCreatesOverlay:
+    def test_init_user_db_creates_overlay_tables(self, tmp_path: Path):
+        from genai_tag_db_tools.db import runtime
+
+        runtime.close_all()
+        user_db_dir = tmp_path / "user_db"
+        user_db_dir.mkdir()
+
+        # base DB paths が必要なので minimal base DB を用意
+        base_db = tmp_path / "base.sqlite"
+        from genai_tag_db_tools.db.schema import Base
+
+        base_engine = _create_engine(base_db)
+        Base.metadata.create_all(base_engine)
+        base_engine.dispose()
+
+        runtime.set_base_database_paths([base_db])
+        runtime.init_engine(base_db)
+        runtime.init_user_db(user_db_dir, format_name="TestApp")
+
+        user_engine = _create_engine(user_db_dir / "user_tags.sqlite")
+        inspector = inspect(user_engine)
+        tables = inspector.get_table_names()
+        user_engine.dispose()
+        runtime.close_all()
+
+        assert "USER_TAGS" in tables
+        assert "USER_TAG_STATUS_PATCH" in tables


### PR DESCRIPTION
## Summary

- `TagRef(scope, tag_id)` を Pydantic BaseModel として `models.py` に追加（内部専用、外部 API には露出しない）
- `UserOverlayBase` を `Base` とは独立した DeclarativeBase として定義
- `USER_TAGS` テーブル: user 独自タグ、`tag_id >= 1_000_000_000` を CHECK 制約で保証
- `USER_TAG_STATUS_PATCH` テーブル: base / user タグへの差分パッチ
  - 複合 PK `(target_scope, target_tag_id, format_id)`
  - `preferred_scope + preferred_tag_id` で cross-scope エイリアス先を表現
  - alias 整合性 CHECK 制約（非 alias は自己参照、alias は自己参照禁止）
- `init_user_db()` で `UserOverlayBase.metadata.create_all()` を追加（旧テーブルは #72 まで共存）

## Test plan

- [ ] `test_overlay_schema.py` 21 テストが全通過することを確認
- [ ] 既存 248 テストに回帰がないことを確認

Closes #70

🤖 Generated with [Claude Code](https://claude.ai/claude-code)