### PR TITLE
Apply approved feedback to user overlay DB

### DIFF
--- a/src/genai_tag_db_tools/__init__.py
+++ b/src/genai_tag_db_tools/__init__.py
@@ -19,18 +19,25 @@ from .core_api import (
     update_tags_type_batch,
 )
 from .models import (
+    ApprovedDbFeedback,
     DbFeedbackProposal,
+    LocalFeedbackApplicationRecord,
+    LocalFeedbackApplyResult,
     ProposalTarget,
     RefinementReason,
     RefinementRecommendation,
     RefinementSuggestion,
     TagTypeUpdate,
 )
+from .services.feedback_apply import apply_approved_feedback, list_local_feedback_applications
 from .services.tag_search import TagSearcher
 from .utils.cleanup_str import TagCleaner
 
 __all__ = [
+    "ApprovedDbFeedback",
     "DbFeedbackProposal",
+    "LocalFeedbackApplicationRecord",
+    "LocalFeedbackApplyResult",
     "ProposalTarget",
     "RefinementReason",
     "RefinementRecommendation",
@@ -38,6 +45,7 @@ __all__ = [
     "TagCleaner",
     "TagSearcher",
     "TagTypeUpdate",
+    "apply_approved_feedback",
     "build_downloaded_at_utc",
     "convert_tags",
     "ensure_databases",
@@ -49,6 +57,7 @@ __all__ = [
     "initialize_databases",
     "initialize_tag_cleaner",
     "initialize_tag_searcher",
+    "list_local_feedback_applications",
     "needs_manual_refinement",
     "recommend_manual_refinement",
     "recommend_tag_record_refinement",

--- a/src/genai_tag_db_tools/db/overlay_reader.py
+++ b/src/genai_tag_db_tools/db/overlay_reader.py
@@ -233,7 +233,6 @@ class OverlayTagReader:
             rows = (
                 session.query(UserTagTranslationPatch)
                 .filter(
-                    UserTagTranslationPatch.target_scope == "user",
                     UserTagTranslationPatch.target_tag_id == tag_id,
                 )
                 .all()
@@ -259,7 +258,6 @@ class OverlayTagReader:
             rows = (
                 session.query(UserTagTranslationPatch)
                 .filter(
-                    UserTagTranslationPatch.target_scope == "user",
                     UserTagTranslationPatch.target_tag_id.in_(tag_ids),
                 )
                 .all()
@@ -389,7 +387,6 @@ class OverlayTagReader:
             row = (
                 session.query(UserTagUsagePatch)
                 .filter(
-                    UserTagUsagePatch.target_scope == "user",
                     UserTagUsagePatch.target_tag_id == tag_id,
                     UserTagUsagePatch.format_id == format_id,
                 )
@@ -402,9 +399,7 @@ class OverlayTagReader:
     ) -> list[TagUsageCounts]:
         """USER_TAG_USAGE_PATCH を TagUsageCounts オブジェクトに変換して返す。"""
         with self.session_factory() as session:
-            query = session.query(UserTagUsagePatch).filter(
-                UserTagUsagePatch.target_scope == "user"
-            )
+            query = session.query(UserTagUsagePatch)
             if tag_id is not None:
                 query = query.filter(UserTagUsagePatch.target_tag_id == tag_id)
             if format_id is not None:

--- a/src/genai_tag_db_tools/db/schema.py
+++ b/src/genai_tag_db_tools/db/schema.py
@@ -293,3 +293,35 @@ class UserTagUsagePatch(UserOverlayBase):
         CheckConstraint("target_scope IN ('base', 'user')", name="ck_usage_patch_scope"),
         Index("ix_usage_patch_target", "target_scope", "target_tag_id"),
     )
+
+
+class LocalFeedbackApplication(UserOverlayBase):
+    """user-local feedback proposal の apply 履歴。
+
+    user DB 専用の audit table。proposal の二重 apply 防止と、あとからの確認に使う。
+    """
+
+    __tablename__ = "LOCAL_FEEDBACK_APPLICATIONS"
+
+    application_id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    proposal_hash: Mapped[str] = mapped_column()
+    proposal_kind: Mapped[str] = mapped_column()
+    target_kind: Mapped[str] = mapped_column()
+    target_scope: Mapped[str | None] = mapped_column(nullable=True)
+    target_tag_id: Mapped[int | None] = mapped_column(nullable=True)
+    format_name: Mapped[str | None] = mapped_column(nullable=True)
+    field: Mapped[str | None] = mapped_column(nullable=True)
+    approved_by: Mapped[str] = mapped_column()
+    approved_at: Mapped[datetime] = mapped_column(DateTime)
+    applied_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
+    status: Mapped[str] = mapped_column()
+    dry_run: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="0")
+    proposal_json: Mapped[str] = mapped_column()
+    before_json: Mapped[str | None] = mapped_column(nullable=True)
+    after_json: Mapped[str | None] = mapped_column(nullable=True)
+    error_message: Mapped[str | None] = mapped_column(nullable=True)
+
+    __table_args__ = (
+        Index("ix_local_feedback_hash", "proposal_hash"),
+        Index("ix_local_feedback_target", "target_scope", "target_tag_id"),
+    )

--- a/src/genai_tag_db_tools/db/user_tag_repository.py
+++ b/src/genai_tag_db_tools/db/user_tag_repository.py
@@ -182,14 +182,33 @@ class UserTagRepository:
                 )
             session.commit()
 
-    def get_or_create_format_id(self, format_name: str) -> int:
+    def get_format_id(self, format_name: str) -> int | None:
+        """user DB 内の TAG_FORMATS から format_id を取得する。"""
+        with self._session_factory() as session:
+            row = session.query(TagFormat.format_id).filter(TagFormat.format_name == format_name).one_or_none()
+            return int(row[0]) if row else None
+
+    def get_or_create_format_id(self, format_name: str, format_id: int | None = None) -> int:
         """user DB 内の TAG_FORMATS から format_id を取得し、無ければ作る。"""
         with self._session_factory() as session:
             existing = session.query(TagFormat).filter(TagFormat.format_name == format_name).one_or_none()
             if existing is not None:
+                if format_id is not None and int(existing.format_id) != format_id:
+                    raise ValueError(
+                        f"format_name={format_name!r} already exists with format_id={existing.format_id}, "
+                        f"not {format_id}"
+                    )
                 return int(existing.format_id)
-            max_id = session.query(func.max(TagFormat.format_id)).scalar()
-            next_id = 1000 if max_id is None else max(int(max_id) + 1, 1000)
+            if format_id is not None:
+                id_owner = session.query(TagFormat).filter(TagFormat.format_id == format_id).one_or_none()
+                if id_owner is not None and id_owner.format_name != format_name:
+                    raise ValueError(
+                        f"format_id={format_id} already belongs to format_name={id_owner.format_name!r}"
+                    )
+                next_id = format_id
+            else:
+                max_id = session.query(func.max(TagFormat.format_id)).scalar()
+                next_id = 1000 if max_id is None else max(int(max_id) + 1, 1000)
             session.add(
                 TagFormat(
                     format_id=next_id,
@@ -236,6 +255,25 @@ class UserTagRepository:
                         .scalar()
                     )
                     type_id = 1 if max_type_id is None else max(int(max_type_id) + 1, 1)
+            else:
+                id_owner = (
+                    session.query(TagTypeFormatMapping)
+                    .filter(
+                        TagTypeFormatMapping.format_id == format_id,
+                        TagTypeFormatMapping.type_id == type_id,
+                    )
+                    .one_or_none()
+                )
+                if id_owner is not None and id_owner.type_name_id != type_name_row.type_name_id:
+                    owner_name = (
+                        session.query(TagTypeName.type_name)
+                        .filter(TagTypeName.type_name_id == id_owner.type_name_id)
+                        .scalar()
+                    )
+                    raise ValueError(
+                        f"type_id={type_id} for format_id={format_id} already belongs to "
+                        f"type_name={owner_name!r}"
+                    )
 
             session.add(
                 TagTypeFormatMapping(

--- a/src/genai_tag_db_tools/db/user_tag_repository.py
+++ b/src/genai_tag_db_tools/db/user_tag_repository.py
@@ -8,6 +8,10 @@ from sqlalchemy.orm import Session
 
 from genai_tag_db_tools.db.schema import (
     USER_TAG_ID_OFFSET,
+    LocalFeedbackApplication,
+    TagFormat,
+    TagTypeFormatMapping,
+    TagTypeName,
     UserTag,
     UserTagStatusPatch,
     UserTagTranslationPatch,
@@ -177,3 +181,162 @@ class UserTagRepository:
                     )
                 )
             session.commit()
+
+    def get_or_create_format_id(self, format_name: str) -> int:
+        """user DB 内の TAG_FORMATS から format_id を取得し、無ければ作る。"""
+        with self._session_factory() as session:
+            existing = session.query(TagFormat).filter(TagFormat.format_name == format_name).one_or_none()
+            if existing is not None:
+                return int(existing.format_id)
+            max_id = session.query(func.max(TagFormat.format_id)).scalar()
+            next_id = 1000 if max_id is None else max(int(max_id) + 1, 1000)
+            session.add(
+                TagFormat(
+                    format_id=next_id,
+                    format_name=format_name,
+                    description=f"Auto-created local feedback format: {format_name}",
+                )
+            )
+            session.commit()
+            return next_id
+
+    def get_or_create_type_id(self, format_id: int, type_name: str, type_id: int | None = None) -> int:
+        """user DB 内の type mapping を取得し、無ければ作る。"""
+        with self._session_factory() as session:
+            type_name_row = session.query(TagTypeName).filter(TagTypeName.type_name == type_name).one_or_none()
+            if type_name_row is None:
+                max_type_name_id = session.query(func.max(TagTypeName.type_name_id)).scalar()
+                type_name_id = 0 if max_type_name_id is None else int(max_type_name_id) + 1
+                type_name_row = TagTypeName(
+                    type_name_id=type_name_id,
+                    type_name=type_name,
+                    description=f"Auto-created local feedback type: {type_name}",
+                )
+                session.add(type_name_row)
+                session.flush()
+
+            existing = (
+                session.query(TagTypeFormatMapping)
+                .filter(
+                    TagTypeFormatMapping.format_id == format_id,
+                    TagTypeFormatMapping.type_name_id == type_name_row.type_name_id,
+                )
+                .one_or_none()
+            )
+            if existing is not None:
+                return int(existing.type_id)
+
+            if type_id is None:
+                if type_name == "unknown":
+                    type_id = 0
+                else:
+                    max_type_id = (
+                        session.query(func.max(TagTypeFormatMapping.type_id))
+                        .filter(TagTypeFormatMapping.format_id == format_id)
+                        .scalar()
+                    )
+                    type_id = 1 if max_type_id is None else max(int(max_type_id) + 1, 1)
+
+            session.add(
+                TagTypeFormatMapping(
+                    format_id=format_id,
+                    type_id=type_id,
+                    type_name_id=type_name_row.type_name_id,
+                    description=f"Auto-created local feedback mapping: {format_id}/{type_name}",
+                )
+            )
+            session.commit()
+            return int(type_id)
+
+    def get_status_patch(
+        self,
+        target_scope: str,
+        target_tag_id: int,
+        format_id: int,
+    ) -> UserTagStatusPatch | None:
+        """既存の status patch を detached 風に返す。"""
+        with self._session_factory() as session:
+            row = (
+                session.query(UserTagStatusPatch)
+                .filter(
+                    UserTagStatusPatch.target_scope == target_scope,
+                    UserTagStatusPatch.target_tag_id == target_tag_id,
+                    UserTagStatusPatch.format_id == format_id,
+                )
+                .one_or_none()
+            )
+            if row is None:
+                return None
+            return UserTagStatusPatch(
+                target_scope=row.target_scope,
+                target_tag_id=row.target_tag_id,
+                format_id=row.format_id,
+                type_id=row.type_id,
+                alias=row.alias,
+                preferred_scope=row.preferred_scope,
+                preferred_tag_id=row.preferred_tag_id,
+                deprecated=row.deprecated,
+                deprecated_at=row.deprecated_at,
+            )
+
+    def has_applied_feedback(self, proposal_hash: str) -> bool:
+        with self._session_factory() as session:
+            return (
+                session.query(LocalFeedbackApplication)
+                .filter(
+                    LocalFeedbackApplication.proposal_hash == proposal_hash,
+                    LocalFeedbackApplication.status == "applied",
+                )
+                .one_or_none()
+                is not None
+            )
+
+    def record_feedback_application(
+        self,
+        *,
+        proposal_hash: str,
+        proposal_kind: str,
+        target_kind: str,
+        target_scope: str | None,
+        target_tag_id: int | None,
+        format_name: str | None,
+        field: str | None,
+        approved_by: str,
+        approved_at,
+        status: str,
+        dry_run: bool,
+        proposal_json: str,
+        before_json: str | None,
+        after_json: str | None,
+        error_message: str | None = None,
+    ) -> LocalFeedbackApplication:
+        with self._session_factory() as session:
+            row = LocalFeedbackApplication(
+                proposal_hash=proposal_hash,
+                proposal_kind=proposal_kind,
+                target_kind=target_kind,
+                target_scope=target_scope,
+                target_tag_id=target_tag_id,
+                format_name=format_name,
+                field=field,
+                approved_by=approved_by,
+                approved_at=approved_at,
+                status=status,
+                dry_run=dry_run,
+                proposal_json=proposal_json,
+                before_json=before_json,
+                after_json=after_json,
+                error_message=error_message,
+            )
+            session.add(row)
+            session.commit()
+            session.refresh(row)
+            return row
+
+    def list_feedback_applications(self) -> list[LocalFeedbackApplication]:
+        with self._session_factory() as session:
+            return (
+                session.query(LocalFeedbackApplication)
+                .order_by(LocalFeedbackApplication.application_id)
+                .all()
+            )

--- a/src/genai_tag_db_tools/db/user_tag_repository.py
+++ b/src/genai_tag_db_tools/db/user_tag_repository.py
@@ -286,6 +286,34 @@ class UserTagRepository:
             session.commit()
             return int(type_id)
 
+    def get_type_id(self, format_id: int, type_name: str) -> int | None:
+        """user DB 内の既存 type mapping から type_id を取得する。"""
+        with self._session_factory() as session:
+            row = (
+                session.query(TagTypeFormatMapping.type_id)
+                .join(TagTypeName, TagTypeFormatMapping.type_name_id == TagTypeName.type_name_id)
+                .filter(
+                    TagTypeFormatMapping.format_id == format_id,
+                    TagTypeName.type_name == type_name,
+                )
+                .one_or_none()
+            )
+            return int(row[0]) if row else None
+
+    def get_type_name_for_type_id(self, format_id: int, type_id: int) -> str | None:
+        """user DB 内の既存 type mapping から type_id の所有 type_name を取得する。"""
+        with self._session_factory() as session:
+            row = (
+                session.query(TagTypeName.type_name)
+                .join(TagTypeFormatMapping, TagTypeFormatMapping.type_name_id == TagTypeName.type_name_id)
+                .filter(
+                    TagTypeFormatMapping.format_id == format_id,
+                    TagTypeFormatMapping.type_id == type_id,
+                )
+                .one_or_none()
+            )
+            return str(row[0]) if row else None
+
     def get_status_patch(
         self,
         target_scope: str,

--- a/src/genai_tag_db_tools/models.py
+++ b/src/genai_tag_db_tools/models.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Literal, TypedDict
 
 from pydantic import BaseModel, Field, model_validator
@@ -409,6 +410,54 @@ class RefinementRecommendation(BaseModel):
     proposals: list[DbFeedbackProposal] = Field(
         default_factory=list,
         description="Future DB feedback proposals derived from the recommendation",
+    )
+
+
+class ApprovedDbFeedback(BaseModel):
+    """人間承認済みの DB feedback proposal。"""
+
+    proposal: DbFeedbackProposal = Field(..., description="Approved proposal")
+    approved: bool = Field(..., description="Whether this proposal was approved by a human")
+    approved_by: str = Field(..., description="Human approver identifier")
+    approved_at: datetime = Field(..., description="Approval timestamp")
+    approval_note: str | None = Field(default=None, description="Optional approval note")
+
+
+class LocalFeedbackApplicationRecord(BaseModel):
+    """user-local feedback apply の audit record。"""
+
+    application_id: int
+    proposal_hash: str
+    proposal_kind: str
+    target_kind: str
+    target_scope: Literal["base", "user"] | None = None
+    target_tag_id: int | None = None
+    format_name: str | None = None
+    field: str | None = None
+    approved_by: str
+    approved_at: datetime
+    applied_at: datetime | None = None
+    status: Literal["applied", "dry_run", "skipped", "failed"]
+    dry_run: bool
+    proposal_json: str
+    before_json: str | None = None
+    after_json: str | None = None
+    error_message: str | None = None
+
+
+class LocalFeedbackApplyResult(BaseModel):
+    """user-local feedback apply の結果。"""
+
+    ok: bool = Field(..., description="Whether the operation completed without validation/apply error")
+    status: Literal["applied", "dry_run", "skipped", "failed"] = Field(..., description="Apply status")
+    dry_run: bool = Field(..., description="Whether this was a dry run")
+    proposal_hash: str = Field(..., description="Stable hash of the proposal payload")
+    proposal_kind: str = Field(..., description="Proposal kind")
+    message: str = Field(..., description="Human-readable result message")
+    changes: list[dict[str, ProposalValue]] = Field(default_factory=list, description="Planned or applied changes")
+    application: LocalFeedbackApplicationRecord | None = Field(
+        default=None,
+        description="Audit record for applied/dry-run/skipped proposals",
     )
 
 

--- a/src/genai_tag_db_tools/services/feedback_apply.py
+++ b/src/genai_tag_db_tools/services/feedback_apply.py
@@ -143,28 +143,16 @@ class LocalFeedbackApplyService:
         proposed = _require_proposed(proposal)
         format_id = self._format_id(target)
         existing = self._user_repository.get_status_patch(target.target_scope, target.target_tag_id, format_id)
-        current = proposal.current or {}
-        alias = existing.alias if existing is not None else (_optional_bool_value(current, "alias") or False)
-        preferred_scope = (
-            existing.preferred_scope
-            if existing is not None
-            else (_optional_string_value(current, "preferred_scope") or target.target_scope)
-        )
-        preferred_tag_id = (
-            existing.preferred_tag_id
-            if existing is not None
-            else (_optional_int_value(current, "preferred_tag_id") or target.target_tag_id)
-        )
-        type_id = existing.type_id if existing is not None else (_optional_int_value(current, "type_id") or 0)
+        status = self._status_values(target, format_id, existing, proposal.current)
         deprecated = _bool_value(proposed, "deprecated")
         self._user_repository.write_patch(
             target_scope=target.target_scope,
             target_tag_id=target.target_tag_id,
             format_id=format_id,
-            type_id=type_id,
-            alias=alias,
-            preferred_scope=preferred_scope,
-            preferred_tag_id=preferred_tag_id,
+            type_id=status["type_id"],
+            alias=status["alias"],
+            preferred_scope=status["preferred_scope"],
+            preferred_tag_id=status["preferred_tag_id"],
             deprecated=deprecated,
         )
 
@@ -174,30 +162,18 @@ class LocalFeedbackApplyService:
         format_id = self._format_id(target)
         type_name = _optional_string_value(proposed, "type_name") or "unknown"
         proposed_type_id = _optional_int_value(proposed, "type_id")
-        type_id = self._user_repository.get_or_create_type_id(format_id, type_name, proposed_type_id)
+        type_id = self._resolve_type_id(target, format_id, type_name, proposed_type_id)
         existing = self._user_repository.get_status_patch(target.target_scope, target.target_tag_id, format_id)
-        current = proposal.current or {}
-        alias = existing.alias if existing is not None else (_optional_bool_value(current, "alias") or False)
-        preferred_scope = (
-            existing.preferred_scope
-            if existing is not None
-            else (_optional_string_value(current, "preferred_scope") or target.target_scope)
-        )
-        preferred_tag_id = (
-            existing.preferred_tag_id
-            if existing is not None
-            else (_optional_int_value(current, "preferred_tag_id") or target.target_tag_id)
-        )
-        deprecated = existing.deprecated if existing is not None else (_optional_bool_value(current, "deprecated") or False)
+        status = self._status_values(target, format_id, existing, proposal.current)
         self._user_repository.write_patch(
             target_scope=target.target_scope,
             target_tag_id=target.target_tag_id,
             format_id=format_id,
             type_id=type_id,
-            alias=alias,
-            preferred_scope=preferred_scope,
-            preferred_tag_id=preferred_tag_id,
-            deprecated=deprecated,
+            alias=status["alias"],
+            preferred_scope=status["preferred_scope"],
+            preferred_tag_id=status["preferred_tag_id"],
+            deprecated=status["deprecated"],
         )
 
     def _apply_usage(self, proposal: DbFeedbackProposal) -> None:
@@ -227,11 +203,7 @@ class LocalFeedbackApplyService:
             target_scope = target.target_scope
 
         type_name = _optional_string_value(proposed, "type_name") or "unknown"
-        type_id = self._user_repository.get_or_create_type_id(
-            format_id,
-            type_name,
-            _optional_int_value(proposed, "type_id"),
-        )
+        type_id = self._resolve_type_id(target, format_id, type_name, _optional_int_value(proposed, "type_id"))
         self._user_repository.write_patch(
             target_scope=target_scope,
             target_tag_id=alias_tag_id,
@@ -249,18 +221,16 @@ class LocalFeedbackApplyService:
             raise ValueError("preferred_tag_correction requires preferred_scope and preferred_tag_id")
         format_id = self._format_id(target)
         existing = self._user_repository.get_status_patch(target.target_scope, target.target_tag_id, format_id)
-        current = proposal.current or {}
-        type_id = existing.type_id if existing is not None else (_optional_int_value(current, "type_id") or 0)
-        deprecated = existing.deprecated if existing is not None else (_optional_bool_value(current, "deprecated") or False)
+        status = self._status_values(target, format_id, existing, proposal.current)
         self._user_repository.write_patch(
             target_scope=target.target_scope,
             target_tag_id=target.target_tag_id,
             format_id=format_id,
-            type_id=type_id,
+            type_id=status["type_id"],
             alias=True,
             preferred_scope=target.preferred_scope,
             preferred_tag_id=target.preferred_tag_id,
-            deprecated=deprecated,
+            deprecated=status["deprecated"],
         )
 
     def _apply_tag_name(self, proposal: DbFeedbackProposal) -> None:
@@ -279,6 +249,8 @@ class LocalFeedbackApplyService:
         if target.format_name is None:
             raise ValueError("format-dependent local apply requires format_name")
         base_format_id = self._reader_format_id(target.format_name)
+        if target.target_scope == "base" and self._reader is None:
+            raise ValueError("base-scope format-dependent local apply requires reader")
         return self._user_repository.get_or_create_format_id(target.format_name, base_format_id)
 
     def _reader_format_id(self, format_name: str) -> int | None:
@@ -288,6 +260,75 @@ class LocalFeedbackApplyService:
             return int(self._reader.get_format_id(format_name))
         except ValueError:
             return None
+
+    def _reader_type_id(self, type_name: str, format_id: int) -> int | None:
+        if self._reader is None or not hasattr(self._reader, "get_type_id_for_format"):
+            return None
+        return self._reader.get_type_id_for_format(type_name, format_id)
+
+    def _reader_status(self, target: ProposalTarget, format_id: int) -> Any | None:
+        if self._reader is None or target.target_tag_id is None:
+            return None
+        if not hasattr(self._reader, "get_tag_status"):
+            return None
+        return self._reader.get_tag_status(target.target_tag_id, format_id)
+
+    def _resolve_type_id(
+        self,
+        target: ProposalTarget,
+        format_id: int,
+        type_name: str,
+        proposed_type_id: int | None,
+    ) -> int:
+        reader_type_id = self._reader_type_id(type_name, format_id)
+        if target.target_scope == "base":
+            if proposed_type_id is not None and reader_type_id is not None and proposed_type_id != reader_type_id:
+                raise ValueError(
+                    f"proposed type_id={proposed_type_id} does not match reader type_id={reader_type_id} "
+                    f"for {target.format_name}/{type_name}"
+                )
+            if reader_type_id is not None:
+                return reader_type_id
+            if proposed_type_id is not None:
+                return proposed_type_id
+            raise ValueError(f"base-scope type correction requires resolvable type_id for {type_name!r}")
+        return self._user_repository.get_or_create_type_id(format_id, type_name, proposed_type_id)
+
+    def _status_values(
+        self,
+        target: ProposalTarget,
+        format_id: int,
+        existing: Any | None,
+        current: Mapping[str, ProposalValue] | None,
+    ) -> dict[str, Any]:
+        if existing is not None:
+            return {
+                "type_id": existing.type_id,
+                "alias": existing.alias,
+                "preferred_scope": existing.preferred_scope,
+                "preferred_tag_id": existing.preferred_tag_id,
+                "deprecated": existing.deprecated,
+            }
+
+        reader_status = self._reader_status(target, format_id)
+        if reader_status is not None:
+            preferred_tag_id = int(reader_status.preferred_tag_id)
+            return {
+                "type_id": int(reader_status.type_id),
+                "alias": bool(reader_status.alias),
+                "preferred_scope": "user" if preferred_tag_id >= 1_000_000_000 else "base",
+                "preferred_tag_id": preferred_tag_id,
+                "deprecated": bool(reader_status.deprecated),
+            }
+
+        current_values = current or {}
+        return {
+            "type_id": _optional_int_value(current_values, "type_id") or 0,
+            "alias": _optional_bool_value(current_values, "alias") or False,
+            "preferred_scope": _optional_string_value(current_values, "preferred_scope") or target.target_scope,
+            "preferred_tag_id": _optional_int_value(current_values, "preferred_tag_id") or target.target_tag_id,
+            "deprecated": _optional_bool_value(current_values, "deprecated") or False,
+        }
 
     def _validate_proposal(self, proposal: DbFeedbackProposal) -> None:
         match proposal.kind:

--- a/src/genai_tag_db_tools/services/feedback_apply.py
+++ b/src/genai_tag_db_tools/services/feedback_apply.py
@@ -31,8 +31,9 @@ class LocalFeedbackApplyService:
         "tag_name_correction",
     }
 
-    def __init__(self, user_repository: UserTagRepository) -> None:
+    def __init__(self, user_repository: UserTagRepository, reader: Any | None = None) -> None:
         self._user_repository = user_repository
+        self._reader = reader
 
     def apply(self, feedback: ApprovedDbFeedback, *, dry_run: bool = False) -> LocalFeedbackApplyResult:
         proposal = feedback.proposal
@@ -44,6 +45,7 @@ class LocalFeedbackApplyService:
             raise ValueError(f"local apply unsupported proposal kind: {proposal.kind}")
         if proposal.kind == "format_relation_review":
             raise ValueError("format_relation_review is review-only and cannot be applied")
+        self._validate_proposal(proposal)
 
         if self._user_repository.has_applied_feedback(proposal_hash):
             application = self._record_application(
@@ -141,10 +143,19 @@ class LocalFeedbackApplyService:
         proposed = _require_proposed(proposal)
         format_id = self._format_id(target)
         existing = self._user_repository.get_status_patch(target.target_scope, target.target_tag_id, format_id)
-        alias = existing.alias if existing is not None else False
-        preferred_scope = existing.preferred_scope if existing is not None else target.target_scope
-        preferred_tag_id = existing.preferred_tag_id if existing is not None else target.target_tag_id
-        type_id = existing.type_id if existing is not None else 0
+        current = proposal.current or {}
+        alias = existing.alias if existing is not None else (_optional_bool_value(current, "alias") or False)
+        preferred_scope = (
+            existing.preferred_scope
+            if existing is not None
+            else (_optional_string_value(current, "preferred_scope") or target.target_scope)
+        )
+        preferred_tag_id = (
+            existing.preferred_tag_id
+            if existing is not None
+            else (_optional_int_value(current, "preferred_tag_id") or target.target_tag_id)
+        )
+        type_id = existing.type_id if existing is not None else (_optional_int_value(current, "type_id") or 0)
         deprecated = _bool_value(proposed, "deprecated")
         self._user_repository.write_patch(
             target_scope=target.target_scope,
@@ -165,10 +176,19 @@ class LocalFeedbackApplyService:
         proposed_type_id = _optional_int_value(proposed, "type_id")
         type_id = self._user_repository.get_or_create_type_id(format_id, type_name, proposed_type_id)
         existing = self._user_repository.get_status_patch(target.target_scope, target.target_tag_id, format_id)
-        alias = existing.alias if existing is not None else False
-        preferred_scope = existing.preferred_scope if existing is not None else target.target_scope
-        preferred_tag_id = existing.preferred_tag_id if existing is not None else target.target_tag_id
-        deprecated = existing.deprecated if existing is not None else False
+        current = proposal.current or {}
+        alias = existing.alias if existing is not None else (_optional_bool_value(current, "alias") or False)
+        preferred_scope = (
+            existing.preferred_scope
+            if existing is not None
+            else (_optional_string_value(current, "preferred_scope") or target.target_scope)
+        )
+        preferred_tag_id = (
+            existing.preferred_tag_id
+            if existing is not None
+            else (_optional_int_value(current, "preferred_tag_id") or target.target_tag_id)
+        )
+        deprecated = existing.deprecated if existing is not None else (_optional_bool_value(current, "deprecated") or False)
         self._user_repository.write_patch(
             target_scope=target.target_scope,
             target_tag_id=target.target_tag_id,
@@ -195,6 +215,7 @@ class LocalFeedbackApplyService:
         proposed = _require_proposed(proposal)
         if target.preferred_scope is None or target.preferred_tag_id is None:
             raise ValueError("alias_addition requires preferred_scope and preferred_tag_id")
+        format_id = self._format_id(target)
 
         alias_tag_id = target.target_tag_id
         if alias_tag_id is None:
@@ -205,7 +226,6 @@ class LocalFeedbackApplyService:
         else:
             target_scope = target.target_scope
 
-        format_id = self._format_id(target)
         type_name = _optional_string_value(proposed, "type_name") or "unknown"
         type_id = self._user_repository.get_or_create_type_id(
             format_id,
@@ -229,8 +249,9 @@ class LocalFeedbackApplyService:
             raise ValueError("preferred_tag_correction requires preferred_scope and preferred_tag_id")
         format_id = self._format_id(target)
         existing = self._user_repository.get_status_patch(target.target_scope, target.target_tag_id, format_id)
-        type_id = existing.type_id if existing is not None else 0
-        deprecated = existing.deprecated if existing is not None else False
+        current = proposal.current or {}
+        type_id = existing.type_id if existing is not None else (_optional_int_value(current, "type_id") or 0)
+        deprecated = existing.deprecated if existing is not None else (_optional_bool_value(current, "deprecated") or False)
         self._user_repository.write_patch(
             target_scope=target.target_scope,
             target_tag_id=target.target_tag_id,
@@ -257,7 +278,55 @@ class LocalFeedbackApplyService:
     def _format_id(self, target: ProposalTarget) -> int:
         if target.format_name is None:
             raise ValueError("format-dependent local apply requires format_name")
-        return self._user_repository.get_or_create_format_id(target.format_name)
+        base_format_id = self._reader_format_id(target.format_name)
+        return self._user_repository.get_or_create_format_id(target.format_name, base_format_id)
+
+    def _reader_format_id(self, format_name: str) -> int | None:
+        if self._reader is None:
+            return None
+        try:
+            return int(self._reader.get_format_id(format_name))
+        except ValueError:
+            return None
+
+    def _validate_proposal(self, proposal: DbFeedbackProposal) -> None:
+        match proposal.kind:
+            case "translation_correction":
+                _require_target_tag(proposal.target)
+                proposed = _require_proposed(proposal)
+                _string_value(proposed, "language", fallback=proposal.target.language)
+                _string_value(proposed, "translation")
+            case "status_correction":
+                target = _require_target_tag(proposal.target)
+                _bool_value(_require_proposed(proposal), "deprecated")
+                _require_format_name(target)
+            case "type_correction":
+                target = _require_target_tag(proposal.target)
+                _require_proposed(proposal)
+                _require_format_name(target)
+            case "usage_correction":
+                target = _require_target_tag(proposal.target)
+                _int_value(_require_proposed(proposal), "count")
+                _require_format_name(target)
+            case "alias_addition":
+                target = proposal.target
+                proposed = _require_proposed(proposal)
+                if target.preferred_scope is None or target.preferred_tag_id is None:
+                    raise ValueError("alias_addition requires preferred_scope and preferred_tag_id")
+                _require_format_name(target)
+                if target.target_tag_id is None:
+                    _string_value(proposed, "alias_tag", fallback=_optional_string_value(proposed, "tag"))
+            case "preferred_tag_correction":
+                target = _require_target_tag(proposal.target)
+                if target.preferred_scope is None or target.preferred_tag_id is None:
+                    raise ValueError("preferred_tag_correction requires preferred_scope and preferred_tag_id")
+                _require_format_name(target)
+            case "tag_name_correction":
+                if proposal.target.target_tag_id is not None:
+                    raise ValueError("tag_name_correction can only create a new user tag locally")
+                _string_value(_require_proposed(proposal), "tag")
+            case _:
+                raise ValueError(f"local apply unsupported proposal kind: {proposal.kind}")
 
     def _snapshot_before(self, proposal: DbFeedbackProposal) -> dict[str, ProposalValue]:
         return {
@@ -315,9 +384,10 @@ def apply_approved_feedback(
     feedback: ApprovedDbFeedback,
     *,
     user_repository: UserTagRepository,
+    reader: Any | None = None,
     dry_run: bool = False,
 ) -> LocalFeedbackApplyResult:
-    return LocalFeedbackApplyService(user_repository).apply(feedback, dry_run=dry_run)
+    return LocalFeedbackApplyService(user_repository, reader=reader).apply(feedback, dry_run=dry_run)
 
 
 def list_local_feedback_applications(
@@ -357,6 +427,12 @@ def _require_target_tag(target: ProposalTarget) -> ProposalTarget:
     if target.target_tag_id is None:
         raise ValueError(f"{target.kind} proposal requires target_tag_id")
     return target
+
+
+def _require_format_name(target: ProposalTarget) -> str:
+    if target.format_name is None:
+        raise ValueError("format-dependent local apply requires format_name")
+    return target.format_name
 
 
 def _require_proposed(proposal: DbFeedbackProposal) -> Mapping[str, ProposalValue]:

--- a/src/genai_tag_db_tools/services/feedback_apply.py
+++ b/src/genai_tag_db_tools/services/feedback_apply.py
@@ -72,7 +72,9 @@ class LocalFeedbackApplyService:
         changes = self._planned_changes(proposal)
         after = {"changes": changes}
 
-        if not dry_run:
+        if dry_run:
+            self._prepare_proposal(proposal)
+        else:
             self._apply_proposal(proposal)
 
         application = self._record_application(
@@ -126,11 +128,27 @@ class LocalFeedbackApplyService:
             case _:
                 raise ValueError(f"local apply unsupported proposal kind: {proposal.kind}")
 
+    def _prepare_proposal(self, proposal: DbFeedbackProposal) -> None:
+        match proposal.kind:
+            case "translation_correction":
+                self._prepare_translation(proposal)
+            case "status_correction":
+                self._prepare_status(proposal, create=False)
+            case "type_correction":
+                self._prepare_type(proposal, create=False)
+            case "usage_correction":
+                self._prepare_usage(proposal, create=False)
+            case "alias_addition":
+                self._prepare_alias_addition(proposal, create=False)
+            case "preferred_tag_correction":
+                self._prepare_preferred_correction(proposal, create=False)
+            case "tag_name_correction":
+                self._prepare_tag_name(proposal)
+            case _:
+                raise ValueError(f"local apply unsupported proposal kind: {proposal.kind}")
+
     def _apply_translation(self, proposal: DbFeedbackProposal) -> None:
-        target = _require_target_tag(proposal.target)
-        proposed = _require_proposed(proposal)
-        language = _string_value(proposed, "language", fallback=proposal.target.language)
-        translation = _string_value(proposed, "translation")
+        target, language, translation = self._prepare_translation(proposal)
         self._user_repository.write_translation_patch(
             target_scope=target.target_scope,
             target_tag_id=target.target_tag_id,
@@ -138,12 +156,18 @@ class LocalFeedbackApplyService:
             translation=translation,
         )
 
-    def _apply_status(self, proposal: DbFeedbackProposal) -> None:
+    def _prepare_translation(self, proposal: DbFeedbackProposal) -> tuple[ProposalTarget, str, str]:
         target = _require_target_tag(proposal.target)
         proposed = _require_proposed(proposal)
-        format_id = self._format_id(target)
-        existing = self._user_repository.get_status_patch(target.target_scope, target.target_tag_id, format_id)
-        status = self._status_values(target, format_id, existing, proposal.current)
+        language = _string_value(proposed, "language", fallback=proposal.target.language)
+        translation = _string_value(proposed, "translation")
+        current_translation = _optional_mapping_string(proposal.current, "translation")
+        if current_translation is not None and current_translation != translation:
+            raise ValueError("translation_correction cannot replace existing translation with current overlay schema")
+        return target, language, translation
+
+    def _apply_status(self, proposal: DbFeedbackProposal) -> None:
+        target, format_id, status, proposed = self._prepare_status(proposal, create=True)
         deprecated = _bool_value(proposed, "deprecated")
         self._user_repository.write_patch(
             target_scope=target.target_scope,
@@ -156,15 +180,18 @@ class LocalFeedbackApplyService:
             deprecated=deprecated,
         )
 
-    def _apply_type(self, proposal: DbFeedbackProposal) -> None:
+    def _prepare_status(
+        self, proposal: DbFeedbackProposal, *, create: bool
+    ) -> tuple[ProposalTarget, int, dict[str, Any], Mapping[str, ProposalValue]]:
         target = _require_target_tag(proposal.target)
         proposed = _require_proposed(proposal)
-        format_id = self._format_id(target)
-        type_name = _optional_string_value(proposed, "type_name") or "unknown"
-        proposed_type_id = _optional_int_value(proposed, "type_id")
-        type_id = self._resolve_type_id(target, format_id, type_name, proposed_type_id)
+        format_id = self._format_id(target, create=create)
         existing = self._user_repository.get_status_patch(target.target_scope, target.target_tag_id, format_id)
         status = self._status_values(target, format_id, existing, proposal.current)
+        return target, format_id, status, proposed
+
+    def _apply_type(self, proposal: DbFeedbackProposal) -> None:
+        target, format_id, type_id, status = self._prepare_type(proposal, create=True)
         self._user_repository.write_patch(
             target_scope=target.target_scope,
             target_tag_id=target.target_tag_id,
@@ -176,23 +203,34 @@ class LocalFeedbackApplyService:
             deprecated=status["deprecated"],
         )
 
-    def _apply_usage(self, proposal: DbFeedbackProposal) -> None:
+    def _prepare_type(self, proposal: DbFeedbackProposal, *, create: bool) -> tuple[ProposalTarget, int, int, dict[str, Any]]:
         target = _require_target_tag(proposal.target)
         proposed = _require_proposed(proposal)
+        format_id = self._format_id(target, create=create)
+        type_name = _required_type_name_or_id(proposed)
+        proposed_type_id = _optional_int_value(proposed, "type_id")
+        type_id = self._resolve_type_id(target, format_id, type_name, proposed_type_id, create=create)
+        existing = self._user_repository.get_status_patch(target.target_scope, target.target_tag_id, format_id)
+        status = self._status_values(target, format_id, existing, proposal.current)
+        return target, format_id, type_id, status
+
+    def _apply_usage(self, proposal: DbFeedbackProposal) -> None:
+        target, format_id, count = self._prepare_usage(proposal, create=True)
         self._user_repository.write_usage_patch(
             target_scope=target.target_scope,
             target_tag_id=target.target_tag_id,
-            format_id=self._format_id(target),
-            count=_int_value(proposed, "count"),
+            format_id=format_id,
+            count=count,
         )
 
-    def _apply_alias_addition(self, proposal: DbFeedbackProposal) -> None:
-        target = proposal.target
+    def _prepare_usage(self, proposal: DbFeedbackProposal, *, create: bool) -> tuple[ProposalTarget, int, int]:
+        target = _require_target_tag(proposal.target)
         proposed = _require_proposed(proposal)
-        if target.preferred_scope is None or target.preferred_tag_id is None:
-            raise ValueError("alias_addition requires preferred_scope and preferred_tag_id")
-        format_id = self._format_id(target)
+        count = _non_negative_int_value(proposed, "count")
+        return target, self._format_id(target, create=create), count
 
+    def _apply_alias_addition(self, proposal: DbFeedbackProposal) -> None:
+        target, format_id, type_id, proposed = self._prepare_alias_addition(proposal, create=True)
         alias_tag_id = target.target_tag_id
         if alias_tag_id is None:
             alias_tag = _string_value(proposed, "alias_tag", fallback=_optional_string_value(proposed, "tag"))
@@ -202,8 +240,6 @@ class LocalFeedbackApplyService:
         else:
             target_scope = target.target_scope
 
-        type_name = _optional_string_value(proposed, "type_name") or "unknown"
-        type_id = self._resolve_type_id(target, format_id, type_name, _optional_int_value(proposed, "type_id"))
         self._user_repository.write_patch(
             target_scope=target_scope,
             target_tag_id=alias_tag_id,
@@ -215,13 +251,26 @@ class LocalFeedbackApplyService:
             deprecated=_optional_bool_value(proposed, "deprecated") or False,
         )
 
-    def _apply_preferred_correction(self, proposal: DbFeedbackProposal) -> None:
-        target = _require_target_tag(proposal.target)
+    def _prepare_alias_addition(
+        self, proposal: DbFeedbackProposal, *, create: bool
+    ) -> tuple[ProposalTarget, int, int, Mapping[str, ProposalValue]]:
+        target = proposal.target
+        proposed = _require_proposed(proposal)
         if target.preferred_scope is None or target.preferred_tag_id is None:
-            raise ValueError("preferred_tag_correction requires preferred_scope and preferred_tag_id")
-        format_id = self._format_id(target)
-        existing = self._user_repository.get_status_patch(target.target_scope, target.target_tag_id, format_id)
-        status = self._status_values(target, format_id, existing, proposal.current)
+            raise ValueError("alias_addition requires preferred_scope and preferred_tag_id")
+        format_id = self._format_id(target, create=create)
+        type_name = _required_type_name_or_id(proposed)
+        type_id = self._resolve_type_id(
+            target,
+            format_id,
+            type_name,
+            _optional_int_value(proposed, "type_id"),
+            create=create,
+        )
+        return target, format_id, type_id, proposed
+
+    def _apply_preferred_correction(self, proposal: DbFeedbackProposal) -> None:
+        target, format_id, status = self._prepare_preferred_correction(proposal, create=True)
         self._user_repository.write_patch(
             target_scope=target.target_scope,
             target_tag_id=target.target_tag_id,
@@ -233,7 +282,22 @@ class LocalFeedbackApplyService:
             deprecated=status["deprecated"],
         )
 
+    def _prepare_preferred_correction(
+        self, proposal: DbFeedbackProposal, *, create: bool
+    ) -> tuple[ProposalTarget, int, dict[str, Any]]:
+        target = _require_target_tag(proposal.target)
+        if target.preferred_scope is None or target.preferred_tag_id is None:
+            raise ValueError("preferred_tag_correction requires preferred_scope and preferred_tag_id")
+        format_id = self._format_id(target, create=create)
+        existing = self._user_repository.get_status_patch(target.target_scope, target.target_tag_id, format_id)
+        status = self._status_values(target, format_id, existing, proposal.current)
+        return target, format_id, status
+
     def _apply_tag_name(self, proposal: DbFeedbackProposal) -> None:
+        tag, source_tag = self._prepare_tag_name(proposal)
+        self._user_repository.create_user_tag(source_tag, tag)
+
+    def _prepare_tag_name(self, proposal: DbFeedbackProposal) -> tuple[str, str]:
         if proposal.target.target_tag_id is not None:
             raise ValueError("tag_name_correction can only create a new user tag locally")
         proposed = _require_proposed(proposal)
@@ -243,28 +307,43 @@ class LocalFeedbackApplyService:
             or _optional_mapping_string(proposal.current, "source_tag")
             or tag
         )
-        self._user_repository.create_user_tag(source_tag, tag)
+        return tag, source_tag
 
-    def _format_id(self, target: ProposalTarget) -> int:
+    def _format_id(self, target: ProposalTarget, *, create: bool) -> int:
         if target.format_name is None:
             raise ValueError("format-dependent local apply requires format_name")
         base_format_id = self._reader_format_id(target.format_name)
-        if target.target_scope == "base" and self._reader is None:
-            raise ValueError("base-scope format-dependent local apply requires reader")
-        return self._user_repository.get_or_create_format_id(target.format_name, base_format_id)
+        if base_format_id is not None:
+            if create:
+                return self._user_repository.get_or_create_format_id(target.format_name, base_format_id)
+            return base_format_id
+
+        existing_user_format_id = self._user_repository.get_format_id(target.format_name)
+        if existing_user_format_id is not None:
+            return existing_user_format_id
+
+        if target.target_scope == "base":
+            raise ValueError("base-scope format-dependent local apply requires reader-resolved format_id")
+        if self._reader is None:
+            raise ValueError("format-dependent local apply requires reader or existing local format")
+        if not create:
+            raise ValueError(f"format_name={target.format_name!r} is not resolvable without creating a local format")
+        return self._user_repository.get_or_create_format_id(target.format_name)
 
     def _reader_format_id(self, format_name: str) -> int | None:
         if self._reader is None:
             return None
         try:
-            return int(self._reader.get_format_id(format_name))
+            format_id = int(self._reader.get_format_id(format_name))
         except ValueError:
             return None
+        return format_id if format_id > 0 else None
 
     def _reader_type_id(self, type_name: str, format_id: int) -> int | None:
         if self._reader is None or not hasattr(self._reader, "get_type_id_for_format"):
             return None
-        return self._reader.get_type_id_for_format(type_name, format_id)
+        type_id = self._reader.get_type_id_for_format(type_name, format_id)
+        return int(type_id) if type_id is not None else None
 
     def _reader_status(self, target: ProposalTarget, format_id: int) -> Any | None:
         if self._reader is None or target.target_tag_id is None:
@@ -279,19 +358,39 @@ class LocalFeedbackApplyService:
         format_id: int,
         type_name: str,
         proposed_type_id: int | None,
+        *,
+        create: bool,
     ) -> int:
         reader_type_id = self._reader_type_id(type_name, format_id)
-        if target.target_scope == "base":
-            if proposed_type_id is not None and reader_type_id is not None and proposed_type_id != reader_type_id:
-                raise ValueError(
-                    f"proposed type_id={proposed_type_id} does not match reader type_id={reader_type_id} "
-                    f"for {target.format_name}/{type_name}"
-                )
-            if reader_type_id is not None:
-                return reader_type_id
-            if proposed_type_id is not None:
-                return proposed_type_id
+        if proposed_type_id is not None and reader_type_id is not None and proposed_type_id != reader_type_id:
+            raise ValueError(
+                f"proposed type_id={proposed_type_id} does not match reader type_id={reader_type_id} "
+                f"for {target.format_name}/{type_name}"
+            )
+        if reader_type_id is not None:
+            return reader_type_id
+        if target.target_scope == "base" and proposed_type_id is None:
             raise ValueError(f"base-scope type correction requires resolvable type_id for {type_name!r}")
+        if not create:
+            existing_type_id = self._user_repository.get_type_id(format_id, type_name)
+            if existing_type_id is not None:
+                return existing_type_id
+            if proposed_type_id is not None:
+                owner_name = self._user_repository.get_type_name_for_type_id(format_id, proposed_type_id)
+                if owner_name is not None and owner_name != type_name:
+                    raise ValueError(
+                        f"type_id={proposed_type_id} for format_id={format_id} already belongs to "
+                        f"type_name={owner_name!r}"
+                    )
+                return proposed_type_id
+            raise ValueError(f"type correction requires resolvable type_id for {type_name!r}")
+        if proposed_type_id is not None:
+            owner_name = self._user_repository.get_type_name_for_type_id(format_id, proposed_type_id)
+            if owner_name is not None and owner_name != type_name:
+                raise ValueError(
+                    f"type_id={proposed_type_id} for format_id={format_id} already belongs to "
+                    f"type_name={owner_name!r}"
+                )
         return self._user_repository.get_or_create_type_id(format_id, type_name, proposed_type_id)
 
     def _status_values(
@@ -343,11 +442,11 @@ class LocalFeedbackApplyService:
                 _require_format_name(target)
             case "type_correction":
                 target = _require_target_tag(proposal.target)
-                _require_proposed(proposal)
+                _required_type_name_or_id(_require_proposed(proposal))
                 _require_format_name(target)
             case "usage_correction":
                 target = _require_target_tag(proposal.target)
-                _int_value(_require_proposed(proposal), "count")
+                _non_negative_int_value(_require_proposed(proposal), "count")
                 _require_format_name(target)
             case "alias_addition":
                 target = proposal.target
@@ -357,6 +456,7 @@ class LocalFeedbackApplyService:
                 _require_format_name(target)
                 if target.target_tag_id is None:
                     _string_value(proposed, "alias_tag", fallback=_optional_string_value(proposed, "tag"))
+                _required_type_name_or_id(proposed)
             case "preferred_tag_correction":
                 target = _require_target_tag(proposal.target)
                 if target.preferred_scope is None or target.preferred_tag_id is None:
@@ -532,6 +632,13 @@ def _int_value(data: Mapping[str, ProposalValue], key: str) -> int:
     raise ValueError(f"{key} is required")
 
 
+def _non_negative_int_value(data: Mapping[str, ProposalValue], key: str) -> int:
+    value = _int_value(data, key)
+    if value < 0:
+        raise ValueError(f"{key} must be greater than or equal to 0")
+    return value
+
+
 def _optional_int_value(data: Mapping[str, ProposalValue], key: str) -> int | None:
     value = data.get(key)
     if isinstance(value, bool):
@@ -549,3 +656,13 @@ def _bool_value(data: Mapping[str, ProposalValue], key: str) -> bool:
 def _optional_bool_value(data: Mapping[str, ProposalValue], key: str) -> bool | None:
     value = data.get(key)
     return value if isinstance(value, bool) else None
+
+
+def _required_type_name_or_id(data: Mapping[str, ProposalValue]) -> str:
+    type_name = _optional_string_value(data, "type_name")
+    type_id = _optional_int_value(data, "type_id")
+    if type_name is not None:
+        return type_name
+    if type_id is not None:
+        return "unknown"
+    raise ValueError("type_name or type_id is required")

--- a/src/genai_tag_db_tools/services/feedback_apply.py
+++ b/src/genai_tag_db_tools/services/feedback_apply.py
@@ -1,0 +1,434 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from typing import Any, ClassVar
+
+from genai_tag_db_tools.db.schema import LocalFeedbackApplication
+from genai_tag_db_tools.db.user_tag_repository import UserTagRepository
+from genai_tag_db_tools.models import (
+    ApprovedDbFeedback,
+    DbFeedbackProposal,
+    LocalFeedbackApplicationRecord,
+    LocalFeedbackApplyResult,
+    ProposalTarget,
+    ProposalValue,
+)
+
+
+class LocalFeedbackApplyService:
+    """承認済み DB feedback proposal を user-local overlay DB に反映する。"""
+
+    _SUPPORTED_KINDS: ClassVar[set[str]] = {
+        "alias_addition",
+        "preferred_tag_correction",
+        "translation_correction",
+        "usage_correction",
+        "type_correction",
+        "status_correction",
+        "tag_name_correction",
+    }
+
+    def __init__(self, user_repository: UserTagRepository) -> None:
+        self._user_repository = user_repository
+
+    def apply(self, feedback: ApprovedDbFeedback, *, dry_run: bool = False) -> LocalFeedbackApplyResult:
+        proposal = feedback.proposal
+        proposal_hash = proposal_hash_for(proposal)
+        proposal_json = _json_dumps(proposal.model_dump(mode="json"))
+
+        self._validate_feedback(feedback)
+        if proposal.kind not in self._SUPPORTED_KINDS:
+            raise ValueError(f"local apply unsupported proposal kind: {proposal.kind}")
+        if proposal.kind == "format_relation_review":
+            raise ValueError("format_relation_review is review-only and cannot be applied")
+
+        if self._user_repository.has_applied_feedback(proposal_hash):
+            application = self._record_application(
+                feedback,
+                proposal_hash=proposal_hash,
+                proposal_json=proposal_json,
+                status="skipped",
+                dry_run=dry_run,
+                before=None,
+                after=None,
+                error_message=None,
+            )
+            return LocalFeedbackApplyResult(
+                ok=True,
+                status="skipped",
+                dry_run=dry_run,
+                proposal_hash=proposal_hash,
+                proposal_kind=proposal.kind,
+                message="proposal is already applied",
+                application=application,
+            )
+
+        before = self._snapshot_before(proposal)
+        changes = self._planned_changes(proposal)
+        after = {"changes": changes}
+
+        if not dry_run:
+            self._apply_proposal(proposal)
+
+        application = self._record_application(
+            feedback,
+            proposal_hash=proposal_hash,
+            proposal_json=proposal_json,
+            status="dry_run" if dry_run else "applied",
+            dry_run=dry_run,
+            before=before,
+            after=after,
+            error_message=None,
+        )
+        return LocalFeedbackApplyResult(
+            ok=True,
+            status="dry_run" if dry_run else "applied",
+            dry_run=dry_run,
+            proposal_hash=proposal_hash,
+            proposal_kind=proposal.kind,
+            message="dry-run complete" if dry_run else "feedback applied",
+            changes=changes,
+            application=application,
+        )
+
+    def list_applications(self) -> list[LocalFeedbackApplicationRecord]:
+        return [_application_record(row) for row in self._user_repository.list_feedback_applications()]
+
+    def _validate_feedback(self, feedback: ApprovedDbFeedback) -> None:
+        if not feedback.approved:
+            raise ValueError("feedback must be approved before local apply")
+        if not feedback.approved_by.strip():
+            raise ValueError("approved_by is required")
+        if feedback.approved_at is None:
+            raise ValueError("approved_at is required")
+
+    def _apply_proposal(self, proposal: DbFeedbackProposal) -> None:
+        match proposal.kind:
+            case "translation_correction":
+                self._apply_translation(proposal)
+            case "status_correction":
+                self._apply_status(proposal)
+            case "type_correction":
+                self._apply_type(proposal)
+            case "usage_correction":
+                self._apply_usage(proposal)
+            case "alias_addition":
+                self._apply_alias_addition(proposal)
+            case "preferred_tag_correction":
+                self._apply_preferred_correction(proposal)
+            case "tag_name_correction":
+                self._apply_tag_name(proposal)
+            case _:
+                raise ValueError(f"local apply unsupported proposal kind: {proposal.kind}")
+
+    def _apply_translation(self, proposal: DbFeedbackProposal) -> None:
+        target = _require_target_tag(proposal.target)
+        proposed = _require_proposed(proposal)
+        language = _string_value(proposed, "language", fallback=proposal.target.language)
+        translation = _string_value(proposed, "translation")
+        self._user_repository.write_translation_patch(
+            target_scope=target.target_scope,
+            target_tag_id=target.target_tag_id,
+            language=language,
+            translation=translation,
+        )
+
+    def _apply_status(self, proposal: DbFeedbackProposal) -> None:
+        target = _require_target_tag(proposal.target)
+        proposed = _require_proposed(proposal)
+        format_id = self._format_id(target)
+        existing = self._user_repository.get_status_patch(target.target_scope, target.target_tag_id, format_id)
+        alias = existing.alias if existing is not None else False
+        preferred_scope = existing.preferred_scope if existing is not None else target.target_scope
+        preferred_tag_id = existing.preferred_tag_id if existing is not None else target.target_tag_id
+        type_id = existing.type_id if existing is not None else 0
+        deprecated = _bool_value(proposed, "deprecated")
+        self._user_repository.write_patch(
+            target_scope=target.target_scope,
+            target_tag_id=target.target_tag_id,
+            format_id=format_id,
+            type_id=type_id,
+            alias=alias,
+            preferred_scope=preferred_scope,
+            preferred_tag_id=preferred_tag_id,
+            deprecated=deprecated,
+        )
+
+    def _apply_type(self, proposal: DbFeedbackProposal) -> None:
+        target = _require_target_tag(proposal.target)
+        proposed = _require_proposed(proposal)
+        format_id = self._format_id(target)
+        type_name = _optional_string_value(proposed, "type_name") or "unknown"
+        proposed_type_id = _optional_int_value(proposed, "type_id")
+        type_id = self._user_repository.get_or_create_type_id(format_id, type_name, proposed_type_id)
+        existing = self._user_repository.get_status_patch(target.target_scope, target.target_tag_id, format_id)
+        alias = existing.alias if existing is not None else False
+        preferred_scope = existing.preferred_scope if existing is not None else target.target_scope
+        preferred_tag_id = existing.preferred_tag_id if existing is not None else target.target_tag_id
+        deprecated = existing.deprecated if existing is not None else False
+        self._user_repository.write_patch(
+            target_scope=target.target_scope,
+            target_tag_id=target.target_tag_id,
+            format_id=format_id,
+            type_id=type_id,
+            alias=alias,
+            preferred_scope=preferred_scope,
+            preferred_tag_id=preferred_tag_id,
+            deprecated=deprecated,
+        )
+
+    def _apply_usage(self, proposal: DbFeedbackProposal) -> None:
+        target = _require_target_tag(proposal.target)
+        proposed = _require_proposed(proposal)
+        self._user_repository.write_usage_patch(
+            target_scope=target.target_scope,
+            target_tag_id=target.target_tag_id,
+            format_id=self._format_id(target),
+            count=_int_value(proposed, "count"),
+        )
+
+    def _apply_alias_addition(self, proposal: DbFeedbackProposal) -> None:
+        target = proposal.target
+        proposed = _require_proposed(proposal)
+        if target.preferred_scope is None or target.preferred_tag_id is None:
+            raise ValueError("alias_addition requires preferred_scope and preferred_tag_id")
+
+        alias_tag_id = target.target_tag_id
+        if alias_tag_id is None:
+            alias_tag = _string_value(proposed, "alias_tag", fallback=_optional_string_value(proposed, "tag"))
+            source_tag = _optional_string_value(proposed, "source_tag") or alias_tag
+            alias_tag_id = self._user_repository.create_user_tag(source_tag, alias_tag)
+            target_scope = "user"
+        else:
+            target_scope = target.target_scope
+
+        format_id = self._format_id(target)
+        type_name = _optional_string_value(proposed, "type_name") or "unknown"
+        type_id = self._user_repository.get_or_create_type_id(
+            format_id,
+            type_name,
+            _optional_int_value(proposed, "type_id"),
+        )
+        self._user_repository.write_patch(
+            target_scope=target_scope,
+            target_tag_id=alias_tag_id,
+            format_id=format_id,
+            type_id=type_id,
+            alias=True,
+            preferred_scope=target.preferred_scope,
+            preferred_tag_id=target.preferred_tag_id,
+            deprecated=_optional_bool_value(proposed, "deprecated") or False,
+        )
+
+    def _apply_preferred_correction(self, proposal: DbFeedbackProposal) -> None:
+        target = _require_target_tag(proposal.target)
+        if target.preferred_scope is None or target.preferred_tag_id is None:
+            raise ValueError("preferred_tag_correction requires preferred_scope and preferred_tag_id")
+        format_id = self._format_id(target)
+        existing = self._user_repository.get_status_patch(target.target_scope, target.target_tag_id, format_id)
+        type_id = existing.type_id if existing is not None else 0
+        deprecated = existing.deprecated if existing is not None else False
+        self._user_repository.write_patch(
+            target_scope=target.target_scope,
+            target_tag_id=target.target_tag_id,
+            format_id=format_id,
+            type_id=type_id,
+            alias=True,
+            preferred_scope=target.preferred_scope,
+            preferred_tag_id=target.preferred_tag_id,
+            deprecated=deprecated,
+        )
+
+    def _apply_tag_name(self, proposal: DbFeedbackProposal) -> None:
+        if proposal.target.target_tag_id is not None:
+            raise ValueError("tag_name_correction can only create a new user tag locally")
+        proposed = _require_proposed(proposal)
+        tag = _string_value(proposed, "tag")
+        source_tag = (
+            _optional_string_value(proposed, "source_tag")
+            or _optional_mapping_string(proposal.current, "source_tag")
+            or tag
+        )
+        self._user_repository.create_user_tag(source_tag, tag)
+
+    def _format_id(self, target: ProposalTarget) -> int:
+        if target.format_name is None:
+            raise ValueError("format-dependent local apply requires format_name")
+        return self._user_repository.get_or_create_format_id(target.format_name)
+
+    def _snapshot_before(self, proposal: DbFeedbackProposal) -> dict[str, ProposalValue]:
+        return {
+            "kind": proposal.kind,
+            "target_scope": proposal.target.target_scope,
+            "target_tag_id": proposal.target.target_tag_id,
+            "format_name": proposal.target.format_name,
+        }
+
+    def _planned_changes(self, proposal: DbFeedbackProposal) -> list[dict[str, ProposalValue]]:
+        return [
+            {
+                "proposal_kind": proposal.kind,
+                "target_kind": proposal.target.kind,
+                "target_scope": proposal.target.target_scope,
+                "target_tag_id": proposal.target.target_tag_id,
+                "format_name": proposal.target.format_name,
+            }
+        ]
+
+    def _record_application(
+        self,
+        feedback: ApprovedDbFeedback,
+        *,
+        proposal_hash: str,
+        proposal_json: str,
+        status: str,
+        dry_run: bool,
+        before: dict[str, Any] | None,
+        after: dict[str, Any] | None,
+        error_message: str | None,
+    ) -> LocalFeedbackApplicationRecord:
+        proposal = feedback.proposal
+        row = self._user_repository.record_feedback_application(
+            proposal_hash=proposal_hash,
+            proposal_kind=proposal.kind,
+            target_kind=proposal.target.kind,
+            target_scope=proposal.target.target_scope,
+            target_tag_id=proposal.target.target_tag_id,
+            format_name=proposal.target.format_name,
+            field=_target_field(proposal),
+            approved_by=feedback.approved_by,
+            approved_at=feedback.approved_at,
+            status=status,
+            dry_run=dry_run,
+            proposal_json=proposal_json,
+            before_json=_json_dumps(before) if before is not None else None,
+            after_json=_json_dumps(after) if after is not None else None,
+            error_message=error_message,
+        )
+        return _application_record(row)
+
+
+def apply_approved_feedback(
+    feedback: ApprovedDbFeedback,
+    *,
+    user_repository: UserTagRepository,
+    dry_run: bool = False,
+) -> LocalFeedbackApplyResult:
+    return LocalFeedbackApplyService(user_repository).apply(feedback, dry_run=dry_run)
+
+
+def list_local_feedback_applications(
+    *,
+    user_repository: UserTagRepository,
+) -> list[LocalFeedbackApplicationRecord]:
+    return LocalFeedbackApplyService(user_repository).list_applications()
+
+
+def proposal_hash_for(proposal: DbFeedbackProposal) -> str:
+    return hashlib.sha256(_json_dumps(proposal.model_dump(mode="json")).encode("utf-8")).hexdigest()
+
+
+def _application_record(row: LocalFeedbackApplication) -> LocalFeedbackApplicationRecord:
+    return LocalFeedbackApplicationRecord(
+        application_id=row.application_id,
+        proposal_hash=row.proposal_hash,
+        proposal_kind=row.proposal_kind,
+        target_kind=row.target_kind,
+        target_scope=row.target_scope,
+        target_tag_id=row.target_tag_id,
+        format_name=row.format_name,
+        field=row.field,
+        approved_by=row.approved_by,
+        approved_at=row.approved_at,
+        applied_at=row.applied_at,
+        status=row.status,
+        dry_run=row.dry_run,
+        proposal_json=row.proposal_json,
+        before_json=row.before_json,
+        after_json=row.after_json,
+        error_message=row.error_message,
+    )
+
+
+def _require_target_tag(target: ProposalTarget) -> ProposalTarget:
+    if target.target_tag_id is None:
+        raise ValueError(f"{target.kind} proposal requires target_tag_id")
+    return target
+
+
+def _require_proposed(proposal: DbFeedbackProposal) -> Mapping[str, ProposalValue]:
+    if proposal.proposed is None:
+        raise ValueError(f"{proposal.kind} requires proposed values")
+    return proposal.proposed
+
+
+def _target_field(proposal: DbFeedbackProposal) -> str | None:
+    if proposal.target.language is not None:
+        return f"translation.{proposal.target.language}"
+    return _optional_mapping_string(proposal.current, "field") or _optional_mapping_string(proposal.proposed, "field")
+
+
+def _json_dumps(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"), default=_json_default)
+
+
+def _json_default(value: Any) -> str:
+    if isinstance(value, datetime):
+        return value.astimezone(UTC).isoformat()
+    return str(value)
+
+
+def _string_value(
+    data: Mapping[str, ProposalValue],
+    key: str,
+    *,
+    fallback: str | None = None,
+) -> str:
+    value = data.get(key)
+    if isinstance(value, str) and value:
+        return value
+    if fallback:
+        return fallback
+    raise ValueError(f"{key} is required")
+
+
+def _optional_string_value(data: Mapping[str, ProposalValue], key: str) -> str | None:
+    value = data.get(key)
+    return value if isinstance(value, str) and value else None
+
+
+def _optional_mapping_string(data: Mapping[str, ProposalValue] | None, key: str) -> str | None:
+    if data is None:
+        return None
+    return _optional_string_value(data, key)
+
+
+def _int_value(data: Mapping[str, ProposalValue], key: str) -> int:
+    value = data.get(key)
+    if isinstance(value, bool):
+        raise ValueError(f"{key} must be an integer")
+    if isinstance(value, int):
+        return value
+    raise ValueError(f"{key} is required")
+
+
+def _optional_int_value(data: Mapping[str, ProposalValue], key: str) -> int | None:
+    value = data.get(key)
+    if isinstance(value, bool):
+        return None
+    return value if isinstance(value, int) else None
+
+
+def _bool_value(data: Mapping[str, ProposalValue], key: str) -> bool:
+    value = data.get(key)
+    if isinstance(value, bool):
+        return value
+    raise ValueError(f"{key} is required")
+
+
+def _optional_bool_value(data: Mapping[str, ProposalValue], key: str) -> bool | None:
+    value = data.get(key)
+    return value if isinstance(value, bool) else None

--- a/tests/unit/test_feedback_apply.py
+++ b/tests/unit/test_feedback_apply.py
@@ -401,7 +401,7 @@ def test_alias_addition_creates_user_alias_without_copying_preferred_base_tag(
         proposed={"alias_tag": "blakc hair", "type_name": "general"},
     )
 
-    apply_approved_feedback(_approved(proposal), user_repository=user_repo)
+    apply_approved_feedback(_approved(proposal), user_repository=user_repo, reader=_ReaderWithBaseFormats())
 
     with user_session_factory() as session:
         alias_tag = session.query(UserTag).filter_by(tag="blakc hair").one()
@@ -412,6 +412,47 @@ def test_alias_addition_creates_user_alias_without_copying_preferred_base_tag(
     assert patches[0].alias is True
     assert patches[0].preferred_scope == "base"
     assert patches[0].preferred_tag_id == 30
+    assert patches[0].type_id == 1
+    with user_session_factory() as session:
+        assert session.query(TagTypeFormatMapping).count() == 0
+
+
+def test_user_scope_base_format_apply_requires_reader_or_existing_local_format(user_repo):
+    proposal = _proposal(
+        "usage_correction",
+        target=ProposalTarget(
+            kind="usage",
+            target_scope="user",
+            target_tag_id=1_000_000_040,
+            format_name="danbooru",
+        ),
+        proposed={"count": 123},
+    )
+
+    with pytest.raises(ValueError, match="requires reader or existing local format"):
+        apply_approved_feedback(_approved(proposal), user_repository=user_repo)
+
+
+def test_user_scope_type_correction_uses_reader_type_for_base_format(user_repo, user_session_factory):
+    proposal = _proposal(
+        "type_correction",
+        target=ProposalTarget(
+            kind="tag_type",
+            target_scope="user",
+            target_tag_id=1_000_000_021,
+            format_name="danbooru",
+        ),
+        current={"type_id": 5, "type_name": "meta"},
+        proposed={"type_name": "character"},
+    )
+
+    apply_approved_feedback(_approved(proposal), user_repository=user_repo, reader=_ReaderWithBaseFormats())
+
+    with user_session_factory() as session:
+        patch = session.query(UserTagStatusPatch).one()
+        assert session.query(TagTypeFormatMapping).count() == 0
+    assert patch.format_id == 1
+    assert patch.type_id == 4
 
 
 def test_alias_addition_missing_format_does_not_create_orphan_user_tag(user_repo, user_session_factory):
@@ -458,6 +499,22 @@ def test_usage_correction_writes_usage_patch(user_repo, user_session_factory):
     assert patch.target_scope == "base"
     assert patch.target_tag_id == 40
     assert patch.count == 123
+
+
+def test_usage_correction_rejects_negative_count(user_repo):
+    proposal = _proposal(
+        "usage_correction",
+        target=ProposalTarget(
+            kind="usage",
+            target_scope="base",
+            target_tag_id=40,
+            format_name="danbooru",
+        ),
+        proposed={"count": -1},
+    )
+
+    with pytest.raises(ValueError, match="greater than or equal to 0"):
+        apply_approved_feedback(_approved(proposal), user_repository=user_repo, reader=_ReaderWithBaseFormats())
 
 
 def test_usage_correction_uses_base_format_id_and_reader_can_read_base_scope_patch(
@@ -522,6 +579,74 @@ def test_duplicate_apply_is_skipped(user_repo, user_session_factory):
     with user_session_factory() as session:
         assert session.query(UserTagTranslationPatch).count() == 1
         assert session.query(LocalFeedbackApplication).count() == 2
+
+
+def test_type_correction_requires_proposed_type(user_repo):
+    proposal = _proposal(
+        "type_correction",
+        target=ProposalTarget(
+            kind="tag_type",
+            target_scope="base",
+            target_tag_id=21,
+            format_name="danbooru",
+        ),
+        proposed={},
+    )
+
+    with pytest.raises(ValueError, match="type_name or type_id"):
+        apply_approved_feedback(_approved(proposal), user_repository=user_repo, reader=_ReaderWithBaseFormats())
+
+
+def test_dry_run_runs_reader_dependent_resolution(user_repo, user_session_factory):
+    proposal = _proposal(
+        "status_correction",
+        target=ProposalTarget(
+            kind="tag_status",
+            target_scope="base",
+            target_tag_id=20,
+            format_name="danbooru",
+        ),
+        proposed={"deprecated": True},
+    )
+
+    with pytest.raises(ValueError, match="requires reader-resolved format_id"):
+        apply_approved_feedback(_approved(proposal), user_repository=user_repo, dry_run=True)
+
+    with user_session_factory() as session:
+        assert session.query(TagFormat).count() == 0
+        assert session.query(LocalFeedbackApplication).count() == 0
+
+
+def test_translation_correction_rejects_replacement_without_tombstone(user_repo):
+    proposal = _proposal(
+        "translation_correction",
+        target=ProposalTarget(kind="translation", target_scope="base", target_tag_id=10, language="ja"),
+        current={"translation": "古い訳"},
+        proposed={"language": "ja", "translation": "新しい訳"},
+    )
+
+    with pytest.raises(ValueError, match="cannot replace existing translation"):
+        apply_approved_feedback(_approved(proposal), user_repository=user_repo)
+
+
+def test_reader_format_id_zero_is_unresolved(user_repo):
+    class _ReaderReturningZero:
+        def get_format_id(self, format_name: str) -> int:
+            return 0
+
+    proposal = _proposal(
+        "usage_correction",
+        target=ProposalTarget(
+            kind="usage",
+            target_scope="base",
+            target_tag_id=40,
+            format_name="missing",
+        ),
+        proposed={"count": 1},
+    )
+
+    with pytest.raises(ValueError, match="requires reader-resolved format_id"):
+        apply_approved_feedback(_approved(proposal), user_repository=user_repo, reader=_ReaderReturningZero())
 
 
 def test_list_local_feedback_applications_returns_audit_records(user_repo):

--- a/tests/unit/test_feedback_apply.py
+++ b/tests/unit/test_feedback_apply.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from sqlalchemy import StaticPool, create_engine
@@ -28,9 +29,33 @@ from genai_tag_db_tools.services.feedback_apply import (
 
 class _ReaderWithBaseFormats:
     def get_format_id(self, format_name: str) -> int:
-        if format_name == "danbooru":
-            return 1
+        if format_name in {"danbooru", "unknown"}:
+            return {"danbooru": 1, "unknown": 999}[format_name]
         raise ValueError(format_name)
+
+    def get_type_id_for_format(self, type_name: str, format_id: int) -> int | None:
+        return {
+            (1, "general"): 1,
+            (1, "character"): 4,
+            (1, "meta"): 5,
+            (999, "unknown"): 0,
+        }.get((format_id, type_name))
+
+    def get_tag_status(self, tag_id: int, format_id: int):
+        return {
+            (20, 1): SimpleNamespace(
+                type_id=5,
+                alias=True,
+                preferred_tag_id=99,
+                deprecated=False,
+            ),
+            (21, 1): SimpleNamespace(
+                type_id=5,
+                alias=True,
+                preferred_tag_id=99,
+                deprecated=True,
+            ),
+        }.get((tag_id, format_id))
 
 
 @pytest.fixture()
@@ -176,7 +201,11 @@ def test_status_correction_writes_deprecated_overlay_patch(user_repo, user_sessi
         proposed={"deprecated": True},
     )
 
-    result = apply_approved_feedback(_approved(proposal), user_repository=user_repo)
+    result = apply_approved_feedback(
+        _approved(proposal),
+        user_repository=user_repo,
+        reader=_ReaderWithBaseFormats(),
+    )
 
     assert result.status == "applied"
     with user_session_factory() as session:
@@ -228,21 +257,21 @@ def test_status_correction_preserves_current_base_status_fields(user_repo, user_
 def test_type_correction_preserves_existing_status_fields(user_repo, user_session_factory):
     format_id = user_repo.get_or_create_format_id("danbooru")
     user_repo.write_patch(
-        target_scope="base",
-        target_tag_id=21,
+        target_scope="user",
+        target_tag_id=1_000_000_021,
         format_id=format_id,
         type_id=0,
         alias=False,
-        preferred_scope="base",
-        preferred_tag_id=21,
+        preferred_scope="user",
+        preferred_tag_id=1_000_000_021,
         deprecated=True,
     )
     proposal = _proposal(
         "type_correction",
         target=ProposalTarget(
             kind="tag_type",
-            target_scope="base",
-            target_tag_id=21,
+            target_scope="user",
+            target_tag_id=1_000_000_021,
             format_name="danbooru",
         ),
         proposed={"type_id": 4, "type_name": "character"},
@@ -266,8 +295,8 @@ def test_type_correction_rejects_type_id_collision(user_repo):
         "type_correction",
         target=ProposalTarget(
             kind="tag_type",
-            target_scope="base",
-            target_tag_id=21,
+            target_scope="user",
+            target_tag_id=1_000_000_021,
             format_name="danbooru",
         ),
         proposed={"type_id": 1, "type_name": "character"},
@@ -275,6 +304,84 @@ def test_type_correction_rejects_type_id_collision(user_repo):
 
     with pytest.raises(ValueError, match="already belongs"):
         apply_approved_feedback(_approved(proposal), user_repository=user_repo)
+
+
+def test_base_scope_format_dependent_apply_requires_reader(user_repo):
+    proposal = _proposal(
+        "status_correction",
+        target=ProposalTarget(
+            kind="tag_status",
+            target_scope="base",
+            target_tag_id=20,
+            format_name="danbooru",
+        ),
+        proposed={"deprecated": True},
+    )
+
+    with pytest.raises(ValueError, match="requires reader"):
+        apply_approved_feedback(_approved(proposal), user_repository=user_repo)
+
+
+def test_status_correction_uses_reader_status_when_current_is_sparse(user_repo, user_session_factory):
+    proposal = _proposal(
+        "status_correction",
+        target=ProposalTarget(
+            kind="tag_status",
+            target_scope="base",
+            target_tag_id=20,
+            format_name="danbooru",
+        ),
+        current={"deprecated": False},
+        proposed={"deprecated": True},
+    )
+
+    apply_approved_feedback(
+        _approved(proposal),
+        user_repository=user_repo,
+        reader=_ReaderWithBaseFormats(),
+    )
+
+    with user_session_factory() as session:
+        patch = session.query(UserTagStatusPatch).one()
+    assert patch.format_id == 1
+    assert patch.type_id == 5
+    assert patch.alias is True
+    assert patch.preferred_scope == "base"
+    assert patch.preferred_tag_id == 99
+    assert patch.deprecated is True
+
+
+def test_type_correction_uses_reader_type_and_preserves_reader_status(
+    user_repo,
+    user_session_factory,
+):
+    proposal = _proposal(
+        "type_correction",
+        target=ProposalTarget(
+            kind="tag_type",
+            target_scope="base",
+            target_tag_id=21,
+            format_name="danbooru",
+        ),
+        current={"type_id": 5, "type_name": "meta"},
+        proposed={"type_name": "character"},
+    )
+
+    apply_approved_feedback(
+        _approved(proposal),
+        user_repository=user_repo,
+        reader=_ReaderWithBaseFormats(),
+    )
+
+    with user_session_factory() as session:
+        patch = session.query(UserTagStatusPatch).one()
+        assert session.query(TagTypeFormatMapping).count() == 0
+    assert patch.format_id == 1
+    assert patch.type_id == 4
+    assert patch.alias is True
+    assert patch.preferred_scope == "base"
+    assert patch.preferred_tag_id == 99
+    assert patch.deprecated is True
 
 
 def test_alias_addition_creates_user_alias_without_copying_preferred_base_tag(
@@ -340,7 +447,11 @@ def test_usage_correction_writes_usage_patch(user_repo, user_session_factory):
         proposed={"count": 123},
     )
 
-    apply_approved_feedback(_approved(proposal), user_repository=user_repo)
+    apply_approved_feedback(
+        _approved(proposal),
+        user_repository=user_repo,
+        reader=_ReaderWithBaseFormats(),
+    )
 
     with user_session_factory() as session:
         patch = session.query(UserTagUsagePatch).one()

--- a/tests/unit/test_feedback_apply.py
+++ b/tests/unit/test_feedback_apply.py
@@ -26,6 +26,13 @@ from genai_tag_db_tools.services.feedback_apply import (
 )
 
 
+class _ReaderWithBaseFormats:
+    def get_format_id(self, format_name: str) -> int:
+        if format_name == "danbooru":
+            return 1
+        raise ValueError(format_name)
+
+
 @pytest.fixture()
 def user_engine(tmp_path: Path):
     db_path = tmp_path / "feedback_apply.sqlite"
@@ -105,6 +112,20 @@ def test_dry_run_does_not_write_patch_but_records_audit(user_repo, user_session_
     assert audit.dry_run is True
 
 
+def test_dry_run_validates_invalid_proposal(user_repo, user_session_factory):
+    proposal = _proposal(
+        "translation_correction",
+        target=ProposalTarget(kind="translation", target_scope="base", target_tag_id=10, language="ja"),
+        proposed=None,
+    )
+
+    with pytest.raises(ValueError, match="proposed"):
+        apply_approved_feedback(_approved(proposal), user_repository=user_repo, dry_run=True)
+
+    with user_session_factory() as session:
+        assert session.query(LocalFeedbackApplication).count() == 0
+
+
 def test_translation_correction_applies_to_base_scope_without_user_tag_shadow(
     user_repo,
     user_session_factory,
@@ -125,6 +146,22 @@ def test_translation_correction_applies_to_base_scope_without_user_tag_shadow(
         assert patch.language == "ja"
         assert patch.translation == "青い目"
         assert session.query(UserTag).count() == 0
+
+
+def test_overlay_reader_returns_base_scope_translation_patch(user_repo, user_session_factory):
+    from genai_tag_db_tools.db.overlay_reader import OverlayTagReader
+
+    proposal = _proposal(
+        "translation_correction",
+        target=ProposalTarget(kind="translation", target_scope="base", target_tag_id=10, language="ja"),
+        proposed={"language": "ja", "translation": "青い目"},
+    )
+    apply_approved_feedback(_approved(proposal), user_repository=user_repo)
+
+    reader = OverlayTagReader(session_factory=user_session_factory)
+
+    assert [row.translation for row in reader.get_translations(10)] == ["青い目"]
+    assert [row.translation for row in reader.get_translations_batch([10])[10]] == ["青い目"]
 
 
 def test_status_correction_writes_deprecated_overlay_patch(user_repo, user_session_factory):
@@ -151,6 +188,41 @@ def test_status_correction_writes_deprecated_overlay_patch(user_repo, user_sessi
         assert patch.preferred_scope == "base"
         assert patch.preferred_tag_id == 20
         assert session.query(TagFormat).filter_by(format_name="unknown").one()
+
+
+def test_status_correction_preserves_current_base_status_fields(user_repo, user_session_factory):
+    proposal = _proposal(
+        "status_correction",
+        target=ProposalTarget(
+            kind="tag_status",
+            target_scope="base",
+            target_tag_id=20,
+            format_name="danbooru",
+        ),
+        current={
+            "type_id": 5,
+            "alias": True,
+            "preferred_scope": "base",
+            "preferred_tag_id": 99,
+            "deprecated": False,
+        },
+        proposed={"deprecated": True},
+    )
+
+    apply_approved_feedback(
+        _approved(proposal),
+        user_repository=user_repo,
+        reader=_ReaderWithBaseFormats(),
+    )
+
+    with user_session_factory() as session:
+        patch = session.query(UserTagStatusPatch).one()
+    assert patch.format_id == 1
+    assert patch.type_id == 5
+    assert patch.alias is True
+    assert patch.preferred_scope == "base"
+    assert patch.preferred_tag_id == 99
+    assert patch.deprecated is True
 
 
 def test_type_correction_preserves_existing_status_fields(user_repo, user_session_factory):
@@ -187,6 +259,24 @@ def test_type_correction_preserves_existing_status_fields(user_repo, user_sessio
         assert mapping is not None
 
 
+def test_type_correction_rejects_type_id_collision(user_repo):
+    format_id = user_repo.get_or_create_format_id("danbooru")
+    user_repo.get_or_create_type_id(format_id, "general", 1)
+    proposal = _proposal(
+        "type_correction",
+        target=ProposalTarget(
+            kind="tag_type",
+            target_scope="base",
+            target_tag_id=21,
+            format_name="danbooru",
+        ),
+        proposed={"type_id": 1, "type_name": "character"},
+    )
+
+    with pytest.raises(ValueError, match="already belongs"):
+        apply_approved_feedback(_approved(proposal), user_repository=user_repo)
+
+
 def test_alias_addition_creates_user_alias_without_copying_preferred_base_tag(
     user_repo,
     user_session_factory,
@@ -217,6 +307,27 @@ def test_alias_addition_creates_user_alias_without_copying_preferred_base_tag(
     assert patches[0].preferred_tag_id == 30
 
 
+def test_alias_addition_missing_format_does_not_create_orphan_user_tag(user_repo, user_session_factory):
+    proposal = _proposal(
+        "alias_addition",
+        target=ProposalTarget(
+            kind="alias",
+            target_scope="user",
+            target_tag_id=None,
+            preferred_scope="base",
+            preferred_tag_id=30,
+        ),
+        proposed={"alias_tag": "blakc hair", "type_name": "general"},
+    )
+
+    with pytest.raises(ValueError, match="format_name"):
+        apply_approved_feedback(_approved(proposal), user_repository=user_repo)
+
+    with user_session_factory() as session:
+        assert session.query(UserTag).count() == 0
+        assert session.query(LocalFeedbackApplication).count() == 0
+
+
 def test_usage_correction_writes_usage_patch(user_repo, user_session_factory):
     proposal = _proposal(
         "usage_correction",
@@ -236,6 +347,37 @@ def test_usage_correction_writes_usage_patch(user_repo, user_session_factory):
     assert patch.target_scope == "base"
     assert patch.target_tag_id == 40
     assert patch.count == 123
+
+
+def test_usage_correction_uses_base_format_id_and_reader_can_read_base_scope_patch(
+    user_repo,
+    user_session_factory,
+):
+    from genai_tag_db_tools.db.overlay_reader import OverlayTagReader
+
+    proposal = _proposal(
+        "usage_correction",
+        target=ProposalTarget(
+            kind="usage",
+            target_scope="base",
+            target_tag_id=40,
+            format_name="danbooru",
+        ),
+        proposed={"count": 123},
+    )
+
+    apply_approved_feedback(
+        _approved(proposal),
+        user_repository=user_repo,
+        reader=_ReaderWithBaseFormats(),
+    )
+    reader = OverlayTagReader(session_factory=user_session_factory)
+
+    with user_session_factory() as session:
+        patch = session.query(UserTagUsagePatch).one()
+    assert patch.format_id == 1
+    assert reader.get_usage_count(40, 1) == 123
+    assert reader.list_usage_counts(tag_id=40, format_id=1)[0].count == 123
 
 
 def test_tag_name_correction_creates_new_user_tag(user_repo, user_session_factory):

--- a/tests/unit/test_feedback_apply.py
+++ b/tests/unit/test_feedback_apply.py
@@ -1,0 +1,299 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from sqlalchemy import StaticPool, create_engine
+from sqlalchemy.orm import sessionmaker
+
+from genai_tag_db_tools.db.schema import (
+    Base,
+    LocalFeedbackApplication,
+    TagFormat,
+    TagTypeFormatMapping,
+    UserOverlayBase,
+    UserTag,
+    UserTagStatusPatch,
+    UserTagTranslationPatch,
+    UserTagUsagePatch,
+)
+from genai_tag_db_tools.db.user_tag_repository import UserTagRepository
+from genai_tag_db_tools.models import ApprovedDbFeedback, DbFeedbackProposal, ProposalTarget
+from genai_tag_db_tools.services.feedback_apply import (
+    apply_approved_feedback,
+    list_local_feedback_applications,
+)
+
+
+@pytest.fixture()
+def user_engine(tmp_path: Path):
+    db_path = tmp_path / "feedback_apply.sqlite"
+    engine = create_engine(
+        f"sqlite:///{db_path}",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    UserOverlayBase.metadata.create_all(engine)
+    yield engine
+    engine.dispose()
+
+
+@pytest.fixture()
+def user_session_factory(user_engine):
+    return sessionmaker(bind=user_engine, autoflush=False, autocommit=False)
+
+
+@pytest.fixture()
+def user_repo(user_session_factory):
+    return UserTagRepository(user_session_factory)
+
+
+def _proposal(
+    kind: str,
+    *,
+    target: ProposalTarget,
+    proposed: dict | None = None,
+    current: dict | None = None,
+) -> DbFeedbackProposal:
+    return DbFeedbackProposal(
+        kind=kind,
+        target=target,
+        current=current,
+        proposed=proposed,
+        confidence=0.9,
+        source="test",
+        reason_codes=["test_reason"],
+    )
+
+
+def _approved(proposal: DbFeedbackProposal, *, approved: bool = True) -> ApprovedDbFeedback:
+    return ApprovedDbFeedback(
+        proposal=proposal,
+        approved=approved,
+        approved_by="tester",
+        approved_at=datetime(2026, 6, 28, 12, 0, tzinfo=UTC),
+    )
+
+
+def test_unapproved_feedback_is_rejected(user_repo):
+    proposal = _proposal(
+        "translation_correction",
+        target=ProposalTarget(kind="translation", target_scope="base", target_tag_id=10, language="ja"),
+        proposed={"language": "ja", "translation": "青い目"},
+    )
+
+    with pytest.raises(ValueError, match="approved"):
+        apply_approved_feedback(_approved(proposal, approved=False), user_repository=user_repo)
+
+
+def test_dry_run_does_not_write_patch_but_records_audit(user_repo, user_session_factory):
+    proposal = _proposal(
+        "translation_correction",
+        target=ProposalTarget(kind="translation", target_scope="base", target_tag_id=10, language="ja"),
+        proposed={"language": "ja", "translation": "青い目"},
+    )
+
+    result = apply_approved_feedback(_approved(proposal), user_repository=user_repo, dry_run=True)
+
+    assert result.status == "dry_run"
+    with user_session_factory() as session:
+        assert session.query(UserTagTranslationPatch).count() == 0
+        audit = session.query(LocalFeedbackApplication).one()
+    assert audit.status == "dry_run"
+    assert audit.dry_run is True
+
+
+def test_translation_correction_applies_to_base_scope_without_user_tag_shadow(
+    user_repo,
+    user_session_factory,
+):
+    proposal = _proposal(
+        "translation_correction",
+        target=ProposalTarget(kind="translation", target_scope="base", target_tag_id=10, language="ja"),
+        proposed={"language": "ja", "translation": "青い目"},
+    )
+
+    result = apply_approved_feedback(_approved(proposal), user_repository=user_repo)
+
+    assert result.status == "applied"
+    with user_session_factory() as session:
+        patch = session.query(UserTagTranslationPatch).one()
+        assert patch.target_scope == "base"
+        assert patch.target_tag_id == 10
+        assert patch.language == "ja"
+        assert patch.translation == "青い目"
+        assert session.query(UserTag).count() == 0
+
+
+def test_status_correction_writes_deprecated_overlay_patch(user_repo, user_session_factory):
+    proposal = _proposal(
+        "status_correction",
+        target=ProposalTarget(
+            kind="tag_status",
+            target_scope="base",
+            target_tag_id=20,
+            format_name="unknown",
+        ),
+        proposed={"deprecated": True},
+    )
+
+    result = apply_approved_feedback(_approved(proposal), user_repository=user_repo)
+
+    assert result.status == "applied"
+    with user_session_factory() as session:
+        patch = session.query(UserTagStatusPatch).one()
+        assert patch.target_scope == "base"
+        assert patch.target_tag_id == 20
+        assert patch.deprecated is True
+        assert patch.alias is False
+        assert patch.preferred_scope == "base"
+        assert patch.preferred_tag_id == 20
+        assert session.query(TagFormat).filter_by(format_name="unknown").one()
+
+
+def test_type_correction_preserves_existing_status_fields(user_repo, user_session_factory):
+    format_id = user_repo.get_or_create_format_id("danbooru")
+    user_repo.write_patch(
+        target_scope="base",
+        target_tag_id=21,
+        format_id=format_id,
+        type_id=0,
+        alias=False,
+        preferred_scope="base",
+        preferred_tag_id=21,
+        deprecated=True,
+    )
+    proposal = _proposal(
+        "type_correction",
+        target=ProposalTarget(
+            kind="tag_type",
+            target_scope="base",
+            target_tag_id=21,
+            format_name="danbooru",
+        ),
+        proposed={"type_id": 4, "type_name": "character"},
+    )
+
+    apply_approved_feedback(_approved(proposal), user_repository=user_repo)
+
+    with user_session_factory() as session:
+        patch = session.query(UserTagStatusPatch).one()
+        assert patch.type_id == 4
+        assert patch.deprecated is True
+        assert patch.alias is False
+        mapping = session.query(TagTypeFormatMapping).filter_by(format_id=format_id, type_id=4).one()
+        assert mapping is not None
+
+
+def test_alias_addition_creates_user_alias_without_copying_preferred_base_tag(
+    user_repo,
+    user_session_factory,
+):
+    proposal = _proposal(
+        "alias_addition",
+        target=ProposalTarget(
+            kind="alias",
+            target_scope="user",
+            target_tag_id=None,
+            format_name="danbooru",
+            preferred_scope="base",
+            preferred_tag_id=30,
+        ),
+        proposed={"alias_tag": "blakc hair", "type_name": "general"},
+    )
+
+    apply_approved_feedback(_approved(proposal), user_repository=user_repo)
+
+    with user_session_factory() as session:
+        alias_tag = session.query(UserTag).filter_by(tag="blakc hair").one()
+        patches = session.query(UserTagStatusPatch).all()
+    assert len(patches) == 1
+    assert patches[0].target_scope == "user"
+    assert patches[0].target_tag_id == alias_tag.tag_id
+    assert patches[0].alias is True
+    assert patches[0].preferred_scope == "base"
+    assert patches[0].preferred_tag_id == 30
+
+
+def test_usage_correction_writes_usage_patch(user_repo, user_session_factory):
+    proposal = _proposal(
+        "usage_correction",
+        target=ProposalTarget(
+            kind="usage",
+            target_scope="base",
+            target_tag_id=40,
+            format_name="danbooru",
+        ),
+        proposed={"count": 123},
+    )
+
+    apply_approved_feedback(_approved(proposal), user_repository=user_repo)
+
+    with user_session_factory() as session:
+        patch = session.query(UserTagUsagePatch).one()
+    assert patch.target_scope == "base"
+    assert patch.target_tag_id == 40
+    assert patch.count == 123
+
+
+def test_tag_name_correction_creates_new_user_tag(user_repo, user_session_factory):
+    proposal = _proposal(
+        "tag_name_correction",
+        target=ProposalTarget(kind="tag_name", target_scope="user", target_tag_id=None),
+        current={"source_tag": "blue__eyes"},
+        proposed={"tag": "blue eyes"},
+    )
+
+    apply_approved_feedback(_approved(proposal), user_repository=user_repo)
+
+    with user_session_factory() as session:
+        tag = session.query(UserTag).one()
+    assert tag.source_tag == "blue__eyes"
+    assert tag.tag == "blue eyes"
+
+
+def test_duplicate_apply_is_skipped(user_repo, user_session_factory):
+    proposal = _proposal(
+        "translation_correction",
+        target=ProposalTarget(kind="translation", target_scope="base", target_tag_id=10, language="ja"),
+        proposed={"language": "ja", "translation": "青い目"},
+    )
+
+    first = apply_approved_feedback(_approved(proposal), user_repository=user_repo)
+    second = apply_approved_feedback(_approved(proposal), user_repository=user_repo)
+
+    assert first.status == "applied"
+    assert second.status == "skipped"
+    with user_session_factory() as session:
+        assert session.query(UserTagTranslationPatch).count() == 1
+        assert session.query(LocalFeedbackApplication).count() == 2
+
+
+def test_list_local_feedback_applications_returns_audit_records(user_repo):
+    proposal = _proposal(
+        "translation_correction",
+        target=ProposalTarget(kind="translation", target_scope="base", target_tag_id=10, language="ja"),
+        proposed={"language": "ja", "translation": "青い目"},
+    )
+    apply_approved_feedback(_approved(proposal), user_repository=user_repo)
+
+    records = list_local_feedback_applications(user_repository=user_repo)
+
+    assert len(records) == 1
+    assert records[0].proposal_kind == "translation_correction"
+    assert records[0].target_scope == "base"
+    assert records[0].target_tag_id == 10
+    assert records[0].status == "applied"
+
+
+def test_format_relation_review_is_not_applyable(user_repo):
+    proposal = _proposal(
+        "format_relation_review",
+        target=ProposalTarget(kind="format_relation", target_scope="base", target_tag_id=10),
+        proposed={"note": "review only"},
+    )
+
+    with pytest.raises(ValueError, match="unsupported"):
+        apply_approved_feedback(_approved(proposal), user_repository=user_repo)


### PR DESCRIPTION
Closes #59

## Summary

- add `ApprovedDbFeedback`, local feedback apply result/audit models, and package exports
- add `LOCAL_FEEDBACK_APPLICATIONS` user-overlay audit table
- add user-local feedback apply service for approved proposals
- support dry-run, duplicate apply skip, audit/list, and overlay-only writes
- apply translation/status/type/usage/alias/tag-name proposals into user overlay tables without materializing base tags into `USER_TAGS`

## Notes

- This follows the #65 overlay redesign: base tag overrides are written by `target_scope + target_tag_id` into `USER_TAG_*_PATCH` tables.
- CLI wiring is intentionally left for a later slice; this PR provides the library/API surface and tests.
- `format_relation_review` remains review-only and is rejected by local apply.

## Verification

- `uv run pytest tests/unit/test_feedback_apply.py -q`
- `uv run pytest tests/unit/test_feedback_apply.py tests/unit/test_user_tag_repository.py tests/unit/test_overlay_translation_usage.py tests/unit/test_overlay_schema.py tests/unit/test_db_feedback_proposals.py -q`
- `uv run pytest -q` (555 passed)
- `uv run ruff check .`
- `uv run mypy src`
