### PR TITLE
feat(overlay): cross-scope preferred 解決 (#69)

### DIFF
--- a/src/genai_tag_db_tools/db/repository.py
+++ b/src/genai_tag_db_tools/db/repository.py
@@ -1488,6 +1488,72 @@ class MergedTagReader:
             format_id=format_id,
         )
 
+    def _resolve_cross_scope_preferred(
+        self,
+        rows: list[TagSearchRow],
+    ) -> list[TagSearchRow]:
+        """search_tags 結果のうち preferred が別 DB にあるものを解決する。
+
+        alias=True の行を対象に全リポをまたいだ preferred tag lookup を行い、
+        preferred が見つかれば row を差し替える。
+
+        OverlayTagReader は同一 DB 内の preferred しか解決しないため、
+        cross-scope alias (user → base 等) はこのメソッドで補完する。
+
+        Args:
+            rows: マージ済みの TagSearchRow リスト。
+
+        Returns:
+            preferred 解決後の TagSearchRow リスト。
+        """
+        result: list[TagSearchRow] = []
+        for row in rows:
+            if not row["alias"]:
+                result.append(row)
+                continue
+
+            tag_id = row["tag_id"]
+            preferred_tag_id: int | None = None
+
+            # 全リポからステータスを取得して preferred_tag_id を探す
+            for repo in self._iter_repos():
+                statuses = repo.list_tag_statuses(tag_id)
+                for status in statuses:
+                    if status.alias and status.preferred_tag_id != tag_id:
+                        preferred_tag_id = status.preferred_tag_id
+                        break
+                if preferred_tag_id is not None:
+                    break
+
+            if preferred_tag_id is None or preferred_tag_id == tag_id:
+                result.append(row)
+                continue
+
+            # preferred tag を全リポから取得
+            preferred_tag: Tag | None = None
+            for repo in self._iter_repos():
+                preferred_tag = repo.get_tag_by_id(preferred_tag_id)
+                if preferred_tag is not None:
+                    break
+
+            if preferred_tag is not None:
+                new_row: TagSearchRow = {
+                    "tag_id": preferred_tag_id,
+                    "tag": preferred_tag.tag,
+                    "source_tag": preferred_tag.source_tag,
+                    "usage_count": row["usage_count"],
+                    "alias": False,
+                    "deprecated": row["deprecated"],
+                    "type_id": row["type_id"],
+                    "type_name": row["type_name"],
+                    "translations": row["translations"],
+                    "format_statuses": row["format_statuses"],
+                }
+                result.append(new_row)
+            else:
+                result.append(row)
+        return result
+
     def search_tags(
         self,
         keyword: str,
@@ -1506,7 +1572,7 @@ class MergedTagReader:
         limit: int | None = None,
         offset: int = 0,
     ) -> list[TagSearchRow]:
-        return self._merge_search_tags_adaptive(
+        rows = self._merge_search_tags_adaptive(
             keyword,
             limit=limit,
             offset=offset,
@@ -1522,6 +1588,9 @@ class MergedTagReader:
             deprecated=deprecated,
             resolve_preferred=resolve_preferred,
         )
+        if resolve_preferred and self._has_user():
+            rows = self._resolve_cross_scope_preferred(rows)
+        return rows
 
     def search_tags_bulk(
         self,
@@ -1530,13 +1599,23 @@ class MergedTagReader:
         format_name: str | None = None,
         resolve_preferred: bool = False,
     ) -> dict[str, TagSearchRow]:
-        return self._merge_by_key(
+        merged: dict[str, TagSearchRow] = self._merge_by_key(
             "search_tags_bulk",
             None,
             keywords,
             format_name=format_name,
             resolve_preferred=resolve_preferred,
         )
+        if not resolve_preferred or not self._has_user():
+            return merged
+        # OverlayTagReader.search_tags_bulk がスタブのため、未解決キーワードを
+        # 個別 search_tags で補完する (cross-scope preferred 解決を含む)
+        missing = [kw for kw in keywords if kw not in merged]
+        for kw in missing:
+            rows = self.search_tags(kw, partial=False, format_name=format_name, resolve_preferred=True)
+            if rows:
+                merged[kw] = rows[0]
+        return merged
 
     def get_format_map(self) -> dict[int, str]:
         return self._merge_by_key("get_format_map", None)

--- a/tests/unit/test_overlay_preferred_resolution.py
+++ b/tests/unit/test_overlay_preferred_resolution.py
@@ -1,0 +1,239 @@
+"""MergedTagReader の cross-scope preferred 解決テスト。
+
+user alias → base preferred の cross-scope 解決が機能することを検証する。
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from sqlalchemy import StaticPool, create_engine
+from sqlalchemy.orm import sessionmaker
+
+from genai_tag_db_tools.core_api import convert_tags
+from genai_tag_db_tools.db.overlay_reader import OverlayTagReader
+from genai_tag_db_tools.db.repository import MergedTagReader, TagReader
+from genai_tag_db_tools.db.schema import (
+    USER_TAG_ID_OFFSET,
+    Base,
+    Tag,
+    TagFormat,
+    TagStatus,
+    TagTypeFormatMapping,
+    TagTypeName,
+    UserOverlayBase,
+    UserTag,
+    UserTagStatusPatch,
+)
+
+# テスト用定数
+_BASE_TAG_ID_BLUE_EYES = 100
+_USER_TAG_ID_BLU_EYES = USER_TAG_ID_OFFSET + 100
+_USER_TAG_ID_PREFERRED = USER_TAG_ID_OFFSET + 200
+_FORMAT_ID = 1000
+
+
+# ------------------------------------------------------------------
+# Fixtures: Base DB
+# ------------------------------------------------------------------
+
+
+@pytest.fixture
+def base_engine(tmp_path: Path):
+    """Base DB テーブルを持つ SQLite エンジン。"""
+    db_path = tmp_path / "base.sqlite"
+    engine = create_engine(
+        f"sqlite:///{db_path}",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    return engine
+
+
+@pytest.fixture
+def base_session_factory(base_engine):
+    return sessionmaker(bind=base_engine, autoflush=False, autocommit=False)
+
+
+@pytest.fixture
+def populated_base(base_session_factory):
+    """Base DB に blue eyes タグと TAG_STATUS を挿入する。"""
+    with base_session_factory() as session:
+        session.add(TagFormat(format_id=_FORMAT_ID, format_name="test_format"))
+        session.add(TagTypeName(type_name_id=1, type_name="general"))
+        session.add(TagTypeFormatMapping(format_id=_FORMAT_ID, type_id=0, type_name_id=1))
+        session.add(Tag(tag_id=_BASE_TAG_ID_BLUE_EYES, source_tag="blue_eyes", tag="blue eyes"))
+        session.flush()
+        session.add(
+            TagStatus(
+                tag_id=_BASE_TAG_ID_BLUE_EYES,
+                format_id=_FORMAT_ID,
+                type_id=0,
+                alias=False,
+                preferred_tag_id=_BASE_TAG_ID_BLUE_EYES,
+            )
+        )
+        session.commit()
+
+
+# ------------------------------------------------------------------
+# Fixtures: User DB
+# ------------------------------------------------------------------
+
+
+@pytest.fixture
+def user_engine(tmp_path: Path):
+    """User overlay DB テーブルを持つ SQLite エンジン。"""
+    db_path = tmp_path / "user.sqlite"
+    engine = create_engine(
+        f"sqlite:///{db_path}",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    UserOverlayBase.metadata.create_all(engine)
+    return engine
+
+
+@pytest.fixture
+def user_session_factory(user_engine):
+    return sessionmaker(bind=user_engine, autoflush=False, autocommit=False)
+
+
+@pytest.fixture
+def populated_user_cross_scope(user_session_factory):
+    """User DB に blu eyes → base blue eyes の cross-scope alias を挿入する。"""
+    with user_session_factory() as session:
+        session.add(UserTag(tag_id=_USER_TAG_ID_BLU_EYES, source_tag="blu_eyes", tag="blu eyes"))
+        session.flush()
+        session.add(
+            UserTagStatusPatch(
+                target_scope="user",
+                target_tag_id=_USER_TAG_ID_BLU_EYES,
+                format_id=_FORMAT_ID,
+                type_id=0,
+                alias=True,
+                preferred_scope="base",
+                preferred_tag_id=_BASE_TAG_ID_BLUE_EYES,
+                deprecated=False,
+            )
+        )
+        session.commit()
+
+
+@pytest.fixture
+def populated_user_user_scope(user_session_factory):
+    """User DB に user→user alias を挿入する。"""
+    with user_session_factory() as session:
+        # alias タグ
+        session.add(UserTag(tag_id=_USER_TAG_ID_BLU_EYES, source_tag="alias_src", tag="alias tag"))
+        # preferred タグ
+        session.add(UserTag(tag_id=_USER_TAG_ID_PREFERRED, source_tag="preferred_src", tag="preferred tag"))
+        session.flush()
+        session.add(
+            UserTagStatusPatch(
+                target_scope="user",
+                target_tag_id=_USER_TAG_ID_BLU_EYES,
+                format_id=_FORMAT_ID,
+                type_id=0,
+                alias=True,
+                preferred_scope="user",
+                preferred_tag_id=_USER_TAG_ID_PREFERRED,
+                deprecated=False,
+            )
+        )
+        session.commit()
+
+
+# ------------------------------------------------------------------
+# Fixtures: MergedTagReader
+# ------------------------------------------------------------------
+
+
+@pytest.fixture
+def merged_reader_cross_scope(
+    base_session_factory, user_session_factory, populated_base, populated_user_cross_scope
+):
+    """Base + user cross-scope alias を持つ MergedTagReader。"""
+    base_repo = TagReader(session_factory=base_session_factory)
+    user_repo = OverlayTagReader(session_factory=user_session_factory)
+    return MergedTagReader(base_repo=base_repo, user_repo=user_repo)
+
+
+@pytest.fixture
+def merged_reader_user_scope(
+    base_session_factory, user_session_factory, populated_base, populated_user_user_scope
+):
+    """Base + user→user alias を持つ MergedTagReader。"""
+    base_repo = TagReader(session_factory=base_session_factory)
+    user_repo = OverlayTagReader(session_factory=user_session_factory)
+    return MergedTagReader(base_repo=base_repo, user_repo=user_repo)
+
+
+# ------------------------------------------------------------------
+# Tests: cross-scope preferred 解決
+# ------------------------------------------------------------------
+
+
+class TestCrossScopePreferredResolution:
+    """user alias → base preferred の cross-scope 解決テスト。"""
+
+    def test_search_tags_resolve_preferred_returns_base_tag(self, merged_reader_cross_scope):
+        """resolve_preferred=True のとき user alias が base preferred に差し替えられる。"""
+        rows = merged_reader_cross_scope.search_tags("blu eyes", resolve_preferred=True)
+
+        assert len(rows) == 1
+        assert rows[0]["tag"] == "blue eyes"
+        assert rows[0]["tag_id"] == _BASE_TAG_ID_BLUE_EYES
+        assert rows[0]["alias"] is False
+
+    def test_search_tags_no_resolve_preferred_returns_alias(self, merged_reader_cross_scope):
+        """resolve_preferred=False のとき user alias タグがそのまま返る。"""
+        rows = merged_reader_cross_scope.search_tags("blu eyes", resolve_preferred=False)
+
+        assert len(rows) == 1
+        assert rows[0]["tag"] == "blu eyes"
+        assert rows[0]["tag_id"] == _USER_TAG_ID_BLU_EYES
+        assert rows[0]["alias"] is True
+
+    def test_non_alias_row_unchanged_with_resolve_preferred(self, merged_reader_cross_scope):
+        """alias=False の行は resolve_preferred=True でも変更されない。"""
+        rows = merged_reader_cross_scope.search_tags("blue eyes", resolve_preferred=True)
+
+        assert len(rows) == 1
+        assert rows[0]["tag"] == "blue eyes"
+        assert rows[0]["alias"] is False
+
+    def test_search_tags_user_to_user_alias_resolved(self, merged_reader_user_scope):
+        """user→user alias でも preferred が正しく解決される。"""
+        rows = merged_reader_user_scope.search_tags("alias tag", resolve_preferred=True)
+
+        assert len(rows) == 1
+        assert rows[0]["tag"] == "preferred tag"
+        assert rows[0]["tag_id"] == _USER_TAG_ID_PREFERRED
+        assert rows[0]["alias"] is False
+
+
+# ------------------------------------------------------------------
+# Tests: convert_tags での cross-scope alias 変換
+# ------------------------------------------------------------------
+
+
+class TestConvertTagsCrossScope:
+    """convert_tags が cross-scope alias を通じてタグを変換するテスト。"""
+
+    def test_convert_alias_to_base_preferred(self, merged_reader_cross_scope):
+        """blu_eyes (user alias) が blue eyes (base preferred) に変換される。
+
+        TagCleaner.clean_format がアンダーバーをスペースに変換するため
+        入力 "blu_eyes" は "blu eyes" として検索され、cross-scope 解決が行われる。
+        """
+        result = convert_tags(merged_reader_cross_scope, "blu_eyes", "test_format")
+
+        assert result == "blue eyes"
+
+    def test_convert_non_alias_tag_unchanged(self, merged_reader_cross_scope):
+        """alias でないタグはそのまま変換される。"""
+        result = convert_tags(merged_reader_cross_scope, "blue_eyes", "test_format")
+
+        assert result == "blue eyes"


### PR DESCRIPTION
## Summary
- `MergedTagReader._resolve_cross_scope_preferred` を追加: alias=True の行を対象に全リポをまたいだ preferred tag lookup を実行し、cross-scope alias を解決する
- `MergedTagReader.search_tags` を修正: `resolve_preferred=True` かつ user_repo 有りのとき後処理として `_resolve_cross_scope_preferred` を呼び出す
- `MergedTagReader.search_tags_bulk` を修正: `OverlayTagReader.search_tags_bulk` がスタブ (`{}`) を返すため、未解決キーワードを個別 `search_tags` で補完し cross-scope 解決を含めるようにした
- これにより `convert_tags` (core_api) が overlay alias を自動的に反映する

## Test plan
- [x] user alias → base preferred の cross-scope 解決テスト (`resolve_preferred=True`)
- [x] `resolve_preferred=False` 時はエイリアス行が変更されないことを確認
- [x] alias でない行は変更されないことを確認
- [x] user→user alias でも解決されることを確認
- [x] `convert_tags` での cross-scope alias 変換テスト
- [x] 既存全テスト `not slow and not network` 440件 pass

Closes #69