### PR TITLE
Add manual refinement recommendation API MVP (#53)

### DIFF
--- a/src/genai_tag_db_tools/__init__.py
+++ b/src/genai_tag_db_tools/__init__.py
@@ -10,15 +10,20 @@ from .core_api import (
     get_tag_formats,
     get_unknown_type_tags,
     initialize_databases,
+    needs_manual_refinement,
+    recommend_manual_refinement,
     register_tag,
     search_tags,
     update_tags_type_batch,
 )
-from .models import TagTypeUpdate
+from .models import RefinementReason, RefinementRecommendation, RefinementSuggestion, TagTypeUpdate
 from .services.tag_search import TagSearcher
 from .utils.cleanup_str import TagCleaner
 
 __all__ = [
+    "RefinementReason",
+    "RefinementRecommendation",
+    "RefinementSuggestion",
     "TagCleaner",
     "TagSearcher",
     "TagTypeUpdate",
@@ -33,6 +38,8 @@ __all__ = [
     "initialize_databases",
     "initialize_tag_cleaner",
     "initialize_tag_searcher",
+    "needs_manual_refinement",
+    "recommend_manual_refinement",
     "register_tag",
     "search_tags",
     "update_tags_type_batch",

--- a/src/genai_tag_db_tools/core_api.py
+++ b/src/genai_tag_db_tools/core_api.py
@@ -12,6 +12,9 @@ from genai_tag_db_tools.models import (
     DbSourceRef,
     EnsureDbRequest,
     EnsureDbResult,
+    RefinementReason,
+    RefinementRecommendation,
+    RefinementSuggestion,
     TagRecordPublic,
     TagRegisterRequest,
     TagRegisterResult,
@@ -22,6 +25,39 @@ from genai_tag_db_tools.models import (
 )
 from genai_tag_db_tools.services.tag_register import TagRegisterService
 from genai_tag_db_tools.utils.cleanup_str import TagCleaner
+
+_REFINEMENT_REASON_MESSAGES = {
+    "empty_normalized_tag": "正規化後のタグが空です。",
+    "normalization_changes_tag": "既存の正規化でタグ表記が変わります。",
+    "broad_single_word": "単語が広すぎるため、人による確認が必要です。",
+    "site_info_token": "サイト情報トークンのため、通常タグとして扱うべきか確認が必要です。",
+}
+_BROAD_SINGLE_WORD_TAGS = {
+    "animal",
+    "background",
+    "building",
+    "character",
+    "clothes",
+    "clothing",
+    "flower",
+    "food",
+    "girl",
+    "man",
+    "object",
+    "person",
+    "plant",
+    "style",
+    "woman",
+}
+
+
+def _refinement_reason(code: str) -> RefinementReason:
+    return RefinementReason(code=code, message=_REFINEMENT_REASON_MESSAGES[code])
+
+
+def _looks_like_site_info_token(tag: str) -> bool:
+    stripped = tag.strip()
+    return stripped.startswith("__") or stripped.endswith("__")
 
 
 def _compute_sha256(path: Path) -> str:
@@ -186,6 +222,47 @@ def search_tags(repo: MergedTagReader, request: TagSearchRequest) -> TagSearchRe
 
 def register_tag(service: TagRegisterService, request: TagRegisterRequest) -> TagRegisterResult:
     return service.register_tag(request)
+
+
+def recommend_manual_refinement(tag: str) -> RefinementRecommendation:
+    """Recommend whether a tag needs manual refinement before registration.
+
+    This MVP is deterministic and DB independent. It only uses the existing tag
+    formatting normalization and does not resolve aliases, preferred tags, or
+    overlay state.
+    """
+    normalized_tag = TagCleaner.clean_format(tag)
+    source_candidate = tag.strip()
+    reasons: list[RefinementReason] = []
+    suggestions: list[RefinementSuggestion] = []
+
+    is_site_info_token = _looks_like_site_info_token(tag)
+    if not normalized_tag:
+        reasons.append(_refinement_reason("empty_normalized_tag"))
+        suggestions.append(RefinementSuggestion(kind="review_only"))
+    elif is_site_info_token:
+        reasons.append(_refinement_reason("site_info_token"))
+        suggestions.append(RefinementSuggestion(kind="review_only"))
+    else:
+        if normalized_tag != source_candidate:
+            reasons.append(_refinement_reason("normalization_changes_tag"))
+            suggestions.append(RefinementSuggestion(kind="correction_candidate", tag=normalized_tag))
+        if normalized_tag.lower() in _BROAD_SINGLE_WORD_TAGS and " " not in normalized_tag:
+            reasons.append(_refinement_reason("broad_single_word"))
+            suggestions.append(RefinementSuggestion(kind="review_only"))
+
+    return RefinementRecommendation(
+        source_tag=tag,
+        normalized_tag=normalized_tag,
+        needs_refinement=bool(reasons),
+        reasons=reasons,
+        suggestions=suggestions,
+    )
+
+
+def needs_manual_refinement(tag: str) -> bool:
+    """Compatibility helper returning only the recommendation boolean."""
+    return recommend_manual_refinement(tag).needs_refinement
 
 
 def get_statistics(repo: MergedTagReader) -> TagStatisticsResult:

--- a/src/genai_tag_db_tools/core_api.py
+++ b/src/genai_tag_db_tools/core_api.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import re
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -49,6 +50,8 @@ _BROAD_SINGLE_WORD_TAGS = {
     "style",
     "woman",
 }
+_ANGLE_BRACKET_PATTERN = re.compile(r"<[^>]+>")
+_SITE_INFO_TOKEN_SUFFIXES = ("_id", " id")
 
 
 def _refinement_reason(code: str) -> RefinementReason:
@@ -57,7 +60,38 @@ def _refinement_reason(code: str) -> RefinementReason:
 
 def _looks_like_site_info_token(tag: str) -> bool:
     stripped = tag.strip()
-    return stripped.startswith("__") or stripped.endswith("__")
+    lowered = stripped.lower()
+    return (
+        stripped.startswith("__")
+        or stripped.endswith("__")
+        or lowered.endswith(_SITE_INFO_TOKEN_SUFFIXES)
+    )
+
+
+def _normalize_refinement_tag(tag: str) -> str:
+    cleaned = TagCleaner.clean_format(tag)
+    if not cleaned:
+        return cleaned
+
+    parts: list[str] = []
+    position = 0
+    for match in _ANGLE_BRACKET_PATTERN.finditer(cleaned):
+        parts.append(cleaned[position : match.start()].lower())
+        parts.append(match.group(0))
+        position = match.end()
+    parts.append(cleaned[position:].lower())
+    return "".join(parts)
+
+
+def _refinement_score(reasons: list[RefinementReason], suggestions: list[RefinementSuggestion]) -> float:
+    codes = {reason.code for reason in reasons}
+    if not codes:
+        return 0.0
+    if "empty_normalized_tag" in codes:
+        return 1.0
+    if any(suggestion.kind == "correction_candidate" for suggestion in suggestions):
+        return 0.8
+    return 0.6
 
 
 def _compute_sha256(path: Path) -> str:
@@ -231,7 +265,7 @@ def recommend_manual_refinement(tag: str) -> RefinementRecommendation:
     formatting normalization and does not resolve aliases, preferred tags, or
     overlay state.
     """
-    normalized_tag = TagCleaner.clean_format(tag)
+    normalized_tag = _normalize_refinement_tag(tag)
     source_candidate = tag.strip()
     reasons: list[RefinementReason] = []
     suggestions: list[RefinementSuggestion] = []
@@ -255,6 +289,7 @@ def recommend_manual_refinement(tag: str) -> RefinementRecommendation:
         source_tag=tag,
         normalized_tag=normalized_tag,
         needs_refinement=bool(reasons),
+        score=_refinement_score(reasons, suggestions),
         reasons=reasons,
         suggestions=suggestions,
     )

--- a/src/genai_tag_db_tools/models.py
+++ b/src/genai_tag_db_tools/models.py
@@ -258,6 +258,49 @@ class TagRegisterResult(BaseModel):
     tag_id: int = Field(..., description="登録されたタグID")
 
 
+class RefinementReason(BaseModel):
+    """手動 refinement 推奨理由。
+
+    Args:
+        code: UI/テストが依存する安定コード。
+        message: 人間向けの日本語メッセージ。
+    """
+
+    code: Literal[
+        "empty_normalized_tag",
+        "normalization_changes_tag",
+        "broad_single_word",
+        "site_info_token",
+    ] = Field(..., description="Stable reason code")
+    message: str = Field(..., description="Human-readable Japanese message")
+
+
+class RefinementSuggestion(BaseModel):
+    """refinement の候補または確認アクション。
+
+    Args:
+        kind: 候補の種別。correction_candidate は自動補正候補、
+            review_only は人による確認のみ。
+        tag: 候補タグ。review_only では None。
+    """
+
+    kind: Literal["correction_candidate", "review_only"] = Field(..., description="Suggestion kind")
+    tag: str | None = Field(default=None, description="Suggested normalized tag")
+
+
+class RefinementRecommendation(BaseModel):
+    """タグを手で直すべきかを表す advisory API 結果。"""
+
+    source_tag: str = Field(..., description="Original input tag")
+    normalized_tag: str = Field(..., description="Normalized tag candidate for TAGS.tag / USER_TAGS.tag")
+    needs_refinement: bool = Field(..., description="Whether any correction or review is needed")
+    reasons: list[RefinementReason] = Field(default_factory=list, description="Reasons for the recommendation")
+    suggestions: list[RefinementSuggestion] = Field(
+        default_factory=list,
+        description="Structured correction candidates or review-only actions",
+    )
+
+
 class ConvertTagsRequest(BaseModel):
     """タグ変換リクエスト（CLI/core契約用）。"""
 

--- a/src/genai_tag_db_tools/models.py
+++ b/src/genai_tag_db_tools/models.py
@@ -294,6 +294,7 @@ class RefinementRecommendation(BaseModel):
     source_tag: str = Field(..., description="Original input tag")
     normalized_tag: str = Field(..., description="Normalized tag candidate for TAGS.tag / USER_TAGS.tag")
     needs_refinement: bool = Field(..., description="Whether any correction or review is needed")
+    score: float = Field(..., ge=0.0, le=1.0, description="Advisory confidence/severity score")
     reasons: list[RefinementReason] = Field(default_factory=list, description="Reasons for the recommendation")
     suggestions: list[RefinementSuggestion] = Field(
         default_factory=list,

--- a/tests/unit/test_refinement_recommendation.py
+++ b/tests/unit/test_refinement_recommendation.py
@@ -13,6 +13,7 @@ def test_normal_concrete_tag_does_not_need_refinement():
     assert recommendation.source_tag == "red rose"
     assert recommendation.normalized_tag == "red rose"
     assert recommendation.needs_refinement is False
+    assert recommendation.score == 0.0
     assert recommendation.reasons == []
     assert recommendation.suggestions == []
 
@@ -21,6 +22,7 @@ def test_normalization_change_adds_correction_candidate():
     recommendation = recommend_manual_refinement("blue__eyes")
 
     assert recommendation.needs_refinement is True
+    assert recommendation.score == 0.8
     assert recommendation.normalized_tag == "blue eyes"
     assert _reason_codes("blue__eyes") == ["normalization_changes_tag"]
     assert [(s.kind, s.tag) for s in recommendation.suggestions] == [
@@ -42,6 +44,7 @@ def test_broad_single_word_is_review_only_without_correction_candidate():
     recommendation = recommend_manual_refinement("flower")
 
     assert recommendation.needs_refinement is True
+    assert recommendation.score == 0.6
     assert recommendation.normalized_tag == "flower"
     assert _reason_codes("flower") == ["broad_single_word"]
     assert [(s.kind, s.tag) for s in recommendation.suggestions] == [("review_only", None)]
@@ -51,6 +54,7 @@ def test_site_info_token_is_review_only():
     recommendation = recommend_manual_refinement("__commentary_request")
 
     assert recommendation.needs_refinement is True
+    assert recommendation.score == 0.6
     assert recommendation.normalized_tag == "commentary request"
     assert _reason_codes("__commentary_request") == ["site_info_token"]
     assert [(s.kind, s.tag) for s in recommendation.suggestions] == [("review_only", None)]
@@ -60,6 +64,7 @@ def test_empty_normalized_tag_is_review_only():
     recommendation = recommend_manual_refinement("___")
 
     assert recommendation.needs_refinement is True
+    assert recommendation.score == 1.0
     assert recommendation.normalized_tag == ""
     assert _reason_codes("___") == ["empty_normalized_tag"]
     assert [(s.kind, s.tag) for s in recommendation.suggestions] == [("review_only", None)]
@@ -77,6 +82,33 @@ def test_reason_code_stability():
     assert _reason_codes("blue__eyes") == ["normalization_changes_tag"]
     assert _reason_codes("flower") == ["broad_single_word"]
     assert _reason_codes("__commentary_request") == ["site_info_token"]
+
+
+def test_mixed_case_ordinary_tag_uses_canonical_lowercase_candidate():
+    recommendation = recommend_manual_refinement("Blue Eyes")
+
+    assert recommendation.needs_refinement is True
+    assert recommendation.normalized_tag == "blue eyes"
+    assert _reason_codes("Blue Eyes") == ["normalization_changes_tag"]
+    assert [(s.kind, s.tag) for s in recommendation.suggestions] == [
+        ("correction_candidate", "blue eyes")
+    ]
+
+
+def test_angle_bracket_token_case_is_preserved():
+    recommendation = recommend_manual_refinement("<lora:CharacterName:0.8>")
+
+    assert recommendation.normalized_tag == "<lora:CharacterName:0.8>"
+    assert recommendation.needs_refinement is False
+
+
+def test_site_metadata_id_token_is_review_only():
+    recommendation = recommend_manual_refinement("pixiv_id")
+
+    assert recommendation.needs_refinement is True
+    assert recommendation.normalized_tag == "pixiv id"
+    assert _reason_codes("pixiv_id") == ["site_info_token"]
+    assert [(s.kind, s.tag) for s in recommendation.suggestions] == [("review_only", None)]
 
 
 def test_suggestion_kind_is_structured():

--- a/tests/unit/test_refinement_recommendation.py
+++ b/tests/unit/test_refinement_recommendation.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from genai_tag_db_tools.core_api import needs_manual_refinement, recommend_manual_refinement
+
+
+def _reason_codes(tag: str) -> list[str]:
+    return [reason.code for reason in recommend_manual_refinement(tag).reasons]
+
+
+def test_normal_concrete_tag_does_not_need_refinement():
+    recommendation = recommend_manual_refinement("red rose")
+
+    assert recommendation.source_tag == "red rose"
+    assert recommendation.normalized_tag == "red rose"
+    assert recommendation.needs_refinement is False
+    assert recommendation.reasons == []
+    assert recommendation.suggestions == []
+
+
+def test_normalization_change_adds_correction_candidate():
+    recommendation = recommend_manual_refinement("blue__eyes")
+
+    assert recommendation.needs_refinement is True
+    assert recommendation.normalized_tag == "blue eyes"
+    assert _reason_codes("blue__eyes") == ["normalization_changes_tag"]
+    assert [(s.kind, s.tag) for s in recommendation.suggestions] == [
+        ("correction_candidate", "blue eyes")
+    ]
+
+
+def test_parentheses_normalization_suggests_existing_cleaned_result():
+    recommendation = recommend_manual_refinement("foo_bar (baz)")
+
+    assert recommendation.needs_refinement is True
+    assert recommendation.normalized_tag == r"foo bar \(baz\)"
+    assert _reason_codes("foo_bar (baz)") == ["normalization_changes_tag"]
+    assert recommendation.suggestions[0].kind == "correction_candidate"
+    assert recommendation.suggestions[0].tag == r"foo bar \(baz\)"
+
+
+def test_broad_single_word_is_review_only_without_correction_candidate():
+    recommendation = recommend_manual_refinement("flower")
+
+    assert recommendation.needs_refinement is True
+    assert recommendation.normalized_tag == "flower"
+    assert _reason_codes("flower") == ["broad_single_word"]
+    assert [(s.kind, s.tag) for s in recommendation.suggestions] == [("review_only", None)]
+
+
+def test_site_info_token_is_review_only():
+    recommendation = recommend_manual_refinement("__commentary_request")
+
+    assert recommendation.needs_refinement is True
+    assert recommendation.normalized_tag == "commentary request"
+    assert _reason_codes("__commentary_request") == ["site_info_token"]
+    assert [(s.kind, s.tag) for s in recommendation.suggestions] == [("review_only", None)]
+
+
+def test_empty_normalized_tag_is_review_only():
+    recommendation = recommend_manual_refinement("___")
+
+    assert recommendation.needs_refinement is True
+    assert recommendation.normalized_tag == ""
+    assert _reason_codes("___") == ["empty_normalized_tag"]
+    assert [(s.kind, s.tag) for s in recommendation.suggestions] == [("review_only", None)]
+
+
+def test_needs_manual_refinement_is_thin_helper():
+    recommendation = recommend_manual_refinement("blue__eyes")
+
+    assert needs_manual_refinement("blue__eyes") is recommendation.needs_refinement
+    assert needs_manual_refinement("red rose") is False
+
+
+def test_reason_code_stability():
+    assert _reason_codes("") == ["empty_normalized_tag"]
+    assert _reason_codes("blue__eyes") == ["normalization_changes_tag"]
+    assert _reason_codes("flower") == ["broad_single_word"]
+    assert _reason_codes("__commentary_request") == ["site_info_token"]
+
+
+def test_suggestion_kind_is_structured():
+    correction = recommend_manual_refinement("blue__eyes").suggestions[0]
+    review = recommend_manual_refinement("flower").suggestions[0]
+
+    assert correction.kind == "correction_candidate"
+    assert correction.tag == "blue eyes"
+    assert review.kind == "review_only"
+    assert review.tag is None


### PR DESCRIPTION
## Summary

Implements the deterministic manual refinement recommendation API MVP for #53.

- Adds structured `RefinementRecommendation`, `RefinementReason`, and `RefinementSuggestion` models
- Adds `recommend_manual_refinement(tag)` and `needs_manual_refinement(tag)` public API helpers
- Uses existing `TagCleaner.clean_format()` normalization without DB access
- Keeps overlay redesign untouched: no DB writes, no materialization, no overlay schema changes

## Validation

- `uv run pytest tests/unit/test_refinement_recommendation.py -q`
- `uv run pytest -q`
- `uv run ruff check .`
- `uv run mypy src`
