### PR TITLE
refactor(api): public API の安定インターフェース化 (#73)

### DIFF
--- a/src/genai_tag_db_tools/__init__.py
+++ b/src/genai_tag_db_tools/__init__.py
@@ -1,5 +1,26 @@
-"""genai-tag-db-tools package exports."""
+"""genai-tag-db-tools package exports.
 
+The names re-exported here form the **stable public API**. Downstream consumers
+should import exclusively from this top-level package (or from
+``genai_tag_db_tools.api`` / ``genai_tag_db_tools.models``) and must not depend on
+internal modules such as ``genai_tag_db_tools.db.*`` or
+``genai_tag_db_tools.services.*``.
+
+Stable handles (opaque; use only for annotations): ``TagReaderProtocol``,
+``TagRegisterServiceProtocol``, ``TagWriterProtocol``. Obtain instances via
+``get_tag_reader`` / ``get_user_tag_reader`` / ``create_tag_register_service`` /
+``get_user_repository`` and pass them to the module-level helpers.
+"""
+
+from .api import (
+    TagReaderProtocol,
+    TagRegisterServiceProtocol,
+    TagWriterProtocol,
+    create_tag_register_service,
+    get_tag_reader,
+    get_user_repository,
+    get_user_tag_reader,
+)
 from .core_api import (
     build_downloaded_at_utc,
     convert_tags,
@@ -33,27 +54,44 @@ from .services.feedback_apply import apply_approved_feedback, list_local_feedbac
 from .services.tag_search import TagSearcher
 from .utils.cleanup_str import TagCleaner
 
+# --- Backward-compatibility aliases -------------------------------------------
+# These let existing callers migrate to the top-level package with a one-line
+# import swap before adopting the new factory-based surface. They are intentional
+# *stable type aliases* / factory aliases, not the internal implementation
+# classes. Prefer the canonical names (TagReaderProtocol, get_tag_reader, ...).
+MergedTagReader = TagReaderProtocol
+get_default_reader = get_tag_reader
+
 __all__ = [
     "ApprovedDbFeedback",
     "DbFeedbackProposal",
     "LocalFeedbackApplicationRecord",
     "LocalFeedbackApplyResult",
+    "MergedTagReader",
     "ProposalTarget",
     "RefinementReason",
     "RefinementRecommendation",
     "RefinementSuggestion",
     "TagCleaner",
+    "TagReaderProtocol",
+    "TagRegisterServiceProtocol",
     "TagSearcher",
     "TagTypeUpdate",
+    "TagWriterProtocol",
     "apply_approved_feedback",
     "build_downloaded_at_utc",
     "convert_tags",
+    "create_tag_register_service",
     "ensure_databases",
     "get_all_type_names",
+    "get_default_reader",
     "get_format_type_names",
     "get_statistics",
     "get_tag_formats",
+    "get_tag_reader",
     "get_unknown_type_tags",
+    "get_user_repository",
+    "get_user_tag_reader",
     "initialize_databases",
     "initialize_tag_cleaner",
     "initialize_tag_searcher",

--- a/src/genai_tag_db_tools/api.py
+++ b/src/genai_tag_db_tools/api.py
@@ -1,0 +1,166 @@
+"""Stable public API surface for genai-tag-db-tools.
+
+This module defines the *public contract* that downstream consumers (e.g. LoRAIro)
+should depend on. It deliberately hides the concrete implementation classes
+(``MergedTagReader`` / ``OverlayTagReader`` / ``TagReader`` / ``TagRepository`` /
+``TagRegisterService``) behind lightweight :class:`typing.Protocol` types and
+factory functions.
+
+Why this exists
+---------------
+Historically downstream code imported internal classes directly, e.g.::
+
+    from genai_tag_db_tools.db.repository import MergedTagReader, get_default_reader
+    from genai_tag_db_tools.services.tag_register import TagRegisterService
+    from genai_tag_db_tools.db.runtime import get_user_session_factory
+
+Those imports couple callers to internal module layout and class names, so any
+internal refactor (overlay redesign, renames) breaks them. The protocols and
+factories below provide a stable surface that survives internal refactors.
+
+Public surface
+--------------
+Types (use only for annotations; treat instances as opaque handles):
+    * ``TagReaderProtocol``           - read-only tag database handle
+    * ``TagRegisterServiceProtocol``  - tag registration service handle
+    * ``TagWriterProtocol``           - write-capable user-DB repository handle
+
+Factories:
+    * ``get_tag_reader()``            - merged (base + user overlay) reader
+    * ``get_user_tag_reader()``       - user-DB-only reader
+    * ``create_tag_register_service()`` - registration service
+    * ``get_user_repository()``       - write-capable user repository
+
+Obtain a handle from a factory and pass it back into the module-level helpers
+(``search_tags``, ``convert_tags``, ``register_tag`` ...). Do not call methods on
+the handles directly and do not rely on their concrete runtime type.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Protocol, cast, runtime_checkable
+
+if TYPE_CHECKING:
+    from genai_tag_db_tools.models import TagRegisterRequest, TagRegisterResult
+
+__all__ = [
+    "TagReaderProtocol",
+    "TagRegisterServiceProtocol",
+    "TagWriterProtocol",
+    "create_tag_register_service",
+    "get_tag_reader",
+    "get_user_repository",
+    "get_user_tag_reader",
+]
+
+
+@runtime_checkable
+class TagReaderProtocol(Protocol):
+    """Stable, read-only handle to the tag database.
+
+    Treat instances as opaque: obtain one via :func:`get_tag_reader` or
+    :func:`get_user_tag_reader` and pass it to the module-level helpers such as
+    ``search_tags`` / ``convert_tags`` / ``get_statistics``. The method set below
+    is the contract those helpers rely on; downstream code should not call these
+    directly and should annotate variables as ``TagReaderProtocol``.
+    """
+
+    def search_tags(self, *args: Any, **kwargs: Any) -> Any: ...
+    def search_tags_bulk(self, *args: Any, **kwargs: Any) -> Any: ...
+    def get_format_id(self, *args: Any, **kwargs: Any) -> Any: ...
+    def get_format_name(self, *args: Any, **kwargs: Any) -> Any: ...
+    def get_tag_by_id(self, *args: Any, **kwargs: Any) -> Any: ...
+    def get_tag_status(self, *args: Any, **kwargs: Any) -> Any: ...
+    def list_tags(self, *args: Any, **kwargs: Any) -> Any: ...
+    def list_tag_statuses(self, *args: Any, **kwargs: Any) -> Any: ...
+    def get_tag_formats(self, *args: Any, **kwargs: Any) -> Any: ...
+    def get_all_types(self, *args: Any, **kwargs: Any) -> Any: ...
+    def get_tag_types(self, *args: Any, **kwargs: Any) -> Any: ...
+    def get_type_id_for_format(self, *args: Any, **kwargs: Any) -> Any: ...
+    def get_type_name_by_format_type_id(self, *args: Any, **kwargs: Any) -> Any: ...
+    def get_unknown_type_tag_ids(self, *args: Any, **kwargs: Any) -> Any: ...
+
+
+@runtime_checkable
+class TagRegisterServiceProtocol(Protocol):
+    """Stable handle for registering tags.
+
+    Obtain one via :func:`create_tag_register_service` and pass it to
+    ``register_tag(service, request)``.
+    """
+
+    def register_tag(self, request: TagRegisterRequest) -> TagRegisterResult: ...
+
+
+@runtime_checkable
+class TagWriterProtocol(Protocol):
+    """Stable, write-capable handle to the user tag database.
+
+    Obtain one via :func:`get_user_repository` and pass it to write helpers such
+    as ``update_tags_type_batch``. Treat instances as opaque.
+    """
+
+    def update_tags_type_batch(self, *args: Any, **kwargs: Any) -> Any: ...
+
+
+def get_tag_reader() -> TagReaderProtocol:
+    """Return the default merged reader (base DBs + user overlay).
+
+    This is the stable replacement for the internal
+    ``genai_tag_db_tools.db.repository.get_default_reader``. Databases must be
+    initialized first via :func:`genai_tag_db_tools.initialize_databases`.
+    """
+    from genai_tag_db_tools.db.repository import get_default_reader
+
+    return cast("TagReaderProtocol", get_default_reader())
+
+
+def get_user_tag_reader() -> TagReaderProtocol:
+    """Return a reader scoped to the user database only (no base DBs).
+
+    Useful for operations that should read/search exclusively within the user's
+    own overlay tags. Raises ``RuntimeError`` if the user DB is not initialized.
+    """
+    from genai_tag_db_tools.db.overlay_reader import OverlayTagReader
+    from genai_tag_db_tools.db.repository import MergedTagReader
+    from genai_tag_db_tools.db.runtime import get_user_session_factory_optional
+
+    user_factory = get_user_session_factory_optional()
+    if user_factory is None:
+        raise RuntimeError(
+            "User database is not initialized. Call initialize_databases(..., init_user_db=True) first."
+        )
+    user_reader = OverlayTagReader(session_factory=user_factory)
+    # Expose the user overlay as the base scope of a MergedTagReader so the full
+    # reader interface is available while keeping base DBs out of scope.
+    return cast("TagReaderProtocol", MergedTagReader(base_repo=user_reader, user_repo=None))
+
+
+def create_tag_register_service(
+    reader: TagReaderProtocol | None = None,
+) -> TagRegisterServiceProtocol:
+    """Create a tag registration service.
+
+    Stable replacement for instantiating
+    ``genai_tag_db_tools.services.tag_register.TagRegisterService`` directly.
+
+    Args:
+        reader: Optional reader handle (e.g. from :func:`get_tag_reader`). When
+            omitted the service builds the default reader/repository itself.
+    """
+    from genai_tag_db_tools.services.tag_register import TagRegisterService
+
+    service = TagRegisterService(reader=cast("Any", reader))
+    return cast("TagRegisterServiceProtocol", service)
+
+
+def get_user_repository() -> TagWriterProtocol:
+    """Return a write-capable repository bound to the user database.
+
+    Stable replacement for the internal
+    ``genai_tag_db_tools.db.repository.get_default_repository``. Raises
+    ``ValueError`` if the user DB is not available for writes.
+    """
+    from genai_tag_db_tools.db.repository import get_default_repository
+
+    return cast("TagWriterProtocol", get_default_repository())

--- a/src/genai_tag_db_tools/core_api.py
+++ b/src/genai_tag_db_tools/core_api.py
@@ -8,8 +8,9 @@ from difflib import SequenceMatcher
 from pathlib import Path
 from typing import Any, Literal
 
+from genai_tag_db_tools.api import TagReaderProtocol as MergedTagReader
+from genai_tag_db_tools.api import TagRegisterServiceProtocol as TagRegisterService
 from genai_tag_db_tools.db import runtime
-from genai_tag_db_tools.db.repository import MergedTagReader
 from genai_tag_db_tools.db.schema import USER_TAG_ID_OFFSET
 from genai_tag_db_tools.io import hf_downloader
 from genai_tag_db_tools.models import (
@@ -31,7 +32,6 @@ from genai_tag_db_tools.models import (
     TagSearchRow,
     TagStatisticsResult,
 )
-from genai_tag_db_tools.services.tag_register import TagRegisterService
 from genai_tag_db_tools.utils.cleanup_str import TagCleaner
 
 _REFINEMENT_REASON_MESSAGES = {

--- a/tests/unit/test_public_api.py
+++ b/tests/unit/test_public_api.py
@@ -1,0 +1,99 @@
+"""Tests for the stable public API surface (genai_tag_db_tools.api / __init__).
+
+These tests pin the public contract so that internal refactors (class renames,
+module moves) cannot silently break downstream consumers. They intentionally
+import only from the top-level package.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import genai_tag_db_tools as pkg
+from genai_tag_db_tools import (
+    MergedTagReader,
+    TagReaderProtocol,
+    TagRegisterServiceProtocol,
+    create_tag_register_service,
+    get_default_reader,
+    get_tag_reader,
+    get_user_repository,
+    get_user_tag_reader,
+)
+
+
+def test_public_names_are_exported() -> None:
+    """All advertised public names are reachable from the top-level package."""
+    expected = {
+        "TagReaderProtocol",
+        "TagRegisterServiceProtocol",
+        "TagWriterProtocol",
+        "get_tag_reader",
+        "get_user_tag_reader",
+        "create_tag_register_service",
+        "get_user_repository",
+    }
+    assert expected.issubset(set(pkg.__all__))
+    for name in expected:
+        assert hasattr(pkg, name)
+
+
+def test_backward_compat_aliases() -> None:
+    """Legacy names map onto the stable protocol/factory, not internal classes."""
+    assert MergedTagReader is TagReaderProtocol
+    assert get_default_reader is get_tag_reader
+
+
+def test_internal_reader_satisfies_reader_protocol() -> None:
+    """The concrete reader implementation conforms to TagReaderProtocol."""
+    from genai_tag_db_tools.db.repository import MergedTagReader as _MergedTagReader
+    from genai_tag_db_tools.db.repository import TagReader as _TagReader
+
+    reader = _MergedTagReader(base_repo=_TagReader(session_factory=lambda: None))
+    assert isinstance(reader, TagReaderProtocol)
+
+
+def test_internal_register_service_satisfies_protocol() -> None:
+    """The concrete register service exposes the protocol's register_tag method."""
+    from genai_tag_db_tools.services.tag_register import TagRegisterService
+
+    assert hasattr(TagRegisterService, "register_tag")
+    # Structural check via runtime_checkable Protocol on a lightweight stand-in.
+
+    class _Stub:
+        def register_tag(self, request):
+            return request
+
+    assert isinstance(_Stub(), TagRegisterServiceProtocol)
+
+
+def test_internal_repository_satisfies_writer_protocol() -> None:
+    """The concrete repository exposes the writer protocol surface."""
+    from genai_tag_db_tools.db.repository import TagRepository
+
+    assert hasattr(TagRepository, "update_tags_type_batch")
+
+
+def test_get_user_tag_reader_requires_initialized_user_db() -> None:
+    """Without an initialized user DB, the user-scoped reader fails clearly."""
+    with pytest.raises(RuntimeError):
+        get_user_tag_reader()
+
+
+def test_create_tag_register_service_is_callable() -> None:
+    """The factory returns a register-service handle when given a reader."""
+
+    class _Reader:
+        def get_format_id(self, name):
+            return 1
+
+    # repository defaults to the user DB which is uninitialized in unit tests, so
+    # construction is expected to fail loudly rather than touch a real DB.
+    with pytest.raises(Exception):  # noqa: B017 - any uninitialized-DB error is acceptable
+        create_tag_register_service(reader=_Reader())  # type: ignore[arg-type]
+
+
+def test_get_user_repository_requires_user_db() -> None:
+    """get_user_repository raises when the user DB is unavailable for writes."""
+    with pytest.raises(ValueError):
+        get_user_repository()


### PR DESCRIPTION
## 概要

内部実装クラス (`MergedTagReader` / `TagReader` / `TagRepository` / `TagRegisterService` / `get_default_reader` / `get_default_repository` / `get_user_session_factory`) への直接依存を断ち切り、安定した public contract を導入する。downstream (LoRAIro) は新しい facade のみに依存すれば、内部リファクタ (overlay 再設計・クラス改名) の影響を受けない。

Closes #73

## 新しい public surface

新規モジュール `genai_tag_db_tools/api.py`、トップレベル `__init__.py` から re-export:

**Stable handles (opaque; アノテーション専用):**
- `TagReaderProtocol` — 読み取り専用リーダーハンドル
- `TagRegisterServiceProtocol` — タグ登録サービスハンドル
- `TagWriterProtocol` — user DB 書き込みリポジトリハンドル

**Factories:**
- `get_tag_reader() -> TagReaderProtocol` — merged (base + user overlay) リーダー
- `get_user_tag_reader() -> TagReaderProtocol` — user DB のみのリーダー
- `create_tag_register_service(reader=None) -> TagRegisterServiceProtocol` — 登録サービス生成
- `get_user_repository() -> TagWriterProtocol` — 書き込み可能 user リポジトリ

**Backward-compat エイリアス (`__init__.py`):**
- `MergedTagReader = TagReaderProtocol` (型エイリアス)
- `get_default_reader = get_tag_reader`

ハンドルは不透明トークンとして扱い、既存のモジュールレベルヘルパー (`search_tags` / `convert_tags` / `register_tag` ...) に渡して使う。

## 実装方針

- `core_api.py` は本文を変更せず、`MergedTagReader` / `TagRegisterService` のアノテーションを protocol へ alias import で差し替え (`from __future__ import annotations` によりアノテーションは文字列のため runtime コストゼロ)。これにより公開関数のシグネチャが内部クラス名から切り離される。
- 内部クラス・モジュール (`db.repository` / `db.runtime` / `services.*`) は従来どおり import 可能 (完全な後方互換)。
- `tests/unit/test_public_api.py` で public contract を pin (protocol 適合・エイリアス同一性・factory 挙動)。

## downstream (LoRAIro) 移行ノート

旧 import → 新 import:

```python
# annotation_record.py
- from genai_tag_db_tools.db.repository import MergedTagReader, get_default_reader
- from genai_tag_db_tools.services.tag_register import TagRegisterService
+ from genai_tag_db_tools import (
+     TagReaderProtocol,            # MergedTagReader の型注釈の置き換え
+     get_tag_reader,               # get_default_reader() の置き換え
+     create_tag_register_service,  # TagRegisterService(...) の置き換え
+ )

# tag_management_service.py
- from genai_tag_db_tools.db.repository import TagReader, get_default_repository
- from genai_tag_db_tools.db.runtime import get_user_session_factory
+ from genai_tag_db_tools import (
+     TagReaderProtocol,       # TagReader の型注釈の置き換え
+     get_user_repository,     # get_default_repository() の置き換え (書き込み)
+     get_user_tag_reader,     # get_user_session_factory()+TagReader の置き換え (user スコープ読み取り)
+ )

# tag_suggestion_service.py (stale: db.reader は存在しない)
- from genai_tag_db_tools.db.reader import MergedTagReader
+ from genai_tag_db_tools import TagReaderProtocol  # 型注釈用、get_tag_reader() でインスタンス取得
```

リーダー/サービスのインスタンスは factory から取得し、メソッドを直接呼ばず public ヘルパーに渡すこと。当面は `from genai_tag_db_tools import MergedTagReader, get_default_reader` の互換エイリアスでも動作するため、段階移行が可能。

## 検証

- `uv run pytest -q` → **627 passed** (baseline 619 + 新規 8)
- `uv run mypy src` → **Success: no issues found in 52 source files**
- `uv run ruff check` (変更ファイル) → **All checks passed**

## 残 TODO

- 内部モジュール (`db.repository` / `db.runtime` / `services.*`) からの直接 import に対する **deprecation 警告** は本 PR では未実装。定義の private モジュールへの移設+proxy が必要で overlay 系ブランチ (#82-84, #88) との衝突面が大きいため follow-up とする。
- `TagWriterProtocol` は MVP として `update_tags_type_batch` のみ宣言。LoRAIro が他の書き込み操作を必要とする場合は拡張する。
- ADR (#73 課題5: user tag_id offset の意味変更) は別途。

## conflict リスク

`core_api.py` の import 行のみ変更 (本文・整形は未変更) のため衝突面は最小限。`#88` (translation detection) / `#82-84` (overlay search) が core_api を触る場合でも import ブロックの軽微な衝突に留まる想定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)