### PR TITLE
feat(overlay): translation/usage overlay patch (#68)

### DIFF
--- a/src/genai_tag_db_tools/db/overlay_reader.py
+++ b/src/genai_tag_db_tools/db/overlay_reader.py
@@ -15,6 +15,8 @@ from genai_tag_db_tools.db.schema import (
     TagUsageCounts,
     UserTag,
     UserTagStatusPatch,
+    UserTagTranslationPatch,
+    UserTagUsagePatch,
 )
 from genai_tag_db_tools.models import TagSearchRow
 
@@ -218,17 +220,57 @@ class OverlayTagReader:
         return rows
 
     # ------------------------------------------------------------------
-    # stub メソッド (フェーズ2以降で実装予定)
+    # 翻訳取得 (USER_TAG_TRANSLATION_PATCH)
     # ------------------------------------------------------------------
 
     def get_translations(self, tag_id: int) -> list[TagTranslation]:
-        return []
+        """USER_TAG_TRANSLATION_PATCH から翻訳を取得し TagTranslation オブジェクトに変換する。"""
+        with self.session_factory() as session:
+            rows = (
+                session.query(UserTagTranslationPatch)
+                .filter(
+                    UserTagTranslationPatch.target_scope == "user",
+                    UserTagTranslationPatch.target_tag_id == tag_id,
+                )
+                .all()
+            )
+            return [
+                TagTranslation(
+                    translation_id=r.patch_id,
+                    tag_id=r.target_tag_id,
+                    language=r.language,
+                    translation=r.translation,
+                )
+                for r in rows
+            ]
 
     def list_translations(self) -> list[TagTranslation]:
         return []
 
     def get_translations_batch(self, tag_ids: list[int]) -> dict[int, list[TagTranslation]]:
-        return {}
+        """複数 tag_id の翻訳をバッチ取得する。"""
+        if not tag_ids:
+            return {}
+        with self.session_factory() as session:
+            rows = (
+                session.query(UserTagTranslationPatch)
+                .filter(
+                    UserTagTranslationPatch.target_scope == "user",
+                    UserTagTranslationPatch.target_tag_id.in_(tag_ids),
+                )
+                .all()
+            )
+        result: dict[int, list[TagTranslation]] = {}
+        for r in rows:
+            result.setdefault(r.target_tag_id, []).append(
+                TagTranslation(
+                    translation_id=r.patch_id,
+                    tag_id=r.target_tag_id,
+                    language=r.language,
+                    translation=r.translation,
+                )
+            )
+        return result
 
     def get_format_name(self, format_id: int) -> str | None:
         return None
@@ -261,12 +303,36 @@ class OverlayTagReader:
         return None
 
     def get_usage_count(self, tag_id: int, format_id: int) -> int | None:
-        return None
+        """USER_TAG_USAGE_PATCH から usage count を取得する。"""
+        with self.session_factory() as session:
+            row = (
+                session.query(UserTagUsagePatch)
+                .filter(
+                    UserTagUsagePatch.target_scope == "user",
+                    UserTagUsagePatch.target_tag_id == tag_id,
+                    UserTagUsagePatch.format_id == format_id,
+                )
+                .one_or_none()
+            )
+            return row.count if row is not None else None
 
     def list_usage_counts(
         self, tag_id: int | None = None, format_id: int | None = None
     ) -> list[TagUsageCounts]:
-        return []
+        """USER_TAG_USAGE_PATCH を TagUsageCounts オブジェクトに変換して返す。"""
+        with self.session_factory() as session:
+            query = session.query(UserTagUsagePatch).filter(
+                UserTagUsagePatch.target_scope == "user"
+            )
+            if tag_id is not None:
+                query = query.filter(UserTagUsagePatch.target_tag_id == tag_id)
+            if format_id is not None:
+                query = query.filter(UserTagUsagePatch.format_id == format_id)
+            rows = query.all()
+            return [
+                TagUsageCounts(tag_id=r.target_tag_id, format_id=r.format_id, count=r.count)
+                for r in rows
+            ]
 
     def get_tag_types(self, format_id: int) -> list[str]:
         return []

--- a/src/genai_tag_db_tools/db/schema.py
+++ b/src/genai_tag_db_tools/db/schema.py
@@ -251,3 +251,45 @@ class UserTagStatusPatch(UserOverlayBase):
         Index("ix_patch_target", "target_scope", "target_tag_id"),
         Index("ix_patch_preferred", "preferred_scope", "preferred_tag_id"),
     )
+
+
+class UserTagTranslationPatch(UserOverlayBase):
+    """base / user タグへの翻訳パッチ。
+    TAG_TRANSLATIONS の FK なし版。target_scope + target_tag_id で対象タグを指定する。
+    """
+
+    __tablename__ = "USER_TAG_TRANSLATION_PATCH"
+
+    patch_id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    target_scope: Mapped[str] = mapped_column()
+    target_tag_id: Mapped[int] = mapped_column()
+    language: Mapped[str] = mapped_column()
+    translation: Mapped[str] = mapped_column()
+    created_at: Mapped[datetime | None] = mapped_column(DateTime, server_default=func.now(), nullable=True)
+    updated_at: Mapped[datetime | None] = mapped_column(DateTime, server_default=func.now(), nullable=True)
+
+    __table_args__ = (
+        UniqueConstraint("target_scope", "target_tag_id", "language", "translation", name="uix_trans_patch"),
+        CheckConstraint("target_scope IN ('base', 'user')", name="ck_trans_patch_scope"),
+        Index("ix_trans_patch_target", "target_scope", "target_tag_id"),
+    )
+
+
+class UserTagUsagePatch(UserOverlayBase):
+    """base / user タグへの usage count パッチ。
+    TAG_USAGE_COUNTS の FK なし版。
+    """
+
+    __tablename__ = "USER_TAG_USAGE_PATCH"
+
+    target_scope: Mapped[str] = mapped_column(primary_key=True)
+    target_tag_id: Mapped[int] = mapped_column(primary_key=True)
+    format_id: Mapped[int] = mapped_column(primary_key=True)
+    count: Mapped[int] = mapped_column()
+    created_at: Mapped[datetime | None] = mapped_column(DateTime, server_default=func.now(), nullable=True)
+    updated_at: Mapped[datetime | None] = mapped_column(DateTime, server_default=func.now(), nullable=True)
+
+    __table_args__ = (
+        CheckConstraint("target_scope IN ('base', 'user')", name="ck_usage_patch_scope"),
+        Index("ix_usage_patch_target", "target_scope", "target_tag_id"),
+    )

--- a/src/genai_tag_db_tools/db/user_tag_repository.py
+++ b/src/genai_tag_db_tools/db/user_tag_repository.py
@@ -6,7 +6,13 @@ from logging import getLogger
 from sqlalchemy import func
 from sqlalchemy.orm import Session
 
-from genai_tag_db_tools.db.schema import USER_TAG_ID_OFFSET, UserTag, UserTagStatusPatch
+from genai_tag_db_tools.db.schema import (
+    USER_TAG_ID_OFFSET,
+    UserTag,
+    UserTagStatusPatch,
+    UserTagTranslationPatch,
+    UserTagUsagePatch,
+)
 
 
 class UserTagRepository:
@@ -102,4 +108,72 @@ class UserTagRepository:
                 )
                 session.add(patch)
 
+            session.commit()
+
+    def write_translation_patch(
+        self, target_scope: str, target_tag_id: int, language: str, translation: str
+    ) -> None:
+        """USER_TAG_TRANSLATION_PATCH に翻訳を追加する（重複は無視）。
+
+        Args:
+            target_scope: パッチ対象スコープ ("base" or "user")。
+            target_tag_id: パッチ対象タグID。
+            language: 言語コード（例: ja）。
+            translation: 翻訳文字列。
+        """
+        with self._session_factory() as session:
+            existing = (
+                session.query(UserTagTranslationPatch)
+                .filter(
+                    UserTagTranslationPatch.target_scope == target_scope,
+                    UserTagTranslationPatch.target_tag_id == target_tag_id,
+                    UserTagTranslationPatch.language == language,
+                    UserTagTranslationPatch.translation == translation,
+                )
+                .one_or_none()
+            )
+            if existing is not None:
+                return
+            session.add(
+                UserTagTranslationPatch(
+                    target_scope=target_scope,
+                    target_tag_id=target_tag_id,
+                    language=language,
+                    translation=translation,
+                )
+            )
+            session.commit()
+
+    def write_usage_patch(
+        self, target_scope: str, target_tag_id: int, format_id: int, count: int
+    ) -> None:
+        """USER_TAG_USAGE_PATCH に usage count を INSERT or UPDATE する。
+
+        Args:
+            target_scope: パッチ対象スコープ ("base" or "user")。
+            target_tag_id: パッチ対象タグID。
+            format_id: フォーマットID。
+            count: 使用回数。
+        """
+        with self._session_factory() as session:
+            existing = (
+                session.query(UserTagUsagePatch)
+                .filter(
+                    UserTagUsagePatch.target_scope == target_scope,
+                    UserTagUsagePatch.target_tag_id == target_tag_id,
+                    UserTagUsagePatch.format_id == format_id,
+                )
+                .one_or_none()
+            )
+            if existing is not None:
+                existing.count = count
+            else:
+                session.add(
+                    UserTagUsagePatch(
+                        target_scope=target_scope,
+                        target_tag_id=target_tag_id,
+                        format_id=format_id,
+                        count=count,
+                    )
+                )
             session.commit()

--- a/src/genai_tag_db_tools/services/tag_register.py
+++ b/src/genai_tag_db_tools/services/tag_register.py
@@ -318,6 +318,15 @@ class TagRegisterService:
             preferred_tag_id=preferred_tag_id,
         )
 
+        if request.translations:
+            for tr in request.translations:
+                self._user_tag_repo.write_translation_patch(
+                    target_scope="user",
+                    target_tag_id=tag_id,
+                    language=tr.language,
+                    translation=tr.translation,
+                )
+
         return TagRegisterResult(created=created, tag_id=tag_id)
 
     def register_alias_entry(

--- a/tests/unit/test_overlay_translation_usage.py
+++ b/tests/unit/test_overlay_translation_usage.py
@@ -1,0 +1,397 @@
+"""USER_TAG_TRANSLATION_PATCH / USER_TAG_USAGE_PATCH の単体テスト。"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy import StaticPool, create_engine
+from sqlalchemy.orm import sessionmaker
+
+from genai_tag_db_tools.db.overlay_reader import OverlayTagReader
+from genai_tag_db_tools.db.schema import (
+    USER_TAG_ID_OFFSET,
+    Base,
+    UserOverlayBase,
+    UserTag,
+    UserTagTranslationPatch,
+    UserTagUsagePatch,
+)
+from genai_tag_db_tools.db.user_tag_repository import UserTagRepository
+from genai_tag_db_tools.models import TagRegisterRequest, TagTranslationInput
+from genai_tag_db_tools.services.tag_register import TagRegisterService
+
+
+# --- fixtures ---
+
+
+@pytest.fixture()
+def user_engine(tmp_path: Path):
+    """tmp_path に Base + UserOverlayBase 両スキーマを持つ SQLite エンジン。"""
+    db_path = tmp_path / "test_overlay_trans.sqlite"
+    engine = create_engine(
+        f"sqlite:///{db_path}",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    UserOverlayBase.metadata.create_all(engine)
+    yield engine
+    engine.dispose()
+
+
+@pytest.fixture()
+def user_session_factory(user_engine):
+    """テスト用 user DB セッションファクトリ。"""
+    return sessionmaker(bind=user_engine, autoflush=False, autocommit=False)
+
+
+@pytest.fixture()
+def user_repo(user_session_factory):
+    """テスト対象の UserTagRepository。"""
+    return UserTagRepository(user_session_factory)
+
+
+@pytest.fixture()
+def overlay_reader(user_session_factory):
+    """テスト対象の OverlayTagReader。"""
+    return OverlayTagReader(session_factory=user_session_factory)
+
+
+# --- TestUserTagTranslationPatch ---
+
+
+class TestUserTagTranslationPatch:
+    """write_translation_patch の INSERT・重複無視を検証する。"""
+
+    def test_insert_new_translation(self, user_repo, user_session_factory):
+        """新規翻訳が USER_TAG_TRANSLATION_PATCH に INSERT される。"""
+        tag_id = USER_TAG_ID_OFFSET + 1
+        user_repo.write_translation_patch("user", tag_id, "ja", "タグ")
+
+        with user_session_factory() as session:
+            rows = (
+                session.query(UserTagTranslationPatch)
+                .filter_by(target_scope="user", target_tag_id=tag_id)
+                .all()
+            )
+        assert len(rows) == 1
+        assert rows[0].language == "ja"
+        assert rows[0].translation == "タグ"
+
+    def test_duplicate_is_ignored(self, user_repo, user_session_factory):
+        """同一 (scope, tag_id, language, translation) の重複は無視される。"""
+        tag_id = USER_TAG_ID_OFFSET + 2
+        user_repo.write_translation_patch("user", tag_id, "ja", "タグ")
+        user_repo.write_translation_patch("user", tag_id, "ja", "タグ")
+
+        with user_session_factory() as session:
+            count = (
+                session.query(UserTagTranslationPatch)
+                .filter_by(target_scope="user", target_tag_id=tag_id)
+                .count()
+            )
+        assert count == 1
+
+    def test_different_language_creates_separate_row(self, user_repo, user_session_factory):
+        """言語が異なれば別行になる。"""
+        tag_id = USER_TAG_ID_OFFSET + 3
+        user_repo.write_translation_patch("user", tag_id, "ja", "タグ")
+        user_repo.write_translation_patch("user", tag_id, "zh", "标签")
+
+        with user_session_factory() as session:
+            rows = (
+                session.query(UserTagTranslationPatch)
+                .filter_by(target_scope="user", target_tag_id=tag_id)
+                .all()
+            )
+        assert len(rows) == 2
+        languages = {r.language for r in rows}
+        assert languages == {"ja", "zh"}
+
+    def test_different_translation_same_language_creates_separate_row(self, user_repo, user_session_factory):
+        """同一言語でも翻訳文字列が異なれば別行になる（同義語として扱う）。"""
+        tag_id = USER_TAG_ID_OFFSET + 4
+        user_repo.write_translation_patch("user", tag_id, "ja", "タグA")
+        user_repo.write_translation_patch("user", tag_id, "ja", "タグB")
+
+        with user_session_factory() as session:
+            count = (
+                session.query(UserTagTranslationPatch)
+                .filter_by(target_scope="user", target_tag_id=tag_id, language="ja")
+                .count()
+            )
+        assert count == 2
+
+
+# --- TestUserTagUsagePatch ---
+
+
+class TestUserTagUsagePatch:
+    """write_usage_patch の INSERT/UPDATE を検証する。"""
+
+    def test_insert_new_usage(self, user_repo, user_session_factory):
+        """新規 usage が USER_TAG_USAGE_PATCH に INSERT される。"""
+        tag_id = USER_TAG_ID_OFFSET + 10
+        user_repo.write_usage_patch("user", tag_id, 1000, 42)
+
+        with user_session_factory() as session:
+            row = (
+                session.query(UserTagUsagePatch)
+                .filter_by(target_scope="user", target_tag_id=tag_id, format_id=1000)
+                .one_or_none()
+            )
+        assert row is not None
+        assert row.count == 42
+
+    def test_update_existing_usage(self, user_repo, user_session_factory):
+        """同一 composite PK の行は count が UPDATE される。"""
+        tag_id = USER_TAG_ID_OFFSET + 11
+        user_repo.write_usage_patch("user", tag_id, 1000, 10)
+        user_repo.write_usage_patch("user", tag_id, 1000, 99)
+
+        with user_session_factory() as session:
+            rows = (
+                session.query(UserTagUsagePatch)
+                .filter_by(target_scope="user", target_tag_id=tag_id, format_id=1000)
+                .all()
+            )
+        assert len(rows) == 1
+        assert rows[0].count == 99
+
+    def test_different_format_creates_separate_row(self, user_repo, user_session_factory):
+        """format_id が異なれば別行になる。"""
+        tag_id = USER_TAG_ID_OFFSET + 12
+        user_repo.write_usage_patch("user", tag_id, 1000, 5)
+        user_repo.write_usage_patch("user", tag_id, 2000, 7)
+
+        with user_session_factory() as session:
+            count = (
+                session.query(UserTagUsagePatch)
+                .filter_by(target_scope="user", target_tag_id=tag_id)
+                .count()
+            )
+        assert count == 2
+
+    def test_get_usage_count_returns_count(self, user_repo, overlay_reader):
+        """write_usage_patch で保存した count を get_usage_count で取得できる。"""
+        tag_id = USER_TAG_ID_OFFSET + 13
+        user_repo.write_usage_patch("user", tag_id, 1000, 77)
+
+        result = overlay_reader.get_usage_count(tag_id, 1000)
+        assert result == 77
+
+    def test_get_usage_count_returns_none_when_absent(self, overlay_reader):
+        """存在しないエントリは None を返す。"""
+        assert overlay_reader.get_usage_count(USER_TAG_ID_OFFSET + 999, 1000) is None
+
+    def test_list_usage_counts_all(self, user_repo, overlay_reader):
+        """list_usage_counts() が全件を TagUsageCounts オブジェクトで返す。"""
+        tag_id = USER_TAG_ID_OFFSET + 20
+        user_repo.write_usage_patch("user", tag_id, 1000, 3)
+        user_repo.write_usage_patch("user", tag_id, 2000, 8)
+
+        results = overlay_reader.list_usage_counts(tag_id=tag_id)
+        assert len(results) == 2
+        counts_by_format = {r.format_id: r.count for r in results}
+        assert counts_by_format[1000] == 3
+        assert counts_by_format[2000] == 8
+
+    def test_list_usage_counts_filtered_by_format(self, user_repo, overlay_reader):
+        """format_id 指定でフィルタリングされる。"""
+        tag_id = USER_TAG_ID_OFFSET + 21
+        user_repo.write_usage_patch("user", tag_id, 1000, 1)
+        user_repo.write_usage_patch("user", tag_id, 2000, 2)
+
+        results = overlay_reader.list_usage_counts(tag_id=tag_id, format_id=1000)
+        assert len(results) == 1
+        assert results[0].format_id == 1000
+
+
+# --- TestOverlayReaderTranslations ---
+
+
+class TestOverlayReaderTranslations:
+    """USER_TAG_TRANSLATION_PATCH に書いたデータを OverlayTagReader で読めることを確認。"""
+
+    def test_get_translations_returns_written_data(self, user_repo, overlay_reader):
+        """write_translation_patch で保存した翻訳を get_translations で取得できる。"""
+        tag_id = USER_TAG_ID_OFFSET + 100
+        user_repo.write_translation_patch("user", tag_id, "ja", "犬")
+
+        results = overlay_reader.get_translations(tag_id)
+        assert len(results) == 1
+        assert results[0].tag_id == tag_id
+        assert results[0].language == "ja"
+        assert results[0].translation == "犬"
+
+    def test_get_translations_empty_for_unknown_tag(self, overlay_reader):
+        """未登録 tag_id の場合は空リストを返す。"""
+        assert overlay_reader.get_translations(USER_TAG_ID_OFFSET + 999) == []
+
+    def test_get_translations_batch_returns_per_tag_dict(self, user_repo, overlay_reader):
+        """get_translations_batch が tag_id → list[TagTranslation] の辞書を返す。"""
+        tag_id_a = USER_TAG_ID_OFFSET + 101
+        tag_id_b = USER_TAG_ID_OFFSET + 102
+        user_repo.write_translation_patch("user", tag_id_a, "ja", "猫")
+        user_repo.write_translation_patch("user", tag_id_b, "ja", "犬")
+
+        result = overlay_reader.get_translations_batch([tag_id_a, tag_id_b])
+        assert tag_id_a in result
+        assert tag_id_b in result
+        assert result[tag_id_a][0].translation == "猫"
+        assert result[tag_id_b][0].translation == "犬"
+
+    def test_get_translations_batch_empty_ids(self, overlay_reader):
+        """空リストを渡した場合は空辞書を返す。"""
+        assert overlay_reader.get_translations_batch([]) == {}
+
+    def test_get_translations_batch_partial_miss(self, user_repo, overlay_reader):
+        """一部が未登録でも登録済み分のみ返す。"""
+        tag_id = USER_TAG_ID_OFFSET + 103
+        user_repo.write_translation_patch("user", tag_id, "en", "cat")
+
+        result = overlay_reader.get_translations_batch([tag_id, USER_TAG_ID_OFFSET + 9999])
+        assert tag_id in result
+        assert USER_TAG_ID_OFFSET + 9999 not in result
+
+
+# --- TestRegisterUserTagWithTranslations ---
+
+
+class _DummyRepo:
+    """tag_register.py テスト用の最小 stub。"""
+
+    def __init__(self) -> None:
+        self._tag_ids: dict[str, int] = {}
+
+    def get_format_id(self, format_name: str) -> int | None:
+        return {"danbooru": 1}.get(format_name)
+
+    def get_type_name_id(self, type_name: str) -> int | None:
+        return {"unknown": 0, "general": 1}.get(type_name)
+
+    def get_tag_id_by_name(self, tag: str, partial: bool = False) -> int | None:
+        return self._tag_ids.get(tag)
+
+    def create_tag(self, source_tag: str, tag: str) -> int:
+        tag_id = 10
+        self._tag_ids[tag] = tag_id
+        return tag_id
+
+    def update_tag_status(self, tag_id, format_id, alias, preferred_tag_id, type_id=None):
+        pass
+
+    def add_or_update_translation(self, tag_id, language, translation):
+        pass
+
+    def create_type_name_if_not_exists(self, type_name, description=None):
+        return {"unknown": 0, "general": 1}.get(type_name, 0)
+
+    def create_format_if_not_exists(self, format_name, description=None, reader=None) -> int:
+        return 1001
+
+    def get_next_type_id(self, format_id: int) -> int:
+        return 1
+
+    def create_type_format_mapping_if_not_exists(self, format_id, type_id, type_name_id, description=None):
+        return type_id
+
+
+class _DummyReader:
+    def __init__(self, repo: _DummyRepo) -> None:
+        self._repo = repo
+
+    def get_format_id(self, format_name: str) -> int:
+        result = self._repo.get_format_id(format_name)
+        if result is None:
+            raise ValueError(f"Format not found: {format_name}")
+        return result
+
+    def get_type_id_for_format(self, type_name: str, format_id: int) -> int | None:
+        return self._repo.get_type_name_id(type_name)
+
+    def get_tag_id_by_name(self, tag: str, partial: bool = False) -> int | None:
+        return self._repo.get_tag_id_by_name(tag, partial=partial)
+
+
+class TestRegisterUserTagWithTranslations:
+    """_register_user_tag が translations を write_translation_patch に渡すことを確認。"""
+
+    def _make_service(self):
+        repo = _DummyRepo()
+        reader = _DummyReader(repo)
+        mock_user_repo = MagicMock()
+        mock_user_repo.create_user_tag.return_value = USER_TAG_ID_OFFSET + 1
+        service = TagRegisterService(repository=repo, reader=reader, user_tag_repo=mock_user_repo)
+        return service, mock_user_repo
+
+    def test_translations_written_to_patch(self):
+        """translations が指定されると write_translation_patch が翻訳ごとに呼ばれる。"""
+        service, mock_user_repo = self._make_service()
+        request = TagRegisterRequest(
+            tag="neko",
+            format_name="danbooru",
+            type_name="general",
+            scope="user",
+            translations=[
+                TagTranslationInput(language="ja", translation="猫"),
+                TagTranslationInput(language="zh", translation="猫咪"),
+            ],
+        )
+
+        result = service.register_tag(request)
+
+        assert mock_user_repo.write_translation_patch.call_count == 2
+        calls = mock_user_repo.write_translation_patch.call_args_list
+        first_kwargs = calls[0].kwargs
+        assert first_kwargs["target_scope"] == "user"
+        assert first_kwargs["target_tag_id"] == USER_TAG_ID_OFFSET + 1
+        assert first_kwargs["language"] == "ja"
+        assert first_kwargs["translation"] == "猫"
+        assert result.tag_id == USER_TAG_ID_OFFSET + 1
+
+    def test_no_translations_write_patch_not_called(self):
+        """translations が None の場合は write_translation_patch が呼ばれない。"""
+        service, mock_user_repo = self._make_service()
+        request = TagRegisterRequest(
+            tag="inu",
+            format_name="danbooru",
+            type_name="general",
+            scope="user",
+        )
+
+        service.register_tag(request)
+
+        mock_user_repo.write_translation_patch.assert_not_called()
+
+    def test_empty_translations_write_patch_not_called(self):
+        """translations が空リストの場合も write_translation_patch が呼ばれない。"""
+        service, mock_user_repo = self._make_service()
+        request = TagRegisterRequest(
+            tag="tori",
+            format_name="danbooru",
+            type_name="general",
+            scope="user",
+            translations=[],
+        )
+
+        service.register_tag(request)
+
+        mock_user_repo.write_translation_patch.assert_not_called()
+
+    def test_write_patch_still_called_with_translations(self):
+        """translations の有無に関わらず write_patch は必ず呼ばれる。"""
+        service, mock_user_repo = self._make_service()
+        request = TagRegisterRequest(
+            tag="sakana",
+            format_name="danbooru",
+            type_name="general",
+            scope="user",
+            translations=[TagTranslationInput(language="ja", translation="魚")],
+        )
+
+        service.register_tag(request)
+
+        mock_user_repo.write_patch.assert_called_once()
+        mock_user_repo.write_translation_patch.assert_called_once()


### PR DESCRIPTION
## Summary
- `USER_TAG_TRANSLATION_PATCH` / `USER_TAG_USAGE_PATCH` を UserOverlayBase に追加 (FK なし patch テーブル)
- `OverlayTagReader.get_translations` / `get_translations_batch` / `get_usage_count` / `list_usage_counts` を stub → 実装に置き換え
- `UserTagRepository.write_translation_patch` / `write_usage_patch` を追加
- `_register_user_tag` の translation 欠落 (Issue #78) を修正: `write_patch` 後に `write_translation_patch` を呼ぶ

## Test plan
- [x] `TestUserTagTranslationPatch`: write_translation_patch INSERT・重複無視・言語/翻訳違いの別行
- [x] `TestUserTagUsagePatch`: write_usage_patch INSERT/UPDATE・get_usage_count・list_usage_counts フィルタ
- [x] `TestOverlayReaderTranslations`: get_translations / get_translations_batch バッチ取得・部分 miss
- [x] `TestRegisterUserTagWithTranslations`: _register_user_tag で translations が write_translation_patch に渡ること
- [x] 既存全テスト `not slow and not network` (454 tests) pass

Closes #68