### PR TITLE
feat(overlay): DatabaseMaintenanceTool overlay 対応 (#71)

### DIFF
--- a/src/genai_tag_db_tools/db/db_maintenance_tool.py
+++ b/src/genai_tag_db_tools/db/db_maintenance_tool.py
@@ -11,13 +11,25 @@ from genai_tag_db_tools.db.runtime import init_engine, set_database_path
 class DatabaseMaintenanceTool:
     """タグDBの保守チェックをまとめたユーティリティ。"""
 
-    def __init__(self, db_path: str):
-        """指定DBを対象にツールを初期化する。"""
+    def __init__(self, db_path: str, user_db_path: str | None = None):
+        """指定 DB を対象にツールを初期化する。
+
+        Args:
+            db_path: base DB パス
+            user_db_path: user DB パス (overlay チェックが必要な場合のみ指定)
+        """
         path = Path(db_path)
         set_database_path(path)
         init_engine(path)
         self.tag_repository = get_default_repository()
         self.reader = get_default_reader()
+
+        # user DB セッションファクトリ (overlay チェック用)
+        self._user_session_factory = None
+        if user_db_path is not None:
+            from genai_tag_db_tools.db.runtime import create_session_factory
+
+            self._user_session_factory = create_session_factory(Path(user_db_path))
 
     def detect_duplicates_in_tag_status(self) -> list[dict[str, Any]]:
         """TAG_STATUSの重複を検出して詳細を返す。"""
@@ -190,6 +202,142 @@ class DatabaseMaintenanceTool:
                         }
                     )
         return abnormal
+
+    def detect_overlay_orphan_records(self) -> dict[str, list[dict]]:
+        """overlay テーブルの孤立レコードを検出する。
+
+        USER_TAG_STATUS_PATCH の target_tag_id / preferred_tag_id が
+        対応する TAGS (base) または USER_TAGS (user) に存在するかを検証する。
+
+        Returns:
+            {
+                "orphan_target": [...],      # target が存在しないパッチ
+                "orphan_preferred": [...],   # preferred が存在しないパッチ
+            }
+        """
+        if self._user_session_factory is None:
+            return {"orphan_target": [], "orphan_preferred": []}
+
+        from genai_tag_db_tools.db.schema import UserTag, UserTagStatusPatch
+
+        orphan_target = []
+        orphan_preferred = []
+
+        with self._user_session_factory() as session:
+            patches = session.query(UserTagStatusPatch).all()
+            user_tag_ids = {row.tag_id for row in session.query(UserTag.tag_id).all()}
+
+        base_tag_ids = set(self.reader.get_all_tag_ids())
+
+        for patch in patches:
+            # target の存在チェック
+            if patch.target_scope == "base":
+                if patch.target_tag_id not in base_tag_ids:
+                    orphan_target.append({
+                        "target_scope": patch.target_scope,
+                        "target_tag_id": patch.target_tag_id,
+                        "format_id": patch.format_id,
+                        "reason": "base TAGS に存在しない target_tag_id",
+                    })
+            elif patch.target_scope == "user":
+                if patch.target_tag_id not in user_tag_ids:
+                    orphan_target.append({
+                        "target_scope": patch.target_scope,
+                        "target_tag_id": patch.target_tag_id,
+                        "format_id": patch.format_id,
+                        "reason": "USER_TAGS に存在しない target_tag_id",
+                    })
+
+            # preferred の存在チェック
+            if patch.preferred_scope == "base":
+                if patch.preferred_tag_id not in base_tag_ids:
+                    orphan_preferred.append({
+                        "target_scope": patch.target_scope,
+                        "target_tag_id": patch.target_tag_id,
+                        "format_id": patch.format_id,
+                        "preferred_scope": patch.preferred_scope,
+                        "preferred_tag_id": patch.preferred_tag_id,
+                        "reason": "base TAGS に存在しない preferred_tag_id",
+                    })
+            elif patch.preferred_scope == "user":
+                if patch.preferred_tag_id not in user_tag_ids:
+                    orphan_preferred.append({
+                        "target_scope": patch.target_scope,
+                        "target_tag_id": patch.target_tag_id,
+                        "format_id": patch.format_id,
+                        "preferred_scope": patch.preferred_scope,
+                        "preferred_tag_id": patch.preferred_tag_id,
+                        "reason": "USER_TAGS に存在しない preferred_tag_id",
+                    })
+
+        return {"orphan_target": orphan_target, "orphan_preferred": orphan_preferred}
+
+    def detect_overlay_inconsistent_alias(self) -> list[dict]:
+        """USER_TAG_STATUS_PATCH の alias 整合性が崩れているレコードを検出する。
+
+        CHECK 制約と重複するが application 層の二重確認として有用。
+
+        Returns:
+            整合性エラーがあるパッチ行のリスト。
+        """
+        if self._user_session_factory is None:
+            return []
+
+        from genai_tag_db_tools.db.schema import UserTagStatusPatch
+
+        inconsistencies = []
+        with self._user_session_factory() as session:
+            patches = session.query(UserTagStatusPatch).all()
+
+        for patch in patches:
+            is_self = (
+                patch.preferred_scope == patch.target_scope
+                and patch.preferred_tag_id == patch.target_tag_id
+            )
+            if not patch.alias and not is_self:
+                inconsistencies.append({
+                    "target_scope": patch.target_scope,
+                    "target_tag_id": patch.target_tag_id,
+                    "format_id": patch.format_id,
+                    "reason": "alias=False なのに preferred が自分自身でない",
+                })
+            if patch.alias and is_self:
+                inconsistencies.append({
+                    "target_scope": patch.target_scope,
+                    "target_tag_id": patch.target_tag_id,
+                    "format_id": patch.format_id,
+                    "reason": "alias=True なのに preferred が自分自身を指す",
+                })
+
+        return inconsistencies
+
+    def detect_user_tag_id_range(self) -> list[dict]:
+        """USER_TAGS の tag_id が USER_TAG_ID_OFFSET (1_000_000_000) 以上かを確認する。
+
+        CHECK 制約の二重確認として使用する。
+
+        Returns:
+            オフセット未満の tag_id を持つ行のリスト。
+        """
+        if self._user_session_factory is None:
+            return []
+
+        from genai_tag_db_tools.db.schema import USER_TAG_ID_OFFSET, UserTag
+
+        violations = []
+        with self._user_session_factory() as session:
+            out_of_range = (
+                session.query(UserTag)
+                .filter(UserTag.tag_id < USER_TAG_ID_OFFSET)
+                .all()
+            )
+        for tag in out_of_range:
+            violations.append({
+                "tag_id": tag.tag_id,
+                "tag": tag.tag,
+                "reason": f"tag_id < USER_TAG_ID_OFFSET ({USER_TAG_ID_OFFSET})",
+            })
+        return violations
 
     def optimize_indexes(self) -> None:
         """インデックスの最適化（未実装）。"""

--- a/tests/unit/test_db_maintenance_overlay.py
+++ b/tests/unit/test_db_maintenance_overlay.py
@@ -1,0 +1,321 @@
+"""overlay DB 対応の DatabaseMaintenanceTool テスト。"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.orm import sessionmaker
+
+import genai_tag_db_tools.db.db_maintenance_tool as maintenance_module
+from genai_tag_db_tools.db.runtime import _create_engine
+from genai_tag_db_tools.db.schema import (
+    USER_TAG_ID_OFFSET,
+    Base,
+    Tag,
+    TagFormat,
+    TagTypeFormatMapping,
+    TagTypeName,
+    UserOverlayBase,
+    UserTag,
+    UserTagStatusPatch,
+)
+
+
+# --- fixtures ---
+
+
+@pytest.fixture()
+def base_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """base DB を tmp_path に作成し、タグデータを INSERT する。"""
+    db_path = tmp_path / "base.sqlite"
+    engine = _create_engine(db_path)
+    Base.metadata.create_all(engine)
+
+    Session = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    with Session() as session:
+        session.add(TagTypeName(type_name_id=1, type_name="unknown"))
+        session.add(TagFormat(format_id=1, format_name="test_format"))
+        session.add(TagTypeFormatMapping(format_id=1, type_id=0, type_name_id=1))
+        session.add(Tag(tag_id=100, source_tag="cat", tag="cat"))
+        session.add(Tag(tag_id=200, source_tag="dog", tag="dog"))
+        session.commit()
+
+    engine.dispose()
+
+    # _make_tool が使う runtime 関数をモンキーパッチ
+    monkeypatch.setattr(maintenance_module, "set_database_path", lambda p: None)
+    monkeypatch.setattr(maintenance_module, "init_engine", lambda p: None)
+
+    # reader.get_all_tag_ids() が base タグ ID を返すように差し替える
+    class DummyReader:
+        def get_all_tag_ids(self) -> list[int]:
+            return [100, 200]
+
+    monkeypatch.setattr(maintenance_module, "get_default_reader", lambda: DummyReader())
+    monkeypatch.setattr(maintenance_module, "get_default_repository", lambda: DummyReader())
+
+    return db_path
+
+
+@pytest.fixture()
+def user_db(tmp_path: Path):
+    """user DB を tmp_path に作成し、overlay スキーマのみ用意する。"""
+    db_path = tmp_path / "user.sqlite"
+    engine = _create_engine(db_path)
+    UserOverlayBase.metadata.create_all(engine)
+    engine.dispose()
+    return db_path
+
+
+def _make_tool(base_db: Path, user_db: Path | None = None) -> maintenance_module.DatabaseMaintenanceTool:
+    return maintenance_module.DatabaseMaintenanceTool(
+        db_path=str(base_db),
+        user_db_path=str(user_db) if user_db is not None else None,
+    )
+
+
+def _insert_user_tag(db_path: Path, tag_id: int, tag: str) -> None:
+    engine = _create_engine(db_path)
+    Session = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    with Session() as session:
+        session.add(UserTag(tag_id=tag_id, source_tag=tag, tag=tag))
+        session.commit()
+    engine.dispose()
+
+
+def _make_mock_session_factory(*, query_result=None, filter_result=None):
+    """session.query().all() および .filter().all() を差し替えるモック。
+
+    CHECK 制約で DB に挿入できない不正データを返すために使う。
+    """
+    mock_session = MagicMock()
+    mock_cm = MagicMock()
+    mock_cm.__enter__ = MagicMock(return_value=mock_session)
+    mock_cm.__exit__ = MagicMock(return_value=False)
+
+    mock_query = MagicMock()
+    mock_query.all.return_value = query_result or []
+    mock_query.filter.return_value.all.return_value = filter_result or []
+    mock_session.query.return_value = mock_query
+
+    return MagicMock(return_value=mock_cm)
+
+
+def _insert_patch(db_path: Path, **kwargs) -> None:
+    """USER_TAG_STATUS_PATCH を raw SQL で INSERT（CHECK 制約を回避するため）。"""
+    engine = _create_engine(db_path)
+    defaults = dict(
+        target_scope="base",
+        target_tag_id=100,
+        format_id=1,
+        type_id=0,
+        alias=0,
+        preferred_scope="base",
+        preferred_tag_id=100,
+        deprecated=0,
+    )
+    defaults.update(kwargs)
+    with engine.connect() as conn:
+        # SQLite の CHECK 制約は正常な行にのみ通る
+        conn.execute(
+            text(
+                "INSERT INTO USER_TAG_STATUS_PATCH "
+                "(target_scope, target_tag_id, format_id, type_id, alias, "
+                "preferred_scope, preferred_tag_id, deprecated) "
+                "VALUES (:target_scope, :target_tag_id, :format_id, :type_id, :alias, "
+                ":preferred_scope, :preferred_tag_id, :deprecated)"
+            ),
+            defaults,
+        )
+        conn.commit()
+    engine.dispose()
+
+
+# --- TestDetectOverlayOrphanRecords ---
+
+
+@pytest.mark.db_tools
+class TestDetectOverlayOrphanRecords:
+    def test_no_patches_returns_empty(self, base_db, user_db):
+        tool = _make_tool(base_db, user_db)
+        result = tool.detect_overlay_orphan_records()
+        assert result == {"orphan_target": [], "orphan_preferred": []}
+
+    def test_valid_patch_not_in_orphan(self, base_db, user_db):
+        """存在するタグを参照する正常パッチは孤立とならない。"""
+        _insert_patch(user_db, target_scope="base", target_tag_id=100, preferred_tag_id=100)
+        tool = _make_tool(base_db, user_db)
+        result = tool.detect_overlay_orphan_records()
+        assert result["orphan_target"] == []
+        assert result["orphan_preferred"] == []
+
+    def test_nonexistent_base_target_detected(self, base_db, user_db):
+        """base TAGS に存在しない target_tag_id を持つパッチを検出する。"""
+        _insert_patch(user_db, target_scope="base", target_tag_id=999, preferred_tag_id=999)
+        tool = _make_tool(base_db, user_db)
+        result = tool.detect_overlay_orphan_records()
+        assert len(result["orphan_target"]) == 1
+        assert result["orphan_target"][0]["target_tag_id"] == 999
+        assert "base TAGS" in result["orphan_target"][0]["reason"]
+
+    def test_nonexistent_user_target_detected(self, base_db, user_db):
+        """USER_TAGS に存在しない target_tag_id (user scope) を検出する。"""
+        # user タグなし; USER_TAG_ID_OFFSET+999 は存在しない
+        _insert_patch(
+            user_db,
+            target_scope="user",
+            target_tag_id=USER_TAG_ID_OFFSET + 999,
+            preferred_scope="user",
+            preferred_tag_id=USER_TAG_ID_OFFSET + 999,
+        )
+        tool = _make_tool(base_db, user_db)
+        result = tool.detect_overlay_orphan_records()
+        assert len(result["orphan_target"]) == 1
+        assert "USER_TAGS" in result["orphan_target"][0]["reason"]
+
+    def test_nonexistent_preferred_detected(self, base_db, user_db):
+        """base TAGS に存在しない preferred_tag_id を持つパッチを検出する。"""
+        # alias patch: target=100 (exists), preferred=888 (not exists)
+        _insert_patch(
+            user_db,
+            target_scope="base",
+            target_tag_id=100,
+            alias=1,
+            preferred_scope="base",
+            preferred_tag_id=888,
+        )
+        tool = _make_tool(base_db, user_db)
+        result = tool.detect_overlay_orphan_records()
+        assert result["orphan_target"] == []
+        assert len(result["orphan_preferred"]) == 1
+        assert result["orphan_preferred"][0]["preferred_tag_id"] == 888
+
+    def test_user_tag_as_target_valid(self, base_db, user_db):
+        """USER_TAGS に存在する user タグを target にしたパッチは孤立にならない。"""
+        uid = USER_TAG_ID_OFFSET + 1
+        _insert_user_tag(user_db, uid, "my_tag")
+        _insert_patch(
+            user_db,
+            target_scope="user",
+            target_tag_id=uid,
+            preferred_scope="user",
+            preferred_tag_id=uid,
+        )
+        tool = _make_tool(base_db, user_db)
+        result = tool.detect_overlay_orphan_records()
+        assert result["orphan_target"] == []
+
+
+# --- TestDetectOverlayInconsistentAlias ---
+
+
+@pytest.mark.db_tools
+class TestDetectOverlayInconsistentAlias:
+    def test_no_patches_returns_empty(self, base_db, user_db):
+        tool = _make_tool(base_db, user_db)
+        assert tool.detect_overlay_inconsistent_alias() == []
+
+    def test_valid_non_alias_patch_not_detected(self, base_db, user_db):
+        """alias=False かつ preferred==self は正常。"""
+        _insert_patch(user_db, alias=0, preferred_tag_id=100)
+        tool = _make_tool(base_db, user_db)
+        assert tool.detect_overlay_inconsistent_alias() == []
+
+    def test_valid_alias_patch_not_detected(self, base_db, user_db):
+        """alias=True かつ preferred!=self は正常。"""
+        _insert_patch(user_db, alias=1, preferred_tag_id=200)
+        tool = _make_tool(base_db, user_db)
+        assert tool.detect_overlay_inconsistent_alias() == []
+
+    def test_non_alias_with_different_preferred_detected(self, base_db, user_db):
+        """alias=False なのに preferred が自分自身でない行を検出する。
+
+        SQLite の CHECK 制約でこの不正データは DB に挿入できないため、
+        セッションファクトリをモックして application 層の検出ロジックを検証する。
+        """
+        fake_patch = SimpleNamespace(
+            target_scope="base", target_tag_id=100, format_id=1,
+            alias=False,
+            preferred_scope="base", preferred_tag_id=200,
+        )
+        tool = _make_tool(base_db, user_db)
+        tool._user_session_factory = _make_mock_session_factory(query_result=[fake_patch])
+
+        result = tool.detect_overlay_inconsistent_alias()
+        assert len(result) == 1
+        assert "alias=False" in result[0]["reason"]
+
+    def test_alias_pointing_to_self_detected(self, base_db, user_db):
+        """alias=True なのに preferred が自分自身を指す行を検出する。
+
+        SQLite の CHECK 制約でこの不正データは DB に挿入できないため、
+        セッションファクトリをモックして application 層の検出ロジックを検証する。
+        """
+        fake_patch = SimpleNamespace(
+            target_scope="base", target_tag_id=100, format_id=1,
+            alias=True,
+            preferred_scope="base", preferred_tag_id=100,
+        )
+        tool = _make_tool(base_db, user_db)
+        tool._user_session_factory = _make_mock_session_factory(query_result=[fake_patch])
+
+        result = tool.detect_overlay_inconsistent_alias()
+        assert len(result) == 1
+        assert "alias=True" in result[0]["reason"]
+
+
+# --- TestDetectUserTagIdRange ---
+
+
+@pytest.mark.db_tools
+class TestDetectUserTagIdRange:
+    def test_no_user_tags_returns_empty(self, base_db, user_db):
+        tool = _make_tool(base_db, user_db)
+        assert tool.detect_user_tag_id_range() == []
+
+    def test_valid_user_tag_not_detected(self, base_db, user_db):
+        """オフセット以上の tag_id は違反にならない。"""
+        _insert_user_tag(user_db, USER_TAG_ID_OFFSET + 1, "valid_tag")
+        tool = _make_tool(base_db, user_db)
+        assert tool.detect_user_tag_id_range() == []
+
+    def test_below_offset_detected_via_mock(self, base_db, user_db):
+        """offset 未満の tag_id を持つ UserTag を検出する。
+
+        SQLite の CHECK 制約でこの不正データは DB に挿入できないため、
+        セッションファクトリをモックして application 層の検出ロジックを検証する。
+        """
+        fake_tag = SimpleNamespace(tag_id=999, tag="x")
+        tool = _make_tool(base_db, user_db)
+        tool._user_session_factory = _make_mock_session_factory(filter_result=[fake_tag])
+
+        result = tool.detect_user_tag_id_range()
+        assert len(result) == 1
+        assert result[0]["tag_id"] == 999
+        assert "USER_TAG_ID_OFFSET" in result[0]["reason"]
+
+
+# --- TestNoUserDb ---
+
+
+@pytest.mark.db_tools
+class TestNoUserDb:
+    def test_detect_overlay_orphan_records_no_user_db(self, base_db):
+        """user_db_path=None のとき detect_overlay_orphan_records は空を返す。"""
+        tool = _make_tool(base_db, None)
+        result = tool.detect_overlay_orphan_records()
+        assert result == {"orphan_target": [], "orphan_preferred": []}
+
+    def test_detect_overlay_inconsistent_alias_no_user_db(self, base_db):
+        """user_db_path=None のとき detect_overlay_inconsistent_alias は空を返す。"""
+        tool = _make_tool(base_db, None)
+        assert tool.detect_overlay_inconsistent_alias() == []
+
+    def test_detect_user_tag_id_range_no_user_db(self, base_db):
+        """user_db_path=None のとき detect_user_tag_id_range は空を返す。"""
+        tool = _make_tool(base_db, None)
+        assert tool.detect_user_tag_id_range() == []


### PR DESCRIPTION
## Summary
- `__init__` に `user_db_path` パラメータを追加（`None` のときは overlay チェックをスキップ）
- `detect_overlay_orphan_records`: USER_TAG_STATUS_PATCH の cross-DB 孤立チェック（target/preferred が base TAGS or USER_TAGS に存在するか検証）
- `detect_overlay_inconsistent_alias`: alias/preferred 整合性の application 層二重確認
- `detect_user_tag_id_range`: USER_TAGS tag_id オフセット (1_000_000_000) 確認

## Test plan
- [x] `test_db_maintenance_overlay.py` 17件 — 各 detect メソッドの正常/異常ケース
- [x] `user_db_path=None` 時は全メソッドが空を返す (`TestNoUserDb`)
- [x] 既存全テスト 386件 `not slow and not network` pass

## 実装メモ
SQLite の CHECK 制約が不正データの直接挿入を防ぐため、`detect_overlay_inconsistent_alias` と `detect_user_tag_id_range` の異常系テストはセッションファクトリをモックして application 層の検出ロジックを検証している。

Closes #71