### PR TITLE
Add local feedback apply models and audit table

### DIFF
--- a/src/genai_tag_db_tools/db/schema.py
+++ b/src/genai_tag_db_tools/db/schema.py
@@ -293,3 +293,35 @@ class UserTagUsagePatch(UserOverlayBase):
         CheckConstraint("target_scope IN ('base', 'user')", name="ck_usage_patch_scope"),
         Index("ix_usage_patch_target", "target_scope", "target_tag_id"),
     )
+
+
+class LocalFeedbackApplication(UserOverlayBase):
+    """user-local feedback proposal の apply 履歴。
+
+    user DB 専用の audit table。proposal の二重 apply 防止と、あとからの確認に使う。
+    """
+
+    __tablename__ = "LOCAL_FEEDBACK_APPLICATIONS"
+
+    application_id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    proposal_hash: Mapped[str] = mapped_column()
+    proposal_kind: Mapped[str] = mapped_column()
+    target_kind: Mapped[str] = mapped_column()
+    target_scope: Mapped[str | None] = mapped_column(nullable=True)
+    target_tag_id: Mapped[int | None] = mapped_column(nullable=True)
+    format_name: Mapped[str | None] = mapped_column(nullable=True)
+    field: Mapped[str | None] = mapped_column(nullable=True)
+    approved_by: Mapped[str] = mapped_column()
+    approved_at: Mapped[datetime] = mapped_column(DateTime)
+    applied_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
+    status: Mapped[str] = mapped_column()
+    dry_run: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="0")
+    proposal_json: Mapped[str] = mapped_column()
+    before_json: Mapped[str | None] = mapped_column(nullable=True)
+    after_json: Mapped[str | None] = mapped_column(nullable=True)
+    error_message: Mapped[str | None] = mapped_column(nullable=True)
+
+    __table_args__ = (
+        Index("ix_local_feedback_hash", "proposal_hash"),
+        Index("ix_local_feedback_target", "target_scope", "target_tag_id"),
+    )

--- a/src/genai_tag_db_tools/db/schema.py
+++ b/src/genai_tag_db_tools/db/schema.py
@@ -12,6 +12,7 @@ from sqlalchemy import (
     Index,
     UniqueConstraint,
     func,
+    text,
 )
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
@@ -322,6 +323,12 @@ class LocalFeedbackApplication(UserOverlayBase):
     error_message: Mapped[str | None] = mapped_column(nullable=True)
 
     __table_args__ = (
+        Index(
+            "uix_local_feedback_applied_hash",
+            "proposal_hash",
+            unique=True,
+            sqlite_where=text("status IN ('applied', 'skipped')"),
+        ),
         Index("ix_local_feedback_hash", "proposal_hash"),
         Index("ix_local_feedback_target", "target_scope", "target_tag_id"),
     )

--- a/src/genai_tag_db_tools/db/schema.py
+++ b/src/genai_tag_db_tools/db/schema.py
@@ -1,7 +1,7 @@
 # genai_tag_db_tools.db.schema
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime
 
 from sqlalchemy import (
     Boolean,
@@ -15,6 +15,28 @@ from sqlalchemy import (
     text,
 )
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
+from sqlalchemy.types import TypeDecorator
+
+
+class UTCDateTime(TypeDecorator[datetime]):
+    """Store aware datetimes as naive UTC and read them back as UTC-aware."""
+
+    impl = DateTime
+    cache_ok = True
+
+    def process_bind_param(self, value: datetime | None, dialect: object) -> datetime | None:
+        if value is None:
+            return None
+        if value.tzinfo is None:
+            return value
+        return value.astimezone(UTC).replace(tzinfo=None)
+
+    def process_result_value(self, value: datetime | None, dialect: object) -> datetime | None:
+        if value is None:
+            return None
+        if value.tzinfo is None:
+            return value.replace(tzinfo=UTC)
+        return value.astimezone(UTC)
 
 
 class Base(DeclarativeBase):
@@ -313,7 +335,7 @@ class LocalFeedbackApplication(UserOverlayBase):
     format_name: Mapped[str | None] = mapped_column(nullable=True)
     field: Mapped[str | None] = mapped_column(nullable=True)
     approved_by: Mapped[str] = mapped_column()
-    approved_at: Mapped[datetime] = mapped_column(DateTime)
+    approved_at: Mapped[datetime] = mapped_column(UTCDateTime())
     applied_at: Mapped[datetime] = mapped_column(DateTime, server_default=func.now())
     status: Mapped[str] = mapped_column()
     dry_run: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="0")
@@ -323,6 +345,21 @@ class LocalFeedbackApplication(UserOverlayBase):
     error_message: Mapped[str | None] = mapped_column(nullable=True)
 
     __table_args__ = (
+        CheckConstraint(
+            "proposal_kind IN ("
+            "'tag_name_correction', 'alias_addition', 'preferred_tag_correction', "
+            "'translation_correction', 'usage_correction', 'type_correction', "
+            "'status_correction', 'format_relation_review'"
+            ")",
+            name="ck_local_feedback_proposal_kind",
+        ),
+        CheckConstraint(
+            "target_kind IN ("
+            "'tag_name', 'alias', 'preferred_tag', 'tag_type', 'tag_status', "
+            "'translation', 'usage', 'format_relation'"
+            ")",
+            name="ck_local_feedback_target_kind",
+        ),
         CheckConstraint(
             "target_scope IS NULL OR target_scope IN ('base', 'user')",
             name="ck_local_feedback_target_scope",
@@ -339,7 +376,7 @@ class LocalFeedbackApplication(UserOverlayBase):
             "uix_local_feedback_applied_hash",
             "proposal_hash",
             unique=True,
-            sqlite_where=text("status IN ('applied', 'skipped')"),
+            sqlite_where=text("dry_run = 0 AND status IN ('applied', 'skipped')"),
         ),
         Index("ix_local_feedback_hash", "proposal_hash"),
         Index("ix_local_feedback_target", "target_scope", "target_tag_id"),

--- a/src/genai_tag_db_tools/db/schema.py
+++ b/src/genai_tag_db_tools/db/schema.py
@@ -323,6 +323,10 @@ class LocalFeedbackApplication(UserOverlayBase):
     error_message: Mapped[str | None] = mapped_column(nullable=True)
 
     __table_args__ = (
+        CheckConstraint(
+            "status IN ('applied', 'dry_run', 'skipped', 'failed')",
+            name="ck_local_feedback_status",
+        ),
         Index(
             "uix_local_feedback_applied_hash",
             "proposal_hash",

--- a/src/genai_tag_db_tools/db/schema.py
+++ b/src/genai_tag_db_tools/db/schema.py
@@ -324,8 +324,16 @@ class LocalFeedbackApplication(UserOverlayBase):
 
     __table_args__ = (
         CheckConstraint(
+            "target_scope IS NULL OR target_scope IN ('base', 'user')",
+            name="ck_local_feedback_target_scope",
+        ),
+        CheckConstraint(
             "status IN ('applied', 'dry_run', 'skipped', 'failed')",
             name="ck_local_feedback_status",
+        ),
+        CheckConstraint(
+            "(status != 'dry_run' OR dry_run = 1) AND (status != 'applied' OR dry_run = 0)",
+            name="ck_local_feedback_dry_run_status",
         ),
         Index(
             "uix_local_feedback_applied_hash",

--- a/src/genai_tag_db_tools/models.py
+++ b/src/genai_tag_db_tools/models.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Literal, TypedDict
 
 from pydantic import BaseModel, Field, model_validator
@@ -409,6 +410,54 @@ class RefinementRecommendation(BaseModel):
     proposals: list[DbFeedbackProposal] = Field(
         default_factory=list,
         description="Future DB feedback proposals derived from the recommendation",
+    )
+
+
+class ApprovedDbFeedback(BaseModel):
+    """人間承認済みの DB feedback proposal。"""
+
+    proposal: DbFeedbackProposal = Field(..., description="Approved proposal")
+    approved: bool = Field(..., description="Whether this proposal was approved by a human")
+    approved_by: str = Field(..., description="Human approver identifier")
+    approved_at: datetime = Field(..., description="Approval timestamp")
+    approval_note: str | None = Field(default=None, description="Optional approval note")
+
+
+class LocalFeedbackApplicationRecord(BaseModel):
+    """user-local feedback apply の audit record。"""
+
+    application_id: int
+    proposal_hash: str
+    proposal_kind: str
+    target_kind: str
+    target_scope: Literal["base", "user"] | None = None
+    target_tag_id: int | None = None
+    format_name: str | None = None
+    field: str | None = None
+    approved_by: str
+    approved_at: datetime
+    applied_at: datetime | None = None
+    status: Literal["applied", "dry_run", "skipped", "failed"]
+    dry_run: bool
+    proposal_json: str
+    before_json: str | None = None
+    after_json: str | None = None
+    error_message: str | None = None
+
+
+class LocalFeedbackApplyResult(BaseModel):
+    """user-local feedback apply の結果。"""
+
+    ok: bool = Field(..., description="Whether the operation completed without validation/apply error")
+    status: Literal["applied", "dry_run", "skipped", "failed"] = Field(..., description="Apply status")
+    dry_run: bool = Field(..., description="Whether this was a dry run")
+    proposal_hash: str = Field(..., description="Stable hash of the proposal payload")
+    proposal_kind: str = Field(..., description="Proposal kind")
+    message: str = Field(..., description="Human-readable result message")
+    changes: list[dict[str, ProposalValue]] = Field(default_factory=list, description="Planned or applied changes")
+    application: LocalFeedbackApplicationRecord | None = Field(
+        default=None,
+        description="Audit record for applied/dry-run/skipped proposals",
     )
 
 

--- a/src/genai_tag_db_tools/models.py
+++ b/src/genai_tag_db_tools/models.py
@@ -422,6 +422,12 @@ class ApprovedDbFeedback(BaseModel):
     approved_at: datetime = Field(..., description="Approval timestamp")
     approval_note: str | None = Field(default=None, description="Optional approval note")
 
+    @model_validator(mode="after")
+    def _validate_approved(self) -> ApprovedDbFeedback:
+        if not self.approved:
+            raise ValueError("approved feedback must have approved=true")
+        return self
+
 
 class LocalFeedbackApplicationRecord(BaseModel):
     """user-local feedback apply の audit record。"""
@@ -459,6 +465,12 @@ class LocalFeedbackApplyResult(BaseModel):
         default=None,
         description="Audit record for applied/dry-run/skipped proposals",
     )
+
+    @model_validator(mode="after")
+    def _validate_ok_status(self) -> LocalFeedbackApplyResult:
+        if self.ok != (self.status != "failed"):
+            raise ValueError("ok must be true unless status is failed")
+        return self
 
 
 class ConvertTagsRequest(BaseModel):

--- a/src/genai_tag_db_tools/models.py
+++ b/src/genai_tag_db_tools/models.py
@@ -470,6 +470,19 @@ class LocalFeedbackApplyResult(BaseModel):
     def _validate_ok_status(self) -> LocalFeedbackApplyResult:
         if self.ok != (self.status != "failed"):
             raise ValueError("ok must be true unless status is failed")
+        if self.status == "applied" and self.dry_run:
+            raise ValueError("applied results must have dry_run=false")
+        if self.status == "dry_run" and not self.dry_run:
+            raise ValueError("dry_run results must have dry_run=true")
+        if self.application is not None:
+            if self.application.proposal_hash != self.proposal_hash:
+                raise ValueError("application proposal_hash must match result proposal_hash")
+            if self.application.proposal_kind != self.proposal_kind:
+                raise ValueError("application proposal_kind must match result proposal_kind")
+            if self.application.status != self.status:
+                raise ValueError("application status must match result status")
+            if self.application.dry_run != self.dry_run:
+                raise ValueError("application dry_run must match result dry_run")
         return self
 
 

--- a/src/genai_tag_db_tools/models.py
+++ b/src/genai_tag_db_tools/models.py
@@ -434,8 +434,26 @@ class LocalFeedbackApplicationRecord(BaseModel):
 
     application_id: int
     proposal_hash: str
-    proposal_kind: str
-    target_kind: str
+    proposal_kind: Literal[
+        "tag_name_correction",
+        "alias_addition",
+        "preferred_tag_correction",
+        "translation_correction",
+        "usage_correction",
+        "type_correction",
+        "status_correction",
+        "format_relation_review",
+    ]
+    target_kind: Literal[
+        "tag_name",
+        "alias",
+        "preferred_tag",
+        "tag_type",
+        "tag_status",
+        "translation",
+        "usage",
+        "format_relation",
+    ]
     target_scope: Literal["base", "user"] | None = None
     target_tag_id: int | None = None
     format_name: str | None = None
@@ -466,7 +484,16 @@ class LocalFeedbackApplyResult(BaseModel):
     status: Literal["applied", "dry_run", "skipped", "failed"] = Field(..., description="Apply status")
     dry_run: bool = Field(..., description="Whether this was a dry run")
     proposal_hash: str = Field(..., description="Stable hash of the proposal payload")
-    proposal_kind: str = Field(..., description="Proposal kind")
+    proposal_kind: Literal[
+        "tag_name_correction",
+        "alias_addition",
+        "preferred_tag_correction",
+        "translation_correction",
+        "usage_correction",
+        "type_correction",
+        "status_correction",
+        "format_relation_review",
+    ] = Field(..., description="Proposal kind")
     message: str = Field(..., description="Human-readable result message")
     changes: list[dict[str, ProposalValue]] = Field(default_factory=list, description="Planned or applied changes")
     application: LocalFeedbackApplicationRecord | None = Field(

--- a/src/genai_tag_db_tools/models.py
+++ b/src/genai_tag_db_tools/models.py
@@ -450,6 +450,14 @@ class LocalFeedbackApplicationRecord(BaseModel):
     after_json: str | None = None
     error_message: str | None = None
 
+    @model_validator(mode="after")
+    def _validate_dry_run_status(self) -> LocalFeedbackApplicationRecord:
+        if self.status == "applied" and self.dry_run:
+            raise ValueError("applied application records must have dry_run=false")
+        if self.status == "dry_run" and not self.dry_run:
+            raise ValueError("dry_run application records must have dry_run=true")
+        return self
+
 
 class LocalFeedbackApplyResult(BaseModel):
     """user-local feedback apply の結果。"""

--- a/tests/unit/test_feedback_apply_models.py
+++ b/tests/unit/test_feedback_apply_models.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta, timezone
 
 import pytest
 from pydantic import ValidationError
-from sqlalchemy import create_engine, inspect
+from sqlalchemy import create_engine, inspect, select
 from sqlalchemy.exc import IntegrityError
 
 from genai_tag_db_tools.db.schema import LocalFeedbackApplication, UserOverlayBase
@@ -38,20 +38,22 @@ def _application_values(
     *,
     proposal_hash: str = "abc123",
     proposal_kind: str = "translation_correction",
+    target_kind: str = "translation",
     target_scope: str | None = "base",
     status: str = "applied",
     dry_run: bool = False,
+    approved_at: datetime | None = None,
 ) -> dict[str, object]:
     return {
         "proposal_hash": proposal_hash,
         "proposal_kind": proposal_kind,
-        "target_kind": "translation",
+        "target_kind": target_kind,
         "target_scope": target_scope,
         "target_tag_id": 10,
         "format_name": None,
         "field": "translation.ja",
         "approved_by": "tester",
-        "approved_at": datetime(2026, 6, 28, 12, 0, tzinfo=UTC),
+        "approved_at": approved_at or datetime(2026, 6, 28, 12, 0, tzinfo=UTC),
         "status": status,
         "dry_run": dry_run,
         "proposal_json": "{}",
@@ -139,6 +141,21 @@ def test_local_feedback_application_record_rejects_contradictory_dry_run_status(
         LocalFeedbackApplicationRecord(
             application_id=1,
             **_application_values(status=status, dry_run=dry_run),
+        )
+
+
+@pytest.mark.parametrize(
+    "application_update",
+    [
+        {"proposal_kind": "typo_kind"},
+        {"target_kind": "typo_target"},
+    ],
+)
+def test_local_feedback_application_record_rejects_unknown_kinds(application_update: dict[str, object]):
+    with pytest.raises(ValidationError):
+        LocalFeedbackApplicationRecord(
+            application_id=1,
+            **(_application_values() | application_update),
         )
 
 
@@ -248,6 +265,21 @@ def test_local_feedback_application_prevents_duplicate_applied_hashes():
             )
 
 
+def test_local_feedback_application_allows_apply_after_dry_run_skip():
+    engine = create_engine("sqlite:///:memory:")
+    UserOverlayBase.metadata.create_all(engine)
+
+    with engine.begin() as conn:
+        conn.execute(
+            LocalFeedbackApplication.__table__.insert(),
+            _application_values(proposal_hash="dry-run-skip", status="skipped", dry_run=True),
+        )
+        conn.execute(
+            LocalFeedbackApplication.__table__.insert(),
+            _application_values(proposal_hash="dry-run-skip", status="applied", dry_run=False),
+        )
+
+
 def test_local_feedback_application_rejects_unknown_status():
     engine = create_engine("sqlite:///:memory:")
     UserOverlayBase.metadata.create_all(engine)
@@ -257,6 +289,25 @@ def test_local_feedback_application_rejects_unknown_status():
             conn.execute(
                 LocalFeedbackApplication.__table__.insert(),
                 _application_values(status="applyed"),
+            )
+
+
+@pytest.mark.parametrize(
+    "values",
+    [
+        {"proposal_kind": "typo_kind"},
+        {"target_kind": "typo_target"},
+    ],
+)
+def test_local_feedback_application_rejects_unknown_kinds(values: dict[str, object]):
+    engine = create_engine("sqlite:///:memory:")
+    UserOverlayBase.metadata.create_all(engine)
+
+    with engine.begin() as conn:
+        with pytest.raises(IntegrityError):
+            conn.execute(
+                LocalFeedbackApplication.__table__.insert(),
+                _application_values(**values),
             )
 
 
@@ -289,3 +340,19 @@ def test_local_feedback_application_rejects_unknown_target_scope():
                 LocalFeedbackApplication.__table__.insert(),
                 _application_values(target_scope="usr"),
             )
+
+
+def test_local_feedback_application_normalizes_approved_at_to_utc():
+    engine = create_engine("sqlite:///:memory:")
+    UserOverlayBase.metadata.create_all(engine)
+    jst = timezone(timedelta(hours=9))
+    approved_at = datetime(2026, 6, 28, 21, 0, tzinfo=jst)
+
+    with engine.begin() as conn:
+        conn.execute(
+            LocalFeedbackApplication.__table__.insert(),
+            _application_values(approved_at=approved_at),
+        )
+        restored = conn.execute(select(LocalFeedbackApplication.__table__.c.approved_at)).scalar_one()
+
+    assert restored == datetime(2026, 6, 28, 12, 0, tzinfo=UTC)

--- a/tests/unit/test_feedback_apply_models.py
+++ b/tests/unit/test_feedback_apply_models.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
+import pytest
+from pydantic import ValidationError
 from sqlalchemy import create_engine, inspect
+from sqlalchemy.exc import IntegrityError
 
-from genai_tag_db_tools.db.schema import UserOverlayBase
+from genai_tag_db_tools.db.schema import LocalFeedbackApplication, UserOverlayBase
 from genai_tag_db_tools.models import (
     ApprovedDbFeedback,
     DbFeedbackProposal,
@@ -48,6 +51,18 @@ def test_approved_db_feedback_roundtrip():
     assert restored.approved_at == approved_at
 
 
+def test_approved_db_feedback_requires_approved_true():
+    approved_at = datetime(2026, 6, 28, 12, 0, tzinfo=UTC)
+
+    with pytest.raises(ValidationError):
+        ApprovedDbFeedback(
+            proposal=_proposal(),
+            approved=False,
+            approved_by="tester",
+            approved_at=approved_at,
+        )
+
+
 def test_local_feedback_application_record_and_result_roundtrip():
     approved_at = datetime(2026, 6, 28, 12, 0, tzinfo=UTC)
     record = LocalFeedbackApplicationRecord(
@@ -85,6 +100,29 @@ def test_local_feedback_application_record_and_result_roundtrip():
     assert restored.application.target_scope == "base"
 
 
+@pytest.mark.parametrize(
+    ("ok", "status"),
+    [
+        (True, "failed"),
+        (False, "applied"),
+        (False, "dry_run"),
+        (False, "skipped"),
+    ],
+)
+def test_local_feedback_apply_result_rejects_contradictory_ok_status(ok: bool, status: str):
+    with pytest.raises(ValidationError):
+        LocalFeedbackApplyResult(
+            ok=ok,
+            status=status,
+            dry_run=status == "dry_run",
+            proposal_hash="abc123",
+            proposal_kind="translation_correction",
+            message="feedback apply result",
+            changes=[],
+            application=None,
+        )
+
+
 def test_local_feedback_application_table_is_user_overlay_schema_only():
     engine = create_engine("sqlite:///:memory:")
     UserOverlayBase.metadata.create_all(engine)
@@ -92,3 +130,48 @@ def test_local_feedback_application_table_is_user_overlay_schema_only():
     table_names = set(inspect(engine).get_table_names())
 
     assert "LOCAL_FEEDBACK_APPLICATIONS" in table_names
+
+
+def test_local_feedback_application_prevents_duplicate_applied_hashes():
+    engine = create_engine("sqlite:///:memory:")
+    UserOverlayBase.metadata.create_all(engine)
+    approved_at = datetime(2026, 6, 28, 12, 0, tzinfo=UTC)
+
+    def application_values(*, proposal_hash: str, status: str, dry_run: bool) -> dict[str, object]:
+        return {
+            "proposal_hash": proposal_hash,
+            "proposal_kind": "translation_correction",
+            "target_kind": "translation",
+            "target_scope": "base",
+            "target_tag_id": 10,
+            "format_name": None,
+            "field": "translation.ja",
+            "approved_by": "tester",
+            "approved_at": approved_at,
+            "status": status,
+            "dry_run": dry_run,
+            "proposal_json": "{}",
+            "before_json": None,
+            "after_json": '{"changes":[]}',
+            "error_message": None,
+        }
+
+    with engine.begin() as conn:
+        conn.execute(
+            LocalFeedbackApplication.__table__.insert(),
+            application_values(proposal_hash="dry-run-can-repeat", status="dry_run", dry_run=True),
+        )
+        conn.execute(
+            LocalFeedbackApplication.__table__.insert(),
+            application_values(proposal_hash="dry-run-can-repeat", status="applied", dry_run=False),
+        )
+        conn.execute(
+            LocalFeedbackApplication.__table__.insert(),
+            application_values(proposal_hash="duplicate-applied", status="applied", dry_run=False),
+        )
+
+        with pytest.raises(IntegrityError):
+            conn.execute(
+                LocalFeedbackApplication.__table__.insert(),
+                application_values(proposal_hash="duplicate-applied", status="applied", dry_run=False),
+            )

--- a/tests/unit/test_feedback_apply_models.py
+++ b/tests/unit/test_feedback_apply_models.py
@@ -38,6 +38,7 @@ def _application_values(
     *,
     proposal_hash: str = "abc123",
     proposal_kind: str = "translation_correction",
+    target_scope: str | None = "base",
     status: str = "applied",
     dry_run: bool = False,
 ) -> dict[str, object]:
@@ -45,7 +46,7 @@ def _application_values(
         "proposal_hash": proposal_hash,
         "proposal_kind": proposal_kind,
         "target_kind": "translation",
-        "target_scope": "base",
+        "target_scope": target_scope,
         "target_tag_id": 10,
         "format_name": None,
         "field": "translation.ja",
@@ -124,6 +125,21 @@ def test_local_feedback_application_record_and_result_roundtrip():
     assert restored == result
     assert restored.application is not None
     assert restored.application.target_scope == "base"
+
+
+@pytest.mark.parametrize(
+    ("status", "dry_run"),
+    [
+        ("applied", True),
+        ("dry_run", False),
+    ],
+)
+def test_local_feedback_application_record_rejects_contradictory_dry_run_status(status: str, dry_run: bool):
+    with pytest.raises(ValidationError):
+        LocalFeedbackApplicationRecord(
+            application_id=1,
+            **_application_values(status=status, dry_run=dry_run),
+        )
 
 
 @pytest.mark.parametrize(
@@ -241,4 +257,35 @@ def test_local_feedback_application_rejects_unknown_status():
             conn.execute(
                 LocalFeedbackApplication.__table__.insert(),
                 _application_values(status="applyed"),
+            )
+
+
+@pytest.mark.parametrize(
+    ("status", "dry_run"),
+    [
+        ("applied", True),
+        ("dry_run", False),
+    ],
+)
+def test_local_feedback_application_rejects_contradictory_dry_run_status(status: str, dry_run: bool):
+    engine = create_engine("sqlite:///:memory:")
+    UserOverlayBase.metadata.create_all(engine)
+
+    with engine.begin() as conn:
+        with pytest.raises(IntegrityError):
+            conn.execute(
+                LocalFeedbackApplication.__table__.insert(),
+                _application_values(status=status, dry_run=dry_run),
+            )
+
+
+def test_local_feedback_application_rejects_unknown_target_scope():
+    engine = create_engine("sqlite:///:memory:")
+    UserOverlayBase.metadata.create_all(engine)
+
+    with engine.begin() as conn:
+        with pytest.raises(IntegrityError):
+            conn.execute(
+                LocalFeedbackApplication.__table__.insert(),
+                _application_values(target_scope="usr"),
             )

--- a/tests/unit/test_feedback_apply_models.py
+++ b/tests/unit/test_feedback_apply_models.py
@@ -34,6 +34,32 @@ def _proposal() -> DbFeedbackProposal:
     )
 
 
+def _application_values(
+    *,
+    proposal_hash: str = "abc123",
+    proposal_kind: str = "translation_correction",
+    status: str = "applied",
+    dry_run: bool = False,
+) -> dict[str, object]:
+    return {
+        "proposal_hash": proposal_hash,
+        "proposal_kind": proposal_kind,
+        "target_kind": "translation",
+        "target_scope": "base",
+        "target_tag_id": 10,
+        "format_name": None,
+        "field": "translation.ja",
+        "approved_by": "tester",
+        "approved_at": datetime(2026, 6, 28, 12, 0, tzinfo=UTC),
+        "status": status,
+        "dry_run": dry_run,
+        "proposal_json": "{}",
+        "before_json": None,
+        "after_json": '{"changes":[]}',
+        "error_message": None,
+    }
+
+
 def test_approved_db_feedback_roundtrip():
     approved_at = datetime(2026, 6, 28, 12, 0, tzinfo=UTC)
     feedback = ApprovedDbFeedback(
@@ -123,6 +149,55 @@ def test_local_feedback_apply_result_rejects_contradictory_ok_status(ok: bool, s
         )
 
 
+@pytest.mark.parametrize(
+    ("status", "dry_run"),
+    [
+        ("applied", True),
+        ("dry_run", False),
+    ],
+)
+def test_local_feedback_apply_result_rejects_contradictory_dry_run_status(status: str, dry_run: bool):
+    with pytest.raises(ValidationError):
+        LocalFeedbackApplyResult(
+            ok=True,
+            status=status,
+            dry_run=dry_run,
+            proposal_hash="abc123",
+            proposal_kind="translation_correction",
+            message="feedback apply result",
+            changes=[],
+            application=None,
+        )
+
+
+@pytest.mark.parametrize(
+    "application_update",
+    [
+        {"proposal_hash": "other-hash"},
+        {"proposal_kind": "tag_name_correction"},
+        {"status": "skipped"},
+        {"dry_run": True},
+    ],
+)
+def test_local_feedback_apply_result_rejects_mismatched_application(application_update: dict[str, object]):
+    record = LocalFeedbackApplicationRecord(
+        application_id=1,
+        **_application_values(),
+    ).model_copy(update=application_update)
+
+    with pytest.raises(ValidationError):
+        LocalFeedbackApplyResult(
+            ok=True,
+            status="applied",
+            dry_run=False,
+            proposal_hash="abc123",
+            proposal_kind="translation_correction",
+            message="feedback applied",
+            changes=[],
+            application=record,
+        )
+
+
 def test_local_feedback_application_table_is_user_overlay_schema_only():
     engine = create_engine("sqlite:///:memory:")
     UserOverlayBase.metadata.create_all(engine)
@@ -135,43 +210,35 @@ def test_local_feedback_application_table_is_user_overlay_schema_only():
 def test_local_feedback_application_prevents_duplicate_applied_hashes():
     engine = create_engine("sqlite:///:memory:")
     UserOverlayBase.metadata.create_all(engine)
-    approved_at = datetime(2026, 6, 28, 12, 0, tzinfo=UTC)
-
-    def application_values(*, proposal_hash: str, status: str, dry_run: bool) -> dict[str, object]:
-        return {
-            "proposal_hash": proposal_hash,
-            "proposal_kind": "translation_correction",
-            "target_kind": "translation",
-            "target_scope": "base",
-            "target_tag_id": 10,
-            "format_name": None,
-            "field": "translation.ja",
-            "approved_by": "tester",
-            "approved_at": approved_at,
-            "status": status,
-            "dry_run": dry_run,
-            "proposal_json": "{}",
-            "before_json": None,
-            "after_json": '{"changes":[]}',
-            "error_message": None,
-        }
 
     with engine.begin() as conn:
         conn.execute(
             LocalFeedbackApplication.__table__.insert(),
-            application_values(proposal_hash="dry-run-can-repeat", status="dry_run", dry_run=True),
+            _application_values(proposal_hash="dry-run-can-repeat", status="dry_run", dry_run=True),
         )
         conn.execute(
             LocalFeedbackApplication.__table__.insert(),
-            application_values(proposal_hash="dry-run-can-repeat", status="applied", dry_run=False),
+            _application_values(proposal_hash="dry-run-can-repeat", status="applied", dry_run=False),
         )
         conn.execute(
             LocalFeedbackApplication.__table__.insert(),
-            application_values(proposal_hash="duplicate-applied", status="applied", dry_run=False),
+            _application_values(proposal_hash="duplicate-applied", status="applied", dry_run=False),
         )
 
         with pytest.raises(IntegrityError):
             conn.execute(
                 LocalFeedbackApplication.__table__.insert(),
-                application_values(proposal_hash="duplicate-applied", status="applied", dry_run=False),
+                _application_values(proposal_hash="duplicate-applied", status="applied", dry_run=False),
+            )
+
+
+def test_local_feedback_application_rejects_unknown_status():
+    engine = create_engine("sqlite:///:memory:")
+    UserOverlayBase.metadata.create_all(engine)
+
+    with engine.begin() as conn:
+        with pytest.raises(IntegrityError):
+            conn.execute(
+                LocalFeedbackApplication.__table__.insert(),
+                _application_values(status="applyed"),
             )

--- a/tests/unit/test_feedback_apply_models.py
+++ b/tests/unit/test_feedback_apply_models.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from sqlalchemy import create_engine, inspect
+
+from genai_tag_db_tools.db.schema import UserOverlayBase
+from genai_tag_db_tools.models import (
+    ApprovedDbFeedback,
+    DbFeedbackProposal,
+    LocalFeedbackApplicationRecord,
+    LocalFeedbackApplyResult,
+    ProposalTarget,
+)
+
+
+def _proposal() -> DbFeedbackProposal:
+    return DbFeedbackProposal(
+        kind="translation_correction",
+        target=ProposalTarget(
+            kind="translation",
+            target_scope="base",
+            target_tag_id=10,
+            language="ja",
+        ),
+        current=None,
+        proposed={"language": "ja", "translation": "青い目"},
+        confidence=0.9,
+        source="unit_test",
+        reason_codes=["translation_mismatch"],
+    )
+
+
+def test_approved_db_feedback_roundtrip():
+    approved_at = datetime(2026, 6, 28, 12, 0, tzinfo=UTC)
+    feedback = ApprovedDbFeedback(
+        proposal=_proposal(),
+        approved=True,
+        approved_by="tester",
+        approved_at=approved_at,
+        approval_note="checked manually",
+    )
+
+    restored = ApprovedDbFeedback.model_validate_json(feedback.model_dump_json())
+
+    assert restored == feedback
+    assert restored.proposal.target.target_scope == "base"
+    assert restored.approved_at == approved_at
+
+
+def test_local_feedback_application_record_and_result_roundtrip():
+    approved_at = datetime(2026, 6, 28, 12, 0, tzinfo=UTC)
+    record = LocalFeedbackApplicationRecord(
+        application_id=1,
+        proposal_hash="abc123",
+        proposal_kind="translation_correction",
+        target_kind="translation",
+        target_scope="base",
+        target_tag_id=10,
+        format_name=None,
+        field="translation.ja",
+        approved_by="tester",
+        approved_at=approved_at,
+        status="applied",
+        dry_run=False,
+        proposal_json="{}",
+        before_json=None,
+        after_json='{"changes":[]}',
+    )
+    result = LocalFeedbackApplyResult(
+        ok=True,
+        status="applied",
+        dry_run=False,
+        proposal_hash="abc123",
+        proposal_kind="translation_correction",
+        message="feedback applied",
+        changes=[],
+        application=record,
+    )
+
+    restored = LocalFeedbackApplyResult.model_validate_json(result.model_dump_json())
+
+    assert restored == result
+    assert restored.application is not None
+    assert restored.application.target_scope == "base"
+
+
+def test_local_feedback_application_table_is_user_overlay_schema_only():
+    engine = create_engine("sqlite:///:memory:")
+    UserOverlayBase.metadata.create_all(engine)
+
+    table_names = set(inspect(engine).get_table_names())
+
+    assert "LOCAL_FEEDBACK_APPLICATIONS" in table_names


### PR DESCRIPTION
## Summary
- add ApprovedDbFeedback and local feedback apply result/audit Pydantic models
- add LOCAL_FEEDBACK_APPLICATIONS to the user overlay schema
- add focused model/schema roundtrip tests

## Validation
- uv run pytest tests/unit/test_feedback_apply_models.py tests/unit/test_db_feedback_proposals.py -q
- uv run ruff check .

Split out from closed PR #89.