### PR TITLE
feat(overlay): OverlayTagReader を追加 (#66)

### DIFF
--- a/src/genai_tag_db_tools/db/overlay_reader.py
+++ b/src/genai_tag_db_tools/db/overlay_reader.py
@@ -1,0 +1,290 @@
+# genai_tag_db_tools.db.overlay_reader
+from __future__ import annotations
+
+from collections.abc import Callable
+from logging import getLogger
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from genai_tag_db_tools.db.query_utils import normalize_search_keyword
+from genai_tag_db_tools.db.schema import (
+    Tag,
+    TagStatus,
+    TagTranslation,
+    TagUsageCounts,
+    UserTag,
+    UserTagStatusPatch,
+)
+from genai_tag_db_tools.models import TagSearchRow
+
+
+class OverlayTagReader:
+    """USER_TAGS / USER_TAG_STATUS_PATCH を読み取る読み取り専用リポジトリ。
+
+    TagReader と同じ公開インターフェースを実装し、MergedTagReader の user_repo として機能する。
+    format / translation 系メソッドはフェーズ2以降で実装予定のため空 stub を置く。
+    """
+
+    def __init__(self, session_factory: Callable[[], Session]):
+        self.logger = getLogger(__name__)
+        self.session_factory = session_factory
+
+    # ------------------------------------------------------------------
+    # タグ取得 (USER_TAGS)
+    # ------------------------------------------------------------------
+
+    def get_tag_by_id(self, tag_id: int) -> Tag | None:
+        """tag_id で USER_TAGS を検索し、見つかれば detached Tag オブジェクトを返す。"""
+        with self.session_factory() as session:
+            row = session.query(UserTag).filter(UserTag.tag_id == tag_id).one_or_none()
+            if row is None:
+                return None
+            return Tag(tag_id=row.tag_id, source_tag=row.source_tag, tag=row.tag)
+
+    def get_tag_id_by_name(self, keyword: str, partial: bool = False) -> int | None:
+        """キーワードで USER_TAGS の tag を検索し、最初に一致した tag_id を返す。"""
+        keyword, use_like = normalize_search_keyword(keyword, partial)
+        with self.session_factory() as session:
+            query = session.query(UserTag)
+            if use_like:
+                query = query.filter(UserTag.tag.like(keyword))
+            else:
+                query = query.filter(UserTag.tag == keyword)
+            results = query.all()
+        if not results:
+            return None
+        if len(results) == 1:
+            return results[0].tag_id
+        if use_like:
+            return results[0].tag_id
+        raise ValueError(f"複数のユーザータグが一致しました: keyword={keyword}")
+
+    def list_tags(self) -> list[Tag]:
+        """USER_TAGS 全件を detached Tag オブジェクトのリストとして返す。"""
+        with self.session_factory() as session:
+            rows = session.query(UserTag).all()
+            return [Tag(tag_id=r.tag_id, source_tag=r.source_tag, tag=r.tag) for r in rows]
+
+    def get_all_tag_ids(self) -> list[int]:
+        """USER_TAGS の全 tag_id を返す。"""
+        with self.session_factory() as session:
+            return [r.tag_id for r in session.query(UserTag).all()]
+
+    def get_max_tag_id(self) -> int:
+        """USER_TAGS の最大 tag_id を返す。存在しなければ 0。"""
+        with self.session_factory() as session:
+            max_id = session.query(func.max(UserTag.tag_id)).scalar()
+            return int(max_id) if max_id is not None else 0
+
+    def search_tag_ids(self, keyword: str, partial: bool = False) -> list[int]:
+        """キーワードに一致する USER_TAGS の tag_id リストを返す。"""
+        keyword, use_like = normalize_search_keyword(keyword, partial)
+        with self.session_factory() as session:
+            query = session.query(UserTag.tag_id)
+            if use_like:
+                query = query.filter(UserTag.tag.like(keyword))
+            else:
+                query = query.filter(UserTag.tag == keyword)
+            return [row[0] for row in query.all()]
+
+    # ------------------------------------------------------------------
+    # ステータス取得 (USER_TAG_STATUS_PATCH)
+    # ------------------------------------------------------------------
+
+    def get_tag_status(self, tag_id: int, format_id: int) -> TagStatus | None:
+        """USER_TAG_STATUS_PATCH からステータスを取得し、detached TagStatus を返す。"""
+        with self.session_factory() as session:
+            row = (
+                session.query(UserTagStatusPatch)
+                .filter(
+                    UserTagStatusPatch.target_tag_id == tag_id,
+                    UserTagStatusPatch.format_id == format_id,
+                )
+                .one_or_none()
+            )
+            if row is None:
+                return None
+            return TagStatus(
+                tag_id=row.target_tag_id,
+                format_id=row.format_id,
+                type_id=row.type_id,
+                alias=row.alias,
+                preferred_tag_id=row.preferred_tag_id,
+                deprecated=row.deprecated,
+                deprecated_at=row.deprecated_at,
+            )
+
+    def list_tag_statuses(self, tag_id: int | None = None) -> list[TagStatus]:
+        """USER_TAG_STATUS_PATCH を全件 (tag_id 指定時はフィルタ) 取得し TagStatus に変換して返す。"""
+        with self.session_factory() as session:
+            query = session.query(UserTagStatusPatch)
+            if tag_id is not None:
+                query = query.filter(UserTagStatusPatch.target_tag_id == tag_id)
+            rows = query.all()
+            return [
+                TagStatus(
+                    tag_id=r.target_tag_id,
+                    format_id=r.format_id,
+                    type_id=r.type_id,
+                    alias=r.alias,
+                    preferred_tag_id=r.preferred_tag_id,
+                    deprecated=r.deprecated,
+                    deprecated_at=r.deprecated_at,
+                )
+                for r in rows
+            ]
+
+    # ------------------------------------------------------------------
+    # 検索 (USER_TAGS + USER_TAG_STATUS_PATCH)
+    # ------------------------------------------------------------------
+
+    def search_tags(
+        self,
+        keyword: str,
+        *,
+        partial: bool = False,
+        format_name: str | None = None,
+        format_names: list[str] | None = None,
+        type_name: str | None = None,
+        type_names: list[str] | None = None,
+        language: str | None = None,
+        min_usage: int | None = None,
+        max_usage: int | None = None,
+        alias: bool | None = None,
+        deprecated: bool | None = None,
+        resolve_preferred: bool = False,
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> list[TagSearchRow]:
+        """USER_TAGS からキーワードマッチするタグを取得し、USER_TAG_STATUS_PATCH でステータスを付与して返す。"""
+        keyword, use_like = normalize_search_keyword(keyword, partial)
+        with self.session_factory() as session:
+            query = session.query(UserTag)
+            if use_like:
+                query = query.filter(UserTag.tag.like(keyword))
+            else:
+                query = query.filter(UserTag.tag == keyword)
+            if offset:
+                query = query.offset(offset)
+            if limit is not None:
+                query = query.limit(limit)
+            user_tags = query.all()
+
+        if not user_tags:
+            return []
+
+        tag_ids = [t.tag_id for t in user_tags]
+        with self.session_factory() as session:
+            patches = (
+                session.query(UserTagStatusPatch)
+                .filter(UserTagStatusPatch.target_tag_id.in_(tag_ids))
+                .all()
+            )
+
+        # target_tag_id → list[UserTagStatusPatch] のマップ
+        patch_map: dict[int, list[UserTagStatusPatch]] = {}
+        for p in patches:
+            patch_map.setdefault(p.target_tag_id, []).append(p)
+
+        rows: list[TagSearchRow] = []
+        for t in user_tags:
+            tag_patches = patch_map.get(t.tag_id, [])
+            first_patch = tag_patches[0] if tag_patches else None
+
+            format_statuses: dict[str, dict[str, object]] = {
+                str(p.format_id): {
+                    "alias": p.alias,
+                    "deprecated": p.deprecated,
+                    "type_id": p.type_id,
+                    "preferred_tag_id": p.preferred_tag_id,
+                }
+                for p in tag_patches
+            }
+
+            row: TagSearchRow = {
+                "tag_id": t.tag_id,
+                "tag": t.tag,
+                "source_tag": t.source_tag,
+                "usage_count": 0,
+                "alias": first_patch.alias if first_patch else False,
+                "deprecated": first_patch.deprecated if first_patch else False,
+                "type_id": first_patch.type_id if first_patch else None,
+                "type_name": "",
+                "translations": {},
+                "format_statuses": format_statuses,
+            }
+            rows.append(row)
+        return rows
+
+    # ------------------------------------------------------------------
+    # stub メソッド (フェーズ2以降で実装予定)
+    # ------------------------------------------------------------------
+
+    def get_translations(self, tag_id: int) -> list[TagTranslation]:
+        return []
+
+    def list_translations(self) -> list[TagTranslation]:
+        return []
+
+    def get_translations_batch(self, tag_ids: list[int]) -> dict[int, list[TagTranslation]]:
+        return {}
+
+    def get_format_name(self, format_id: int) -> str | None:
+        return None
+
+    def get_format_id(self, format_name: str) -> int:
+        return 0
+
+    def get_format_map(self) -> dict[int, str]:
+        return {}
+
+    def get_tag_format_ids(self) -> list[int]:
+        return []
+
+    def get_tag_formats(self) -> list[str]:
+        return []
+
+    def get_tag_languages(self) -> list[str]:
+        return []
+
+    def get_type_mapping_map(self) -> dict[tuple[int, int], str]:
+        return {}
+
+    def get_type_name_by_format_type_id(self, format_id: int, type_id: int) -> str | None:
+        return None
+
+    def get_type_name_id(self, type_name: str) -> int | None:
+        return None
+
+    def get_type_id_for_format(self, type_name: str, format_id: int) -> int | None:
+        return None
+
+    def get_usage_count(self, tag_id: int, format_id: int) -> int | None:
+        return None
+
+    def list_usage_counts(
+        self, tag_id: int | None = None, format_id: int | None = None
+    ) -> list[TagUsageCounts]:
+        return []
+
+    def get_tag_types(self, format_id: int) -> list[str]:
+        return []
+
+    def get_all_types(self) -> list[str]:
+        return []
+
+    def get_unknown_type_tag_ids(self, format_id: int) -> list[int]:
+        return []
+
+    def get_metadata_value(self, key: str) -> str | None:
+        return None
+
+    def search_tags_bulk(
+        self,
+        keywords: list[str],
+        *,
+        format_name: str | None = None,
+        resolve_preferred: bool = False,
+    ) -> dict[str, TagSearchRow]:
+        return {}

--- a/src/genai_tag_db_tools/db/repository.py
+++ b/src/genai_tag_db_tools/db/repository.py
@@ -1,7 +1,10 @@
 from collections.abc import Callable
 from datetime import datetime
 from logging import getLogger
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from genai_tag_db_tools.db.overlay_reader import OverlayTagReader
 
 import polars as pl
 from sqlalchemy import func
@@ -1218,7 +1221,7 @@ class MergedTagReader:
     def __init__(
         self,
         base_repo: TagReader | list[TagReader],
-        user_repo: TagReader | None = None,
+        user_repo: "TagReader | OverlayTagReader | None" = None,
     ):
         self.logger = getLogger(__name__)
         if isinstance(base_repo, list):
@@ -1239,8 +1242,8 @@ class MergedTagReader:
     def _iter_base_repos_low_to_high(self) -> list[TagReader]:
         return list(reversed(self.base_repos))
 
-    def _iter_repos(self) -> list[TagReader]:
-        repos: list[TagReader] = []
+    def _iter_repos(self) -> "list[TagReader | OverlayTagReader]":
+        repos: list[TagReader | OverlayTagReader] = []
         if self.user_repo is not None:
             repos.append(self.user_repo)
         repos.extend(self.base_repos)
@@ -1671,13 +1674,14 @@ class MergedTagReader:
 
 
 def get_default_reader() -> MergedTagReader:
+    from genai_tag_db_tools.db.overlay_reader import OverlayTagReader
     from genai_tag_db_tools.db.runtime import (
         get_base_session_factories,
         get_user_session_factory_optional,
     )
 
     user_factory = get_user_session_factory_optional()
-    user_repo = TagReader(session_factory=user_factory) if user_factory else None
+    user_repo = OverlayTagReader(session_factory=user_factory) if user_factory else None
 
     base_factories = get_base_session_factories()
     if not base_factories:

--- a/tests/unit/test_overlay_reader.py
+++ b/tests/unit/test_overlay_reader.py
@@ -1,0 +1,330 @@
+"""OverlayTagReader の単体テスト。"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from sqlalchemy import StaticPool, create_engine
+from sqlalchemy.orm import sessionmaker
+
+from genai_tag_db_tools.db.overlay_reader import OverlayTagReader
+from genai_tag_db_tools.db.schema import (
+    USER_TAG_ID_OFFSET,
+    Base,
+    UserOverlayBase,
+    UserTag,
+    UserTagStatusPatch,
+)
+
+
+@pytest.fixture
+def overlay_engine(tmp_path: Path):
+    """UserOverlayBase + Base の両テーブルを持つインメモリ SQLite エンジン。"""
+    db_path = tmp_path / "test_overlay.sqlite"
+    engine = create_engine(
+        f"sqlite:///{db_path}",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    UserOverlayBase.metadata.create_all(engine)
+    return engine
+
+
+@pytest.fixture
+def overlay_session_factory(overlay_engine):
+    """テスト用セッションファクトリ。"""
+    return sessionmaker(bind=overlay_engine, autoflush=False, autocommit=False)
+
+
+@pytest.fixture
+def overlay_reader(overlay_session_factory):
+    """テスト対象の OverlayTagReader インスタンス。"""
+    return OverlayTagReader(session_factory=overlay_session_factory)
+
+
+class TestOverlayTagReaderGetTag:
+    """get_tag_by_id / get_tag_id_by_name の基本動作を検証する。"""
+
+    def test_get_tag_by_id_found(self, overlay_reader, overlay_session_factory):
+        tag_id = USER_TAG_ID_OFFSET + 1
+        with overlay_session_factory() as session:
+            session.add(UserTag(tag_id=tag_id, source_tag="my_src", tag="my_tag"))
+            session.commit()
+
+        tag = overlay_reader.get_tag_by_id(tag_id)
+        assert tag is not None
+        assert tag.tag_id == tag_id
+        assert tag.tag == "my_tag"
+        assert tag.source_tag == "my_src"
+
+    def test_get_tag_by_id_not_found(self, overlay_reader):
+        assert overlay_reader.get_tag_by_id(USER_TAG_ID_OFFSET + 999) is None
+
+    def test_get_tag_id_by_name_exact(self, overlay_reader, overlay_session_factory):
+        tag_id = USER_TAG_ID_OFFSET + 2
+        with overlay_session_factory() as session:
+            session.add(UserTag(tag_id=tag_id, source_tag="exact_src", tag="exact_tag"))
+            session.commit()
+
+        result = overlay_reader.get_tag_id_by_name("exact_tag")
+        assert result == tag_id
+
+    def test_get_tag_id_by_name_not_found(self, overlay_reader):
+        assert overlay_reader.get_tag_id_by_name("nonexistent") is None
+
+    def test_get_tag_id_by_name_partial(self, overlay_reader, overlay_session_factory):
+        tag_id = USER_TAG_ID_OFFSET + 3
+        with overlay_session_factory() as session:
+            session.add(UserTag(tag_id=tag_id, source_tag="partial_src", tag="partial_match_tag"))
+            session.commit()
+
+        result = overlay_reader.get_tag_id_by_name("partial", partial=True)
+        assert result == tag_id
+
+    def test_list_tags(self, overlay_reader, overlay_session_factory):
+        with overlay_session_factory() as session:
+            session.add(UserTag(tag_id=USER_TAG_ID_OFFSET + 10, source_tag="s1", tag="list_tag1"))
+            session.add(UserTag(tag_id=USER_TAG_ID_OFFSET + 11, source_tag="s2", tag="list_tag2"))
+            session.commit()
+
+        tags = overlay_reader.list_tags()
+        assert len(tags) == 2
+        tag_ids = {t.tag_id for t in tags}
+        assert USER_TAG_ID_OFFSET + 10 in tag_ids
+        assert USER_TAG_ID_OFFSET + 11 in tag_ids
+
+    def test_get_all_tag_ids(self, overlay_reader, overlay_session_factory):
+        with overlay_session_factory() as session:
+            session.add(UserTag(tag_id=USER_TAG_ID_OFFSET + 20, source_tag="s1", tag="all_ids1"))
+            session.add(UserTag(tag_id=USER_TAG_ID_OFFSET + 21, source_tag="s2", tag="all_ids2"))
+            session.commit()
+
+        ids = overlay_reader.get_all_tag_ids()
+        assert USER_TAG_ID_OFFSET + 20 in ids
+        assert USER_TAG_ID_OFFSET + 21 in ids
+
+    def test_get_max_tag_id(self, overlay_reader, overlay_session_factory):
+        with overlay_session_factory() as session:
+            session.add(UserTag(tag_id=USER_TAG_ID_OFFSET + 100, source_tag="s", tag="max_tag"))
+            session.commit()
+
+        assert overlay_reader.get_max_tag_id() >= USER_TAG_ID_OFFSET + 100
+
+    def test_search_tag_ids(self, overlay_reader, overlay_session_factory):
+        tag_id = USER_TAG_ID_OFFSET + 30
+        with overlay_session_factory() as session:
+            session.add(UserTag(tag_id=tag_id, source_tag="srch_src", tag="search_ids_tag"))
+            session.commit()
+
+        ids = overlay_reader.search_tag_ids("search_ids_tag")
+        assert tag_id in ids
+
+    def test_search_tag_ids_partial(self, overlay_reader, overlay_session_factory):
+        tag_id = USER_TAG_ID_OFFSET + 31
+        with overlay_session_factory() as session:
+            session.add(UserTag(tag_id=tag_id, source_tag="ps", tag="partial_ids_tag"))
+            session.commit()
+
+        ids = overlay_reader.search_tag_ids("partial_ids", partial=True)
+        assert tag_id in ids
+
+
+class TestOverlayTagReaderStatus:
+    """get_tag_status / list_tag_statuses の基本動作を検証する。"""
+
+    def _make_patch(
+        self,
+        tag_id: int,
+        format_id: int,
+        *,
+        alias: bool = False,
+        deprecated: bool = False,
+    ) -> UserTagStatusPatch:
+        return UserTagStatusPatch(
+            target_scope="user",
+            target_tag_id=tag_id,
+            format_id=format_id,
+            type_id=0,
+            alias=alias,
+            preferred_scope="user",
+            preferred_tag_id=tag_id,
+            deprecated=deprecated,
+        )
+
+    def test_get_tag_status_found(self, overlay_reader, overlay_session_factory):
+        tag_id = USER_TAG_ID_OFFSET + 200
+        format_id = 1000
+        with overlay_session_factory() as session:
+            session.add(UserTag(tag_id=tag_id, source_tag="st_src", tag="status_tag"))
+            session.add(self._make_patch(tag_id, format_id))
+            session.commit()
+
+        status = overlay_reader.get_tag_status(tag_id, format_id)
+        assert status is not None
+        assert status.tag_id == tag_id
+        assert status.format_id == format_id
+        assert status.alias is False
+        assert status.deprecated is False
+
+    def test_get_tag_status_not_found(self, overlay_reader):
+        assert overlay_reader.get_tag_status(USER_TAG_ID_OFFSET + 999, 1000) is None
+
+    def test_list_tag_statuses_all(self, overlay_reader, overlay_session_factory):
+        tag_id1 = USER_TAG_ID_OFFSET + 210
+        tag_id2 = USER_TAG_ID_OFFSET + 211
+        format_id = 1000
+        with overlay_session_factory() as session:
+            session.add(UserTag(tag_id=tag_id1, source_tag="s1", tag="lst_stat1"))
+            session.add(UserTag(tag_id=tag_id2, source_tag="s2", tag="lst_stat2"))
+            session.add(self._make_patch(tag_id1, format_id))
+            session.add(self._make_patch(tag_id2, format_id, deprecated=True))
+            session.commit()
+
+        statuses = overlay_reader.list_tag_statuses()
+        assert len(statuses) == 2
+        deprecated_flags = {s.tag_id: s.deprecated for s in statuses}
+        assert deprecated_flags[tag_id2] is True
+
+    def test_list_tag_statuses_filtered(self, overlay_reader, overlay_session_factory):
+        tag_id = USER_TAG_ID_OFFSET + 220
+        format_id = 1000
+        with overlay_session_factory() as session:
+            session.add(UserTag(tag_id=tag_id, source_tag="fs", tag="filtered_stat_tag"))
+            session.add(self._make_patch(tag_id, format_id))
+            session.commit()
+
+        statuses = overlay_reader.list_tag_statuses(tag_id=tag_id)
+        assert len(statuses) == 1
+        assert statuses[0].tag_id == tag_id
+
+    def test_list_tag_statuses_returns_empty_for_unknown(self, overlay_reader, overlay_session_factory):
+        tag_id = USER_TAG_ID_OFFSET + 230
+        with overlay_session_factory() as session:
+            session.add(UserTag(tag_id=tag_id, source_tag="ns", tag="no_status_tag"))
+            session.commit()
+
+        statuses = overlay_reader.list_tag_statuses(tag_id=tag_id)
+        assert statuses == []
+
+
+class TestOverlayTagReaderSearch:
+    """search_tags のキーワードヒット動作を検証する。"""
+
+    def test_search_tags_exact_match(self, overlay_reader, overlay_session_factory):
+        tag_id = USER_TAG_ID_OFFSET + 300
+        with overlay_session_factory() as session:
+            session.add(UserTag(tag_id=tag_id, source_tag="srch_src", tag="search_exact"))
+            session.commit()
+
+        rows = overlay_reader.search_tags("search_exact")
+        assert len(rows) == 1
+        assert rows[0]["tag_id"] == tag_id
+        assert rows[0]["tag"] == "search_exact"
+        assert rows[0]["source_tag"] == "srch_src"
+
+    def test_search_tags_partial_match(self, overlay_reader, overlay_session_factory):
+        tag_id = USER_TAG_ID_OFFSET + 310
+        with overlay_session_factory() as session:
+            session.add(UserTag(tag_id=tag_id, source_tag="ps", tag="partial_keyword_result"))
+            session.commit()
+
+        rows = overlay_reader.search_tags("keyword", partial=True)
+        assert len(rows) == 1
+        assert rows[0]["tag_id"] == tag_id
+
+    def test_search_tags_not_found(self, overlay_reader):
+        assert overlay_reader.search_tags("no_such_tag") == []
+
+    def test_search_tags_with_status(self, overlay_reader, overlay_session_factory):
+        tag_id = USER_TAG_ID_OFFSET + 320
+        format_id = 1000
+        with overlay_session_factory() as session:
+            session.add(UserTag(tag_id=tag_id, source_tag="ws_src", tag="with_status_tag"))
+            session.add(
+                UserTagStatusPatch(
+                    target_scope="user",
+                    target_tag_id=tag_id,
+                    format_id=format_id,
+                    type_id=0,
+                    alias=False,
+                    preferred_scope="user",
+                    preferred_tag_id=tag_id,
+                    deprecated=True,
+                )
+            )
+            session.commit()
+
+        rows = overlay_reader.search_tags("with_status_tag")
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["deprecated"] is True
+        assert row["alias"] is False
+        assert str(format_id) in row["format_statuses"]
+
+    def test_search_tags_row_fields(self, overlay_reader, overlay_session_factory):
+        tag_id = USER_TAG_ID_OFFSET + 330
+        with overlay_session_factory() as session:
+            session.add(UserTag(tag_id=tag_id, source_tag="rf_src", tag="row_fields_tag"))
+            session.commit()
+
+        rows = overlay_reader.search_tags("row_fields_tag")
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["usage_count"] == 0
+        assert row["type_name"] == ""
+        assert row["translations"] == {}
+        assert row["format_statuses"] == {}
+
+
+class TestOverlayTagReaderEmpty:
+    """空 DB で各メソッドが安全にデフォルト値を返すことを検証する。"""
+
+    def test_get_tag_by_id_empty_db(self, overlay_reader):
+        assert overlay_reader.get_tag_by_id(USER_TAG_ID_OFFSET + 1) is None
+
+    def test_get_tag_id_by_name_empty_db(self, overlay_reader):
+        assert overlay_reader.get_tag_id_by_name("anything") is None
+
+    def test_list_tags_empty_db(self, overlay_reader):
+        assert overlay_reader.list_tags() == []
+
+    def test_get_all_tag_ids_empty_db(self, overlay_reader):
+        assert overlay_reader.get_all_tag_ids() == []
+
+    def test_get_max_tag_id_empty_db(self, overlay_reader):
+        assert overlay_reader.get_max_tag_id() == 0
+
+    def test_search_tag_ids_empty_db(self, overlay_reader):
+        assert overlay_reader.search_tag_ids("anything") == []
+
+    def test_get_tag_status_empty_db(self, overlay_reader):
+        assert overlay_reader.get_tag_status(USER_TAG_ID_OFFSET + 1, 1000) is None
+
+    def test_list_tag_statuses_empty_db(self, overlay_reader):
+        assert overlay_reader.list_tag_statuses() == []
+
+    def test_search_tags_empty_db(self, overlay_reader):
+        assert overlay_reader.search_tags("anything") == []
+
+    def test_stub_methods_return_defaults(self, overlay_reader):
+        assert overlay_reader.get_translations(USER_TAG_ID_OFFSET + 1) == []
+        assert overlay_reader.list_translations() == []
+        assert overlay_reader.get_translations_batch([]) == {}
+        assert overlay_reader.get_format_name(1000) is None
+        assert overlay_reader.get_format_id("any") == 0
+        assert overlay_reader.get_format_map() == {}
+        assert overlay_reader.get_tag_format_ids() == []
+        assert overlay_reader.get_tag_formats() == []
+        assert overlay_reader.get_tag_languages() == []
+        assert overlay_reader.get_type_mapping_map() == {}
+        assert overlay_reader.get_type_name_by_format_type_id(1000, 0) is None
+        assert overlay_reader.get_type_name_id("unknown") is None
+        assert overlay_reader.get_type_id_for_format("unknown", 1000) is None
+        assert overlay_reader.get_usage_count(USER_TAG_ID_OFFSET + 1, 1000) is None
+        assert overlay_reader.list_usage_counts() == []
+        assert overlay_reader.get_tag_types(1000) == []
+        assert overlay_reader.get_all_types() == []
+        assert overlay_reader.get_unknown_type_tag_ids(1000) == []
+        assert overlay_reader.get_metadata_value("version") is None
+        assert overlay_reader.search_tags_bulk(["tag"]) == {}


### PR DESCRIPTION
## Summary
- USER_TAGS / USER_TAG_STATUS_PATCH を読む `OverlayTagReader` を `db/overlay_reader.py` に新設
- `get_default_reader()` で user DB が存在する場合は `OverlayTagReader` を使用するよう変更
- tag_id / keyword / status の基本読み取りメソッドを実装（format/translation 系は stub）
- `MergedTagReader.__init__` の `user_repo` 型ヒントを `TagReader | OverlayTagReader | None` に更新

## Test plan
- [x] `test_overlay_reader.py` (30テスト) — get_tag_by_id, get_tag_status, search_tags の基本動作、空 DB 安全性
- [x] 既存全テスト `not slow and not network` 399件 PASS

Closes #66