### PR TITLE
Read base-scope overlay translation and usage patches

### DIFF
--- a/src/genai_tag_db_tools/db/overlay_reader.py
+++ b/src/genai_tag_db_tools/db/overlay_reader.py
@@ -233,7 +233,6 @@ class OverlayTagReader:
             rows = (
                 session.query(UserTagTranslationPatch)
                 .filter(
-                    UserTagTranslationPatch.target_scope == "user",
                     UserTagTranslationPatch.target_tag_id == tag_id,
                 )
                 .all()
@@ -259,7 +258,6 @@ class OverlayTagReader:
             rows = (
                 session.query(UserTagTranslationPatch)
                 .filter(
-                    UserTagTranslationPatch.target_scope == "user",
                     UserTagTranslationPatch.target_tag_id.in_(tag_ids),
                 )
                 .all()
@@ -389,7 +387,6 @@ class OverlayTagReader:
             row = (
                 session.query(UserTagUsagePatch)
                 .filter(
-                    UserTagUsagePatch.target_scope == "user",
                     UserTagUsagePatch.target_tag_id == tag_id,
                     UserTagUsagePatch.format_id == format_id,
                 )
@@ -402,9 +399,7 @@ class OverlayTagReader:
     ) -> list[TagUsageCounts]:
         """USER_TAG_USAGE_PATCH を TagUsageCounts オブジェクトに変換して返す。"""
         with self.session_factory() as session:
-            query = session.query(UserTagUsagePatch).filter(
-                UserTagUsagePatch.target_scope == "user"
-            )
+            query = session.query(UserTagUsagePatch)
             if tag_id is not None:
                 query = query.filter(UserTagUsagePatch.target_tag_id == tag_id)
             if format_id is not None:

--- a/tests/unit/test_overlay_translation_usage.py
+++ b/tests/unit/test_overlay_translation_usage.py
@@ -179,6 +179,14 @@ class TestUserTagUsagePatch:
         result = overlay_reader.get_usage_count(tag_id, 1000)
         assert result == 77
 
+    def test_get_usage_count_returns_base_scope_patch(self, user_repo, overlay_reader):
+        """base tag に対する overlay usage patch も get_usage_count で取得できる。"""
+        tag_id = 13
+        user_repo.write_usage_patch("base", tag_id, 1000, 77)
+
+        result = overlay_reader.get_usage_count(tag_id, 1000)
+        assert result == 77
+
     def test_get_usage_count_returns_none_when_absent(self, overlay_reader):
         """存在しないエントリは None を返す。"""
         assert overlay_reader.get_usage_count(USER_TAG_ID_OFFSET + 999, 1000) is None
@@ -205,6 +213,17 @@ class TestUserTagUsagePatch:
         assert len(results) == 1
         assert results[0].format_id == 1000
 
+    def test_list_usage_counts_returns_base_scope_patch(self, user_repo, overlay_reader):
+        """base tag に対する overlay usage patch も list_usage_counts で取得できる。"""
+        tag_id = 21
+        user_repo.write_usage_patch("base", tag_id, 1000, 1)
+
+        results = overlay_reader.list_usage_counts(tag_id=tag_id, format_id=1000)
+        assert len(results) == 1
+        assert results[0].tag_id == tag_id
+        assert results[0].format_id == 1000
+        assert results[0].count == 1
+
 
 # --- TestOverlayReaderTranslations ---
 
@@ -216,6 +235,17 @@ class TestOverlayReaderTranslations:
         """write_translation_patch で保存した翻訳を get_translations で取得できる。"""
         tag_id = USER_TAG_ID_OFFSET + 100
         user_repo.write_translation_patch("user", tag_id, "ja", "犬")
+
+        results = overlay_reader.get_translations(tag_id)
+        assert len(results) == 1
+        assert results[0].tag_id == tag_id
+        assert results[0].language == "ja"
+        assert results[0].translation == "犬"
+
+    def test_get_translations_returns_base_scope_patch(self, user_repo, overlay_reader):
+        """base tag に対する overlay translation patch も get_translations で取得できる。"""
+        tag_id = 100
+        user_repo.write_translation_patch("base", tag_id, "ja", "犬")
 
         results = overlay_reader.get_translations(tag_id)
         assert len(results) == 1
@@ -239,6 +269,16 @@ class TestOverlayReaderTranslations:
         assert tag_id_b in result
         assert result[tag_id_a][0].translation == "猫"
         assert result[tag_id_b][0].translation == "犬"
+
+    def test_get_translations_batch_returns_base_scope_patch(self, user_repo, overlay_reader):
+        """base tag に対する overlay translation patch も batch で取得できる。"""
+        tag_id = 101
+        user_repo.write_translation_patch("base", tag_id, "ja", "猫")
+
+        result = overlay_reader.get_translations_batch([tag_id])
+        assert tag_id in result
+        assert result[tag_id][0].tag_id == tag_id
+        assert result[tag_id][0].translation == "猫"
 
     def test_get_translations_batch_empty_ids(self, overlay_reader):
         """空リストを渡した場合は空辞書を返す。"""


### PR DESCRIPTION
## Summary
- allow OverlayTagReader translation/usage reads to return base-scope overlay patches
- add focused coverage for base-scope translation and usage patch reads

## Validation
- uv run pytest tests/unit/test_overlay_translation_usage.py -q
- uv run ruff check .

Split out from closed PR #89.