### PR TITLE
feat(overlay): UserTagRepository + scope ルーティング (#67)

### DIFF
--- a/src/genai_tag_db_tools/db/user_tag_repository.py
+++ b/src/genai_tag_db_tools/db/user_tag_repository.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from logging import getLogger
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from genai_tag_db_tools.db.schema import USER_TAG_ID_OFFSET, UserTag, UserTagStatusPatch
+
+
+class UserTagRepository:
+    """user DB の USER_TAGS / USER_TAG_STATUS_PATCH への書き込みを担当する。"""
+
+    def __init__(self, session_factory: Callable[[], Session]) -> None:
+        self.logger = getLogger(__name__)
+        self._session_factory = session_factory
+
+    def create_user_tag(self, source_tag: str, tag: str) -> int:
+        """USER_TAGS にタグを新規作成し tag_id を返す。
+
+        既存の tag (同一 tag 文字列) があれば既存の tag_id を返す。
+        tag_id は max(tag_id) + 1 で採番し USER_TAG_ID_OFFSET (1_000_000_000) 以上を保証する。
+
+        Args:
+            source_tag: ソースタグ文字列。
+            tag: 正規タグ文字列。
+
+        Returns:
+            採番または既存の tag_id。
+        """
+        with self._session_factory() as session:
+            existing = session.query(UserTag).filter(UserTag.tag == tag).one_or_none()
+            if existing is not None:
+                return existing.tag_id
+
+            max_id = session.query(func.max(UserTag.tag_id)).scalar()
+            if max_id is None:
+                new_id = USER_TAG_ID_OFFSET
+            else:
+                new_id = max(int(max_id) + 1, USER_TAG_ID_OFFSET)
+
+            assert new_id >= USER_TAG_ID_OFFSET, f"tag_id={new_id} が OFFSET 未満です"
+
+            new_tag = UserTag(tag_id=new_id, source_tag=source_tag, tag=tag)
+            session.add(new_tag)
+            session.commit()
+            return new_id
+
+    def write_patch(
+        self,
+        target_scope: str,
+        target_tag_id: int,
+        format_id: int,
+        type_id: int,
+        alias: bool,
+        preferred_scope: str,
+        preferred_tag_id: int,
+        deprecated: bool = False,
+    ) -> None:
+        """USER_TAG_STATUS_PATCH に INSERT or UPDATE する。
+
+        既存行 (同一 composite PK) があれば UPDATE。
+
+        Args:
+            target_scope: パッチ対象スコープ ("base" or "user")。
+            target_tag_id: パッチ対象タグID。
+            format_id: フォーマットID。
+            type_id: タイプID。
+            alias: エイリアスかどうか。
+            preferred_scope: 推奨タグスコープ ("base" or "user")。
+            preferred_tag_id: 推奨タグID。
+            deprecated: 非推奨かどうか。
+        """
+        with self._session_factory() as session:
+            existing = (
+                session.query(UserTagStatusPatch)
+                .filter(
+                    UserTagStatusPatch.target_scope == target_scope,
+                    UserTagStatusPatch.target_tag_id == target_tag_id,
+                    UserTagStatusPatch.format_id == format_id,
+                )
+                .one_or_none()
+            )
+
+            if existing is not None:
+                existing.type_id = type_id
+                existing.alias = alias
+                existing.preferred_scope = preferred_scope
+                existing.preferred_tag_id = preferred_tag_id
+                existing.deprecated = deprecated
+            else:
+                patch = UserTagStatusPatch(
+                    target_scope=target_scope,
+                    target_tag_id=target_tag_id,
+                    format_id=format_id,
+                    type_id=type_id,
+                    alias=alias,
+                    preferred_scope=preferred_scope,
+                    preferred_tag_id=preferred_tag_id,
+                    deprecated=deprecated,
+                )
+                session.add(patch)
+
+            session.commit()

--- a/src/genai_tag_db_tools/models.py
+++ b/src/genai_tag_db_tools/models.py
@@ -243,6 +243,7 @@ class TagRegisterRequest(BaseModel):
     alias: bool = Field(default=False, description="エイリアスかどうか")
     preferred_tag: str | None = Field(default=None, description="推奨タグ(alias時のみ)")
     translations: list[TagTranslationInput] | None = Field(default=None, description="翻訳の追加")
+    scope: Literal["base", "user"] = Field(default="base", description="登録先DB種別")
 
 
 class TagRegisterResult(BaseModel):

--- a/src/genai_tag_db_tools/services/tag_register.py
+++ b/src/genai_tag_db_tools/services/tag_register.py
@@ -8,10 +8,12 @@ from genai_tag_db_tools.db.repository import (
     get_default_reader,
     get_default_repository,
 )
+from genai_tag_db_tools.db.schema import USER_TAG_ID_OFFSET
 from genai_tag_db_tools.utils.cleanup_str import TagCleaner
 
 if TYPE_CHECKING:
     from genai_tag_db_tools.db.repository import MergedTagReader
+    from genai_tag_db_tools.db.user_tag_repository import UserTagRepository
     from genai_tag_db_tools.models import (
         AliasRegisterInput,
         AliasRegisterItemResult,
@@ -118,10 +120,19 @@ class TagRegisterService:
         self,
         repository: TagRepository | None = None,
         reader: "MergedTagReader | None" = None,
+        user_tag_repo: "UserTagRepository | None" = None,
     ):
         self.logger = logging.getLogger(self.__class__.__name__)
         self._repo = repository if repository else get_default_repository()
         self._reader = reader or get_default_reader()
+        if user_tag_repo is not None:
+            self._user_tag_repo: "UserTagRepository | None" = user_tag_repo
+        else:
+            from genai_tag_db_tools.db.runtime import get_user_session_factory_optional
+            from genai_tag_db_tools.db.user_tag_repository import UserTagRepository as _UserTagRepository
+
+            user_factory = get_user_session_factory_optional()
+            self._user_tag_repo = _UserTagRepository(user_factory) if user_factory else None
 
     def _resolve_format_id(self, format_name: str) -> int:
         """フォーマット名からformat_idを解決する。存在しない場合は自動作成。
@@ -208,12 +219,16 @@ class TagRegisterService:
 
         Automatically creates format_name and type_name if they don't exist.
         For unknown type_name, uses type_id=0 by default.
+        scope="user" のとき overlay path (USER_TAGS / USER_TAG_STATUS_PATCH) に書く。
 
         Args:
             request: Tag registration request.
         Returns:
             TagRegisterResult indicating whether the tag was created.
         """
+        if request.scope == "user":
+            return self._register_user_tag(request)
+
         from genai_tag_db_tools.models import TagRegisterResult
 
         tag = request.tag
@@ -249,6 +264,58 @@ class TagRegisterService:
             alias=request.alias,
             preferred_tag_id=preferred_tag_id,
             type_id=type_id,
+        )
+
+        return TagRegisterResult(created=created, tag_id=tag_id)
+
+    def _register_user_tag(self, request: "TagRegisterRequest") -> "TagRegisterResult":
+        """USER_TAGS / USER_TAG_STATUS_PATCH にタグを登録する。
+
+        Args:
+            request: scope="user" のタグ登録リクエスト。
+
+        Returns:
+            TagRegisterResult indicating whether the tag was created.
+
+        Raises:
+            RuntimeError: user DB が未初期化の場合。
+            ValueError: alias=True なのに preferred_tag が未指定/未存在の場合。
+        """
+        from genai_tag_db_tools.models import TagRegisterResult
+
+        if self._user_tag_repo is None:
+            raise RuntimeError("User DB が未初期化です。init_user_db() を先に呼んでください。")
+
+        tag = request.tag
+        source_tag = request.source_tag or request.tag
+
+        fmt_id = self._resolve_format_id(request.format_name)
+        type_name = request.type_name or "unknown"
+        type_id = self._resolve_type_id(type_name, request.format_name, fmt_id)
+
+        existing_id = self._reader.get_tag_id_by_name(tag, partial=False)
+        tag_id = self._user_tag_repo.create_user_tag(source_tag, tag)
+        created = existing_id is None
+
+        if request.alias:
+            if not request.preferred_tag:
+                raise ValueError("alias=True の場合 preferred_tag が必須です")
+            preferred_tag_id = self._reader.get_tag_id_by_name(request.preferred_tag, partial=False)
+            if preferred_tag_id is None:
+                raise ValueError(f"推奨タグが見つかりません: {request.preferred_tag}")
+            preferred_scope = "base" if preferred_tag_id < USER_TAG_ID_OFFSET else "user"
+        else:
+            preferred_tag_id = tag_id
+            preferred_scope = "user"
+
+        self._user_tag_repo.write_patch(
+            target_scope="user",
+            target_tag_id=tag_id,
+            format_id=fmt_id,
+            type_id=type_id,
+            alias=request.alias,
+            preferred_scope=preferred_scope,
+            preferred_tag_id=preferred_tag_id,
         )
 
         return TagRegisterResult(created=created, tag_id=tag_id)

--- a/tests/unit/test_user_tag_repository.py
+++ b/tests/unit/test_user_tag_repository.py
@@ -1,0 +1,428 @@
+"""UserTagRepository および TagRegisterService の overlay scope テスト。"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy.orm import sessionmaker
+
+from genai_tag_db_tools.db.runtime import _create_engine
+from genai_tag_db_tools.db.schema import (
+    USER_TAG_ID_OFFSET,
+    Base,
+    UserOverlayBase,
+    UserTagStatusPatch,
+)
+from genai_tag_db_tools.db.user_tag_repository import UserTagRepository
+from genai_tag_db_tools.models import TagRegisterRequest
+from genai_tag_db_tools.services.tag_register import TagRegisterService
+
+
+# --- fixtures ---
+
+
+@pytest.fixture()
+def user_engine(tmp_path: Path):
+    """tmp_path に Base + UserOverlayBase 両スキーマを持つ SQLite エンジン。"""
+    db_path = tmp_path / "user_test.sqlite"
+    engine = _create_engine(db_path)
+    Base.metadata.create_all(engine)
+    UserOverlayBase.metadata.create_all(engine)
+    yield engine
+    engine.dispose()
+
+
+@pytest.fixture()
+def user_session_factory(user_engine):
+    """user DB セッションファクトリ。"""
+    return sessionmaker(bind=user_engine, autoflush=False, autocommit=False)
+
+
+@pytest.fixture()
+def user_repo(user_session_factory):
+    return UserTagRepository(user_session_factory)
+
+
+# --- TestCreateUserTag ---
+
+
+class TestCreateUserTag:
+    def test_create_new_tag(self, user_repo):
+        """正常作成: 新しいタグが USER_TAGS に登録される。"""
+        tag_id = user_repo.create_user_tag("my_src", "my_tag")
+        assert tag_id >= USER_TAG_ID_OFFSET
+
+    def test_create_returns_offset_for_first_tag(self, user_repo):
+        """初回登録は USER_TAG_ID_OFFSET そのもの。"""
+        tag_id = user_repo.create_user_tag("src", "first_tag")
+        assert tag_id == USER_TAG_ID_OFFSET
+
+    def test_create_duplicate_returns_existing_id(self, user_repo):
+        """同一 tag 文字列を登録すると既存 tag_id を返す。"""
+        id1 = user_repo.create_user_tag("src", "dup_tag")
+        id2 = user_repo.create_user_tag("src2", "dup_tag")
+        assert id1 == id2
+
+    def test_tag_id_always_gte_offset(self, user_repo):
+        """複数タグ登録後も tag_id >= USER_TAG_ID_OFFSET を保証。"""
+        for i in range(5):
+            tid = user_repo.create_user_tag(f"src{i}", f"tag_{i}")
+            assert tid >= USER_TAG_ID_OFFSET
+
+    def test_sequential_ids_increment(self, user_repo):
+        """連続登録で tag_id が単調増加する。"""
+        id1 = user_repo.create_user_tag("s1", "tag_a")
+        id2 = user_repo.create_user_tag("s2", "tag_b")
+        assert id2 > id1
+
+
+# --- TestWritePatch ---
+
+
+class TestWritePatch:
+    def _make_patch_kwargs(self, **overrides) -> dict:
+        base: dict = dict(
+            target_scope="user",
+            target_tag_id=USER_TAG_ID_OFFSET + 1,
+            format_id=1000,
+            type_id=0,
+            alias=False,
+            preferred_scope="user",
+            preferred_tag_id=USER_TAG_ID_OFFSET + 1,
+            deprecated=False,
+        )
+        base.update(overrides)
+        return base
+
+    def test_insert_new_patch(self, user_repo, user_session_factory):
+        """新規パッチが INSERT される。"""
+        user_repo.write_patch(**self._make_patch_kwargs())
+        with user_session_factory() as session:
+            row = (
+                session.query(UserTagStatusPatch)
+                .filter_by(
+                    target_scope="user",
+                    target_tag_id=USER_TAG_ID_OFFSET + 1,
+                    format_id=1000,
+                )
+                .one_or_none()
+            )
+        assert row is not None
+        assert row.alias is False
+
+    def test_update_existing_patch(self, user_repo, user_session_factory):
+        """既存行 (同一 composite PK) は UPDATE される。"""
+        user_repo.write_patch(**self._make_patch_kwargs())
+        # alias=True に更新 (preferred は別タグ)
+        updated_kwargs = self._make_patch_kwargs(
+            alias=True,
+            preferred_scope="base",
+            preferred_tag_id=100,
+        )
+        user_repo.write_patch(**updated_kwargs)
+        with user_session_factory() as session:
+            rows = (
+                session.query(UserTagStatusPatch)
+                .filter_by(
+                    target_scope="user",
+                    target_tag_id=USER_TAG_ID_OFFSET + 1,
+                    format_id=1000,
+                )
+                .all()
+            )
+        assert len(rows) == 1
+        assert rows[0].alias is True
+        assert rows[0].preferred_scope == "base"
+
+    def test_composite_pk_uniqueness(self, user_repo, user_session_factory):
+        """異なる format_id は別行になる。"""
+        user_repo.write_patch(**self._make_patch_kwargs(format_id=1000))
+        user_repo.write_patch(**self._make_patch_kwargs(format_id=2000))
+        with user_session_factory() as session:
+            count = session.query(UserTagStatusPatch).count()
+        assert count == 2
+
+    def test_cross_scope_alias_patch(self, user_repo):
+        """user tag が base tag を preferred に持つクロススコープ alias が書ける。"""
+        user_repo.write_patch(
+            target_scope="user",
+            target_tag_id=USER_TAG_ID_OFFSET + 1,
+            format_id=1000,
+            type_id=0,
+            alias=True,
+            preferred_scope="base",
+            preferred_tag_id=100,
+        )
+
+
+# --- DummyRepo / DummyReader (既存テストパターンに準拠) ---
+
+
+class _DummyRepo:
+    def __init__(self) -> None:
+        self.created_tags: list[tuple[str, str]] = []
+        self.status_updates: list[tuple] = []
+        self._tag_ids: dict[str, int] = {}
+        self.format_creations: list[str] = []
+        self.mapping_creations: list[tuple] = []
+
+    def get_format_id(self, format_name: str) -> int | None:
+        return {"danbooru": 1}.get(format_name)
+
+    def get_type_name_id(self, type_name: str) -> int | None:
+        return {"unknown": 0, "general": 1, "character": 2}.get(type_name)
+
+    def get_tag_id_by_name(self, tag: str, partial: bool = False) -> int | None:
+        return self._tag_ids.get(tag)
+
+    def create_tag(self, source_tag: str, tag: str) -> int:
+        self.created_tags.append((source_tag, tag))
+        tag_id = 10
+        self._tag_ids[tag] = tag_id
+        return tag_id
+
+    def update_tag_status(
+        self,
+        tag_id: int,
+        format_id: int,
+        alias: bool,
+        preferred_tag_id: int,
+        type_id: int | None = None,
+    ) -> None:
+        self.status_updates.append((tag_id, format_id, alias, preferred_tag_id, type_id))
+
+    def add_or_update_translation(self, tag_id: int, language: str, translation: str) -> None:
+        pass
+
+    def create_type_name_if_not_exists(self, type_name: str, description: str | None = None) -> int:
+        return {"unknown": 0, "general": 1, "character": 2}.get(type_name, 0)
+
+    def create_format_if_not_exists(
+        self,
+        format_name: str,
+        description: str | None = None,
+        reader: object = None,
+    ) -> int:
+        self.format_creations.append(format_name)
+        self._auto_format_id = getattr(self, "_auto_format_id", 1000) + 1
+        return self._auto_format_id
+
+    def get_next_type_id(self, format_id: int) -> int:
+        return 1
+
+    def create_type_format_mapping_if_not_exists(
+        self,
+        format_id: int,
+        type_id: int,
+        type_name_id: int,
+        description: str | None = None,
+    ) -> int:
+        self.mapping_creations.append((format_id, type_id, type_name_id))
+        return type_id
+
+
+class _DummyReader:
+    def __init__(self, repo: _DummyRepo) -> None:
+        self._repo = repo
+
+    def get_format_id(self, format_name: str) -> int:
+        result = self._repo.get_format_id(format_name)
+        if result is None:
+            raise ValueError(f"Format not found: {format_name}")
+        return result
+
+    def get_type_id_for_format(self, type_name: str, format_id: int) -> int | None:
+        return self._repo.get_type_name_id(type_name)
+
+    def get_tag_id_by_name(self, tag: str, partial: bool = False) -> int | None:
+        return self._repo.get_tag_id_by_name(tag, partial=partial)
+
+
+# --- TestTagRegisterServiceUserScope ---
+
+
+class TestTagRegisterServiceUserScope:
+    """scope="user" のとき overlay path が使われることを確認。"""
+
+    def test_register_user_tag_calls_create_and_write_patch(self):
+        """create_user_tag と write_patch が呼ばれる。"""
+        repo = _DummyRepo()
+        reader = _DummyReader(repo)
+        mock_user_repo = MagicMock()
+        mock_user_repo.create_user_tag.return_value = USER_TAG_ID_OFFSET + 1
+
+        service = TagRegisterService(repository=repo, reader=reader, user_tag_repo=mock_user_repo)
+        request = TagRegisterRequest(
+            tag="user_tag",
+            format_name="danbooru",
+            type_name="general",
+            scope="user",
+        )
+
+        result = service.register_tag(request)
+
+        mock_user_repo.create_user_tag.assert_called_once()
+        mock_user_repo.write_patch.assert_called_once()
+        assert result.tag_id == USER_TAG_ID_OFFSET + 1
+
+    def test_register_user_tag_without_user_db_raises(self):
+        """user_tag_repo=None のとき RuntimeError が発生する。"""
+        repo = _DummyRepo()
+        reader = _DummyReader(repo)
+        service = TagRegisterService(repository=repo, reader=reader, user_tag_repo=None)
+        request = TagRegisterRequest(
+            tag="user_tag",
+            format_name="danbooru",
+            type_name="general",
+            scope="user",
+        )
+        with pytest.raises(RuntimeError, match="User DB"):
+            service.register_tag(request)
+
+    def test_register_user_alias_resolves_preferred_base_scope(self):
+        """alias=True で preferred が base タグのとき preferred_scope="base" になる。"""
+        repo = _DummyRepo()
+        repo._tag_ids["preferred_tag"] = 500  # base DB のタグ (OFFSET 未満)
+        reader = _DummyReader(repo)
+        mock_user_repo = MagicMock()
+        mock_user_repo.create_user_tag.return_value = USER_TAG_ID_OFFSET + 1
+
+        service = TagRegisterService(repository=repo, reader=reader, user_tag_repo=mock_user_repo)
+        request = TagRegisterRequest(
+            tag="alias_tag",
+            format_name="danbooru",
+            type_name="general",
+            alias=True,
+            preferred_tag="preferred_tag",
+            scope="user",
+        )
+
+        service.register_tag(request)
+
+        call_kwargs = mock_user_repo.write_patch.call_args.kwargs
+        assert call_kwargs["alias"] is True
+        assert call_kwargs["preferred_tag_id"] == 500
+        assert call_kwargs["preferred_scope"] == "base"
+
+    def test_register_user_non_alias_uses_self_as_preferred(self):
+        """alias=False のとき preferred_scope="user" かつ preferred_tag_id=tag_id。"""
+        repo = _DummyRepo()
+        reader = _DummyReader(repo)
+        mock_user_repo = MagicMock()
+        new_tag_id = USER_TAG_ID_OFFSET + 10
+        mock_user_repo.create_user_tag.return_value = new_tag_id
+
+        service = TagRegisterService(repository=repo, reader=reader, user_tag_repo=mock_user_repo)
+        request = TagRegisterRequest(
+            tag="solo_tag",
+            format_name="danbooru",
+            type_name="general",
+            scope="user",
+        )
+
+        service.register_tag(request)
+
+        call_kwargs = mock_user_repo.write_patch.call_args.kwargs
+        assert call_kwargs["alias"] is False
+        assert call_kwargs["preferred_scope"] == "user"
+        assert call_kwargs["preferred_tag_id"] == new_tag_id
+        assert call_kwargs["target_scope"] == "user"
+
+    def test_register_user_tag_result_created_true_for_new_tag(self):
+        """存在しないタグは created=True を返す。"""
+        repo = _DummyRepo()
+        reader = _DummyReader(repo)
+        mock_user_repo = MagicMock()
+        mock_user_repo.create_user_tag.return_value = USER_TAG_ID_OFFSET + 1
+
+        service = TagRegisterService(repository=repo, reader=reader, user_tag_repo=mock_user_repo)
+        request = TagRegisterRequest(
+            tag="brand_new",
+            format_name="danbooru",
+            type_name="general",
+            scope="user",
+        )
+
+        result = service.register_tag(request)
+        assert result.created is True
+
+    def test_register_user_tag_result_created_false_for_existing_tag(self):
+        """既存タグ (reader で見つかる) は created=False を返す。"""
+        repo = _DummyRepo()
+        repo._tag_ids["existing_tag"] = USER_TAG_ID_OFFSET + 5
+        reader = _DummyReader(repo)
+        mock_user_repo = MagicMock()
+        mock_user_repo.create_user_tag.return_value = USER_TAG_ID_OFFSET + 5
+
+        service = TagRegisterService(repository=repo, reader=reader, user_tag_repo=mock_user_repo)
+        request = TagRegisterRequest(
+            tag="existing_tag",
+            format_name="danbooru",
+            type_name="general",
+            scope="user",
+        )
+
+        result = service.register_tag(request)
+        assert result.created is False
+
+
+# --- TestTagRegisterServiceBaseScope ---
+
+
+class TestTagRegisterServiceBaseScope:
+    """scope="base" (既定) のとき既存パスが使われることを確認。"""
+
+    def test_base_scope_uses_create_tag_on_base_repo(self):
+        """scope="base" は TAGS テーブルへの create_tag を呼ぶ。"""
+        repo = _DummyRepo()
+        reader = _DummyReader(repo)
+        service = TagRegisterService(repository=repo, reader=reader)
+        request = TagRegisterRequest(
+            tag="base_tag",
+            format_name="danbooru",
+            type_name="general",
+            scope="base",
+        )
+
+        result = service.register_tag(request)
+
+        assert repo.created_tags == [("base_tag", "base_tag")]
+        assert len(repo.status_updates) == 1
+        assert result.tag_id == 10
+
+    def test_default_scope_is_base(self):
+        """scope を省略すると "base" として動作する。"""
+        repo = _DummyRepo()
+        reader = _DummyReader(repo)
+        service = TagRegisterService(repository=repo, reader=reader)
+        request = TagRegisterRequest(
+            tag="default_tag",
+            format_name="danbooru",
+            type_name="general",
+        )
+
+        result = service.register_tag(request)
+
+        assert repo.created_tags == [("default_tag", "default_tag")]
+        assert len(repo.status_updates) == 1
+        assert result.tag_id == 10
+
+    def test_base_scope_does_not_call_user_tag_repo(self):
+        """scope="base" のとき user_tag_repo メソッドは呼ばれない。"""
+        repo = _DummyRepo()
+        reader = _DummyReader(repo)
+        mock_user_repo = MagicMock()
+        service = TagRegisterService(repository=repo, reader=reader, user_tag_repo=mock_user_repo)
+        request = TagRegisterRequest(
+            tag="base_tag",
+            format_name="danbooru",
+            type_name="general",
+            scope="base",
+        )
+
+        service.register_tag(request)
+
+        mock_user_repo.create_user_tag.assert_not_called()
+        mock_user_repo.write_patch.assert_not_called()


### PR DESCRIPTION
## Summary
- USER_TAGS / USER_TAG_STATUS_PATCH への書き込みを担う `UserTagRepository` を新設
- `TagRegisterRequest` に `scope: Literal["base","user"] = "base"` フィールドを追加（後方互換）
- `TagRegisterService.register_tag` で `scope="user"` のとき overlay path に分岐する `_register_user_tag` を実装

## Test plan
- [x] `TestCreateUserTag` — 正常作成、重複タグは既存ID返却、tag_id >= OFFSET 確認
- [x] `TestWritePatch` — 新規 INSERT、既存行 UPDATE、composite PK 一意性確認、クロススコープ alias
- [x] `TestTagRegisterServiceUserScope` — scope="user" で create_user_tag + write_patch が呼ばれることを確認、user DB 未初期化時 RuntimeError、alias 解決ロジック
- [x] `TestTagRegisterServiceBaseScope` — scope="base" (既定) は TAGS/TAG_STATUS を使う既存パスを維持
- [x] 既存全テスト 387 件 `not slow and not network` pass

Closes #67