### PR TITLE
fix: harden scope=user tag registration path (#78, #62)

### DIFF
--- a/src/genai_tag_db_tools/db/repository.py
+++ b/src/genai_tag_db_tools/db/repository.py
@@ -1624,6 +1624,28 @@ class MergedTagReader:
     def get_tag_by_id(self, tag_id: int) -> Tag | None:
         return self._first_found("get_tag_by_id", tag_id)
 
+    def get_tag_scope(self, tag_id: int) -> str | None:
+        """tag_id がどの DB (scope) に属するかを判定する。
+
+        数値 offset (USER_TAG_ID_OFFSET) に依存せず、実際にどのリポジトリが
+        その tag_id を保持しているかで scope を決める。user_repo を優先し、
+        見つかれば "user"、base repos にあれば "base"、どこにも無ければ None。
+
+        Args:
+            tag_id: 判定対象のタグID。
+
+        Returns:
+            "user" / "base" / None。
+        """
+        if self._has_user():
+            assert self.user_repo is not None
+            if self.user_repo.get_tag_by_id(tag_id) is not None:
+                return "user"
+        for repo in self._iter_base_repos():
+            if repo.get_tag_by_id(tag_id) is not None:
+                return "base"
+        return None
+
     def get_tag_status(self, tag_id: int, format_id: int) -> TagStatus | None:
         return self._first_found("get_tag_status", tag_id, format_id)
 

--- a/src/genai_tag_db_tools/db/user_tag_repository.py
+++ b/src/genai_tag_db_tools/db/user_tag_repository.py
@@ -38,7 +38,14 @@ class UserTagRepository:
 
         Returns:
             採番または既存の tag_id。
+
+        Raises:
+            ValueError: tag / source_tag が空の場合（空の tag row を作らない）。
         """
+        missing_fields = [name for name, value in (("tag", tag), ("source_tag", source_tag)) if not value]
+        if missing_fields:
+            raise ValueError(f"Missing required fields: {', '.join(missing_fields)}")
+
         with self._session_factory() as session:
             existing = session.query(UserTag).filter(UserTag.tag == tag).one_or_none()
             if existing is not None:

--- a/src/genai_tag_db_tools/services/tag_register.py
+++ b/src/genai_tag_db_tools/services/tag_register.py
@@ -214,6 +214,45 @@ class TagRegisterService:
         )
         return resolved_type_id
 
+    @staticmethod
+    def _validate_normalized_tag(tag: str) -> None:
+        """正規化後の TAGS.tag が空になる入力を登録前に拒否する (Issue #62)。
+
+        source_tag は由来の値として奇妙な token を保持してよいが、正規化後の
+        TAGS.tag が空文字になる登録はデータとして不正なので InputError 扱いにする。
+        空文字・空白のみ・正規化後に空 (例: "___") のいずれもここで弾く。
+
+        Args:
+            tag: 登録対象の正規タグ（正規化前）。
+
+        Raises:
+            ValueError: 正規化後の tag が空文字になる場合。
+        """
+        normalized = TagCleaner.clean_format(tag or "")
+        if not normalized.strip():
+            raise ValueError(f"正規化後のタグが空です。空文字・空白のみのタグは登録できません: {tag!r}")
+
+    def _resolve_preferred_scope(self, preferred_tag_id: int) -> str:
+        """preferred タグがどの DB (scope) に属するかを判定する (Issue #78-3)。
+
+        `preferred_tag_id < USER_TAG_ID_OFFSET` という数値判定は、旧 TAGS パスで
+        登録された user DB タグが offset 未満の ID を持ちうるため脆い。可能なら
+        reader (MergedTagReader) に実際の所属 DB を問い合わせ、取得できない場合のみ
+        数値 offset のヒューリスティックにフォールバックする。
+
+        Args:
+            preferred_tag_id: 解決済みの preferred タグID。
+
+        Returns:
+            "base" または "user"。
+        """
+        get_tag_scope = getattr(self._reader, "get_tag_scope", None)
+        if callable(get_tag_scope):
+            scope = get_tag_scope(preferred_tag_id)
+            if scope in ("base", "user"):
+                return scope
+        return "user" if preferred_tag_id >= USER_TAG_ID_OFFSET else "base"
+
     def register_tag(self, request: "TagRegisterRequest") -> "TagRegisterResult":
         """Register a tag and optional metadata via the repository.
 
@@ -225,7 +264,12 @@ class TagRegisterService:
             request: Tag registration request.
         Returns:
             TagRegisterResult indicating whether the tag was created.
+
+        Raises:
+            ValueError: 正規化後の tag が空になる場合（空文字・空白のみ・正規化後空）。
         """
+        self._validate_normalized_tag(request.tag)
+
         if request.scope == "user":
             return self._register_user_tag(request)
 
@@ -286,6 +330,8 @@ class TagRegisterService:
         if self._user_tag_repo is None:
             raise RuntimeError("User DB が未初期化です。init_user_db() を先に呼んでください。")
 
+        self._validate_normalized_tag(request.tag)
+
         tag = request.tag
         source_tag = request.source_tag or request.tag
 
@@ -293,17 +339,27 @@ class TagRegisterService:
         type_name = request.type_name or "unknown"
         type_id = self._resolve_type_id(type_name, request.format_name, fmt_id)
 
+        # alias の preferred は USER_TAGS への書き込み前に解決する。
+        # 先にタグを作ってしまうと、preferred 解決失敗時に USER_TAGS 行だけ残り
+        # ステータスパッチの無い中途半端な状態になる (Issue #78-1)。
+        resolved_preferred_id: int | None = None
+        resolved_preferred_scope = "user"
+        if request.alias:
+            if not request.preferred_tag:
+                raise ValueError("alias=True の場合 preferred_tag が必須です")
+            resolved_preferred_id = self._reader.get_tag_id_by_name(request.preferred_tag, partial=False)
+            if resolved_preferred_id is None:
+                raise ValueError(f"推奨タグが見つかりません: {request.preferred_tag}")
+            resolved_preferred_scope = self._resolve_preferred_scope(resolved_preferred_id)
+
         existing_id = self._reader.get_tag_id_by_name(tag, partial=False)
         tag_id = self._user_tag_repo.create_user_tag(source_tag, tag)
         created = existing_id is None
 
         if request.alias:
-            if not request.preferred_tag:
-                raise ValueError("alias=True の場合 preferred_tag が必須です")
-            preferred_tag_id = self._reader.get_tag_id_by_name(request.preferred_tag, partial=False)
-            if preferred_tag_id is None:
-                raise ValueError(f"推奨タグが見つかりません: {request.preferred_tag}")
-            preferred_scope = "base" if preferred_tag_id < USER_TAG_ID_OFFSET else "user"
+            assert resolved_preferred_id is not None
+            preferred_tag_id = resolved_preferred_id
+            preferred_scope = resolved_preferred_scope
         else:
             preferred_tag_id = tag_id
             preferred_scope = "user"

--- a/tests/unit/test_overlay_preferred_resolution.py
+++ b/tests/unit/test_overlay_preferred_resolution.py
@@ -2,6 +2,7 @@
 
 user alias → base preferred の cross-scope 解決が機能することを検証する。
 """
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -212,6 +213,24 @@ class TestCrossScopePreferredResolution:
         assert rows[0]["tag"] == "preferred tag"
         assert rows[0]["tag_id"] == _USER_TAG_ID_PREFERRED
         assert rows[0]["alias"] is False
+
+
+# ------------------------------------------------------------------
+# Tests: get_tag_scope (Issue #78-3)
+# ------------------------------------------------------------------
+
+
+class TestGetTagScope:
+    """tag_id の所属 DB を数値 offset 非依存で判定する。"""
+
+    def test_base_tag_returns_base(self, merged_reader_cross_scope):
+        assert merged_reader_cross_scope.get_tag_scope(_BASE_TAG_ID_BLUE_EYES) == "base"
+
+    def test_user_tag_returns_user(self, merged_reader_cross_scope):
+        assert merged_reader_cross_scope.get_tag_scope(_USER_TAG_ID_BLU_EYES) == "user"
+
+    def test_unknown_tag_returns_none(self, merged_reader_cross_scope):
+        assert merged_reader_cross_scope.get_tag_scope(999_999) is None
 
 
 # ------------------------------------------------------------------

--- a/tests/unit/test_tag_register_service.py
+++ b/tests/unit/test_tag_register_service.py
@@ -1,5 +1,6 @@
 import pytest
 
+from genai_tag_db_tools.db.schema import USER_TAG_ID_OFFSET
 from genai_tag_db_tools.models import TagRegisterRequest, TagTranslationInput
 from genai_tag_db_tools.services.tag_register import TagRegisterService
 
@@ -389,3 +390,281 @@ class TestTypeInconsistencyDetection:
         assert type_id == 0
         assert any("type_id/type_name mismatch" in msg for msg in caplog.messages)
         assert any("type_name='character' resolved to type_id=0" in msg for msg in caplog.messages)
+
+
+# ==============================================================================
+# Dummies for scope="user" registration (Issue #78 / #62)
+# ==============================================================================
+
+
+class DummyUserTagRepo:
+    """USER_TAGS / patch 書き込みを記録するスタブ。"""
+
+    def __init__(self) -> None:
+        self.created_tags: list[tuple[str, str]] = []
+        self.patches: list[dict] = []
+        self.translation_patches: list[dict] = []
+        self._tags: dict[str, int] = {}
+        self._next_id = USER_TAG_ID_OFFSET
+
+    def create_user_tag(self, source_tag: str, tag: str) -> int:
+        missing = [name for name, value in (("tag", tag), ("source_tag", source_tag)) if not value]
+        if missing:
+            raise ValueError(f"Missing required fields: {', '.join(missing)}")
+        if tag in self._tags:
+            return self._tags[tag]
+        tag_id = self._next_id
+        self._next_id += 1
+        self._tags[tag] = tag_id
+        self.created_tags.append((source_tag, tag))
+        return tag_id
+
+    def write_patch(self, **kwargs) -> None:
+        self.patches.append(kwargs)
+
+    def write_translation_patch(self, **kwargs) -> None:
+        self.translation_patches.append(kwargs)
+
+
+class DummyUserReader:
+    """user scope 登録用の reader スタブ。
+
+    name_to_id / id_to_scope を差し替えて preferred 解決と scope 判定を制御する。
+    """
+
+    def __init__(
+        self,
+        name_to_id: dict[str, int] | None = None,
+        id_to_scope: dict[int, str] | None = None,
+    ) -> None:
+        self.name_to_id = name_to_id or {}
+        self.id_to_scope = id_to_scope or {}
+
+    def get_format_id(self, format_name: str) -> int:
+        result = {"danbooru": 1}.get(format_name)
+        if result is None:
+            raise ValueError(f"Format not found: {format_name}")
+        return result
+
+    def get_type_id_for_format(self, type_name: str, format_id: int) -> int | None:
+        return {"character": 2, "general": 1}.get(type_name)
+
+    def get_tag_id_by_name(self, tag: str, partial: bool = False) -> int | None:
+        return self.name_to_id.get(tag)
+
+    def get_tag_scope(self, tag_id: int) -> str | None:
+        return self.id_to_scope.get(tag_id)
+
+
+def _make_user_service(reader: DummyUserReader) -> tuple[TagRegisterService, DummyUserTagRepo]:
+    base_repo = DummyRepo()
+    user_repo = DummyUserTagRepo()
+    service = TagRegisterService(repository=base_repo, reader=reader, user_tag_repo=user_repo)
+    return service, user_repo
+
+
+# ==============================================================================
+# Issue #62 / #78-4: 正規化後に空になるタグの拒否
+# ==============================================================================
+
+
+class TestRejectEmptyNormalizedTag:
+    """空文字・空白のみ・正規化後空のタグ登録を拒否する。"""
+
+    @pytest.mark.db_tools
+    @pytest.mark.parametrize("bad_tag", ["", "   ", "___"])
+    def test_base_scope_rejects_empty_normalized(self, bad_tag):
+        repo = DummyRepo()
+        reader = DummyReader(repo)
+        service = TagRegisterService(repository=repo, reader=reader)
+        request = TagRegisterRequest(
+            tag=bad_tag,
+            source_tag="weird_source",
+            format_name="danbooru",
+            type_name="general",
+        )
+
+        with pytest.raises(ValueError, match="正規化後のタグが空"):
+            service.register_tag(request)
+
+        # 空の tag row は作られない
+        assert repo.created_tags == []
+
+    @pytest.mark.db_tools
+    @pytest.mark.parametrize("bad_tag", ["", "   ", "___"])
+    def test_user_scope_rejects_empty_normalized(self, bad_tag):
+        reader = DummyUserReader()
+        service, user_repo = _make_user_service(reader)
+        request = TagRegisterRequest(
+            tag=bad_tag,
+            source_tag="weird_source",
+            format_name="danbooru",
+            type_name="general",
+            scope="user",
+        )
+
+        with pytest.raises(ValueError, match="正規化後のタグが空"):
+            service.register_tag(request)
+
+        assert user_repo.created_tags == []
+        assert user_repo.patches == []
+
+    @pytest.mark.db_tools
+    def test_normalizable_tag_is_accepted(self):
+        """blue__eyes は blue eyes に正規化できるため登録可能。"""
+        reader = DummyUserReader()
+        service, user_repo = _make_user_service(reader)
+        request = TagRegisterRequest(
+            tag="blue__eyes",
+            source_tag="blue__eyes",
+            format_name="danbooru",
+            type_name="general",
+            scope="user",
+        )
+
+        result = service.register_tag(request)
+
+        assert result.created is True
+        assert user_repo.created_tags == [("blue__eyes", "blue__eyes")]
+
+
+# ==============================================================================
+# Issue #78-1: alias preferred 解決失敗時に user タグを作らない
+# ==============================================================================
+
+
+class TestUserAliasPreValidation:
+    @pytest.mark.db_tools
+    def test_missing_preferred_does_not_create_user_tag(self):
+        # preferred は解決できない (name_to_id 空)
+        reader = DummyUserReader()
+        service, user_repo = _make_user_service(reader)
+        request = TagRegisterRequest(
+            tag="alias_tag",
+            source_tag="alias_tag",
+            format_name="danbooru",
+            type_name="general",
+            alias=True,
+            preferred_tag="does_not_exist",
+            scope="user",
+        )
+
+        with pytest.raises(ValueError, match="推奨タグが見つかりません"):
+            service.register_tag(request)
+
+        # USER_TAGS 行も status patch も残らない (中途半端な状態を作らない)
+        assert user_repo.created_tags == []
+        assert user_repo.patches == []
+
+
+# ==============================================================================
+# Issue #78-3: preferred_scope を reader 経由で判定 (数値 offset 非依存)
+# ==============================================================================
+
+
+class TestPreferredScopeResolution:
+    @pytest.mark.db_tools
+    def test_low_id_user_tag_resolves_to_user_scope(self):
+        """offset 未満の ID でも reader が user と返せば preferred_scope=user。"""
+        # 旧 TAGS パスで登録された user DB タグ (offset 未満の ID) を模す
+        legacy_user_id = 500
+        reader = DummyUserReader(
+            name_to_id={"legacy_preferred": legacy_user_id},
+            id_to_scope={legacy_user_id: "user"},
+        )
+        service, user_repo = _make_user_service(reader)
+        request = TagRegisterRequest(
+            tag="alias_tag",
+            source_tag="alias_tag",
+            format_name="danbooru",
+            type_name="general",
+            alias=True,
+            preferred_tag="legacy_preferred",
+            scope="user",
+        )
+
+        result = service.register_tag(request)
+
+        assert result.created is True
+        assert len(user_repo.patches) == 1
+        patch = user_repo.patches[0]
+        # 数値 offset なら "base" になるが reader 判定で "user" になる
+        assert patch["preferred_scope"] == "user"
+        assert patch["preferred_tag_id"] == legacy_user_id
+
+    @pytest.mark.db_tools
+    def test_base_preferred_resolves_to_base_scope(self):
+        base_id = 100
+        reader = DummyUserReader(
+            name_to_id={"base_preferred": base_id},
+            id_to_scope={base_id: "base"},
+        )
+        service, user_repo = _make_user_service(reader)
+        request = TagRegisterRequest(
+            tag="alias_tag",
+            source_tag="alias_tag",
+            format_name="danbooru",
+            type_name="general",
+            alias=True,
+            preferred_tag="base_preferred",
+            scope="user",
+        )
+
+        service.register_tag(request)
+
+        assert user_repo.patches[0]["preferred_scope"] == "base"
+
+    @pytest.mark.db_tools
+    def test_scope_falls_back_to_numeric_offset_when_reader_silent(self):
+        """reader が scope を返せない場合は数値 offset にフォールバックする。"""
+        high_id = USER_TAG_ID_OFFSET + 5
+        reader = DummyUserReader(
+            name_to_id={"pref": high_id},
+            id_to_scope={},  # get_tag_scope -> None
+        )
+        service, user_repo = _make_user_service(reader)
+        request = TagRegisterRequest(
+            tag="alias_tag",
+            source_tag="alias_tag",
+            format_name="danbooru",
+            type_name="general",
+            alias=True,
+            preferred_tag="pref",
+            scope="user",
+        )
+
+        service.register_tag(request)
+
+        assert user_repo.patches[0]["preferred_scope"] == "user"
+
+
+# ==============================================================================
+# Issue #78-2: user scope で translations が保存される
+# ==============================================================================
+
+
+class TestUserScopeTranslations:
+    @pytest.mark.db_tools
+    def test_translations_saved_as_patches(self):
+        reader = DummyUserReader()
+        service, user_repo = _make_user_service(reader)
+        request = TagRegisterRequest(
+            tag="foo",
+            source_tag="foo",
+            format_name="danbooru",
+            type_name="general",
+            scope="user",
+            translations=[
+                TagTranslationInput(language="ja", translation="フー"),
+                TagTranslationInput(language="en", translation="foo-en"),
+            ],
+        )
+
+        result = service.register_tag(request)
+
+        assert result.created is True
+        langs = {(p["language"], p["translation"]) for p in user_repo.translation_patches}
+        assert langs == {("ja", "フー"), ("en", "foo-en")}
+        for patch in user_repo.translation_patches:
+            assert patch["target_scope"] == "user"
+            assert patch["target_tag_id"] == result.tag_id

--- a/tests/unit/test_user_tag_repository.py
+++ b/tests/unit/test_user_tag_repository.py
@@ -82,6 +82,16 @@ class TestCreateUserTag:
         id2 = user_repo.create_user_tag("s2", "tag_b")
         assert id2 > id1
 
+    def test_empty_tag_rejected(self, user_repo):
+        """空の tag は拒否され、行は作られない (Issue #78-4)。"""
+        with pytest.raises(ValueError, match="tag"):
+            user_repo.create_user_tag("src", "")
+
+    def test_empty_source_tag_rejected(self, user_repo):
+        """空の source_tag は拒否される (Issue #78-4)。"""
+        with pytest.raises(ValueError, match="source_tag"):
+            user_repo.create_user_tag("", "tag")
+
 
 # --- TestWritePatch ---
 


### PR DESCRIPTION
## 概要

scope="user" のタグ登録パスについて、PR #77 の Codex レビューで持ち越された P2 不具合 4 件 (#78) と、空正規化タグの拒否 (#62) を解決する。

## Issue #78 (P2 4件)

1. **alias 事前検証** — `_register_user_tag` で preferred タグを `USER_TAGS` 書き込み前に解決するよう順序変更。preferred 解決に失敗しても status patch のない孤立した `USER_TAGS` 行が残らない。
2. **translation の保存** — user scope の翻訳は既存実装 (`write_translation_patch`) で保存される。回帰テストを追加して挙動を固定。
3. **preferred_scope 判定** — `preferred_tag_id < USER_TAG_ID_OFFSET` という数値依存をやめ、`MergedTagReader.get_tag_scope()` で実際の所属 DB から scope を判定する。reader が答えられない場合のみ数値 offset にフォールバック。`get_tag_scope` は additive に追加（既存メソッドは未変更）。
4. **空タグ拒否** — `UserTagRepository.create_user_tag` 冒頭で空 `tag` / `source_tag` を `ValueError` で拒否。

## Issue #62 (空正規化タグの拒否)

- `register_tag` / `_register_user_tag` の冒頭で `TagCleaner.clean_format` 後に空になる入力を `ValueError`（構造化エラー contract 上の `INVALID_INPUT` / exit 2）で拒否。base / user 両 scope に適用。
- `""`, `"   "`, `"___"` → 登録エラー（空 tag row は作られない）。`"blue__eyes"` → `"blue eyes"` は登録可能。

## テスト

- `uv run pytest -q`: **636 passed**（baseline 619 + 17 件追加）
- `uv run ruff check .`: All checks passed
- `uv run mypy src`: Success, no issues

## 注意 / コンフリクトリスク

- 別エージェントが `OverlayTagReader.search_tags` を #82/#83/#84 で同時編集中。本 PR は `OverlayTagReader` を変更せず、`MergedTagReader.get_tag_scope` を additive に追加するに留めているため、コンフリクトリスクは低い。
- リポジトリには既存の ruff フォーマットドリフト（master 時点で `ruff format --check` が複数ファイルで失敗）があるが、本 PR ではスコープを issue に限定するため全体フォーマットは行っていない。追加コード自体は `ruff format` 準拠。

Closes #78
Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)