### PR TITLE
Investigate #63: fix blank top-level fields for --format-name unknown in search

### DIFF
--- a/docs/investigations/issue-63-cli-search-output.md
+++ b/docs/investigations/issue-63-cli-search-output.md
@@ -1,0 +1,160 @@
+# Issue #63 — tag-db CLI search/status output inconsistencies
+
+Status: investigated, one bug fixed, remaining items documented as expected behavior / doc-UX gaps.
+
+## Scope
+
+Investigate the odd-looking output of `tag-db search`, focusing on the relationship
+between the **top-level** fields (`format_name`, `type_name`, `alias`, `deprecated`,
+`usage_count`, `type_id`) and the per-format `format_statuses` map, especially when
+`--format-name unknown` is used.
+
+## How the search output is built (contract)
+
+CLI `search` → `core_api.search_tags()` → `MergedTagReader.search_tags()` →
+`TagReader.search_tags()` → `TagSearchQueryBuilder.filtered_tag_ids()` +
+`TagSearchResultBuilder.build_row()`.
+
+Key facts:
+
+1. **Top-level `format_name` is an echo of the request, not derived from data.**
+   `core_api.search_tags()` sets `format_name = format_names[0] if len(format_names) == 1 else None`
+   (`src/genai_tag_db_tools/core_api.py:310`, used at `:349`). It documents *which*
+   format the top-level status fields are meant to reflect. If you pass
+   `--format-name unknown`, the top level always shows `format_name=unknown`, even
+   though that string was never read back from the row.
+
+2. **Top-level `type_name`/`alias`/`deprecated`/`usage_count`/`type_id` reflect a
+   single "active" format.** `TagSearchResultBuilder._resolve_status_info()`
+   (`src/genai_tag_db_tools/db/query_utils.py:558`) uses `self.format_id` — the id
+   resolved from the requested format name — to pick the active status. When no single
+   concrete format is requested (no `--format-name`, multiple formats, or `all`), there
+   is no active format and the top-level status fields are intentionally left at their
+   defaults (`type_name=""`, `alias=False`, `deprecated=False`, `usage_count=0`,
+   `type_id=None`).
+
+3. **`format_statuses` always lists every format the tag has a status in.**
+   `TagSearchResultBuilder._build_format_statuses()`
+   (`src/genai_tag_db_tools/db/query_utils.py:626`) iterates all statuses regardless of
+   the requested format. This is why per-format `alias`/`deprecated`/`type_name` can
+   differ across formats in the same result — that is real, per-booru data.
+
+## Findings
+
+### 1. BUG (fixed): `--format-name unknown` blanked the top-level type/status fields
+
+Reproduced (real DB, after `uv run tag-db ensure-dbs`):
+
+```
+$ uv run tag-db search --query sorceress --format-name unknown --include-aliases --include-deprecated --limit 10
+TOP:        type_name="",      type_id=null, usage_count=0
+fs.unknown: type_name="unknown", type_id=0,  usage_count=1096310
+```
+
+Same for `bad id`, `commentary`, etc. The top-level fields were empty while
+`format_statuses.unknown` was fully populated.
+
+**Root cause.** The repository seeds a sentinel format named `unknown` with
+**`format_id == 0`** (see `src/genai_tag_db_tools/db/runtime.py:149` and the type
+mapping that pins `unknown` → `type_id=0`). Two places conflated that real format with
+the "no active format" sentinel, because both used the integer `0`:
+
+- `TagSearchQueryBuilder.filtered_tag_ids()` returned
+  `format_id = format_ids[0] if len(format_ids) == 1 else 0`
+  (`src/genai_tag_db_tools/db/query_utils.py:144`) — so a request for the real `unknown`
+  format (id 0) was indistinguishable from "no format".
+- `TagSearchResultBuilder._resolve_status_info()` guarded the active-status lookup with
+  `if self.format_id:` (truthiness) — and `0` is falsy
+  (`src/genai_tag_db_tools/db/query_utils.py:572`). So for `unknown`, the whole block was
+  skipped and the defaults were returned.
+
+The recommendation code path already worked around this (`_status_from_row_for_unknown_format`,
+`_effective_recommendation_format_name` in `core_api.py`), but the plain `search` path
+did not, leaving the inconsistent output the issue reported.
+
+**Fix.** Use `None` (not `0`) as the "no single concrete format" sentinel, and test for
+it explicitly so `format_id == 0` is treated as a real format:
+
+- `filtered_tag_ids()` / `apply_format_filter()` now return `int | None` and yield `None`
+  for the no-format / `all` / unresolved cases (`query_utils.py`).
+- `TagSearchResultBuilder.format_id` is `int | None`; `_resolve_status_info()` and
+  `_resolve_preferred_tag()` now test `if self.format_id is not None:`.
+
+After the fix:
+
+```
+$ uv run tag-db search --query sorceress --format-name unknown ...
+TOP:        type_name="unknown", type_id=0, usage_count=1096310   # matches fs.unknown
+```
+
+Regression test: `tests/unit/test_query_utils.py::test_filtered_tag_ids_unknown_format_returns_id_zero_not_none`
+(plus the updated `test_filtered_tag_ids_treats_all_as_unfiltered`, which now asserts
+`format_id is None` for `all`).
+
+### 2. EXPECTED: top-level `format_name` echoes the request
+
+`format_name=unknown` at the top level is by design (item 1 above). It is the label for
+"which format do the top-level status fields describe", not a value read from the tag.
+With the bug in finding 1 fixed, top-level `format_name=unknown` + `type_name=unknown`
+are now internally consistent. No code change; documented here.
+
+### 3. EXPECTED: per-format `alias`/`deprecated`/`type` differences
+
+Example `nekomimi --format-name danbooru` shows `alias=true, deprecated=true` for
+danbooru/e621/safebooru and `alias=false, deprecated=false` for derpibooru; `commentary`
+shows `type_name` of `meta`/`general`/`unknown` across formats. This is genuine
+per-booru data: a tag can be a deprecated alias in one booru and a canonical tag in
+another. `format_statuses` is meant to expose exactly that. Not a bug.
+
+### 4. EXPECTED (doc/UX gap): `pixiv` / `pixiv id` return 0 results under `--format-name unknown`
+
+`--format-name unknown` filters to tags that have a status row **in the `unknown`
+format**. `pixiv id` exists (in danbooru, safebooru, …) but has **no `unknown`-format
+status**, so the `unknown` filter correctly returns 0:
+
+```
+$ uv run tag-db search --query "pixiv id" --format-name danbooru --exact ...
+tag='pixiv id'  fmt keys=[danbooru, safebooru, ...]  has unknown = False   (count=1)
+
+$ uv run tag-db search --query "pixiv id" --format-name unknown --exact ...
+count=0
+```
+
+This is consistent with the format-filter semantics, not a bug. It is a UX gap: users
+may not expect `--format-name unknown` to be a *restrictive* filter (only tags carrying
+an `unknown`-format status), as opposed to "show me whatever, format-agnostic". The
+`unknown` format is a sparse sentinel, so it legitimately returns far fewer tags than a
+real booru. Recommendation: document that `--format-name unknown` matches only tags that
+have an explicit `unknown`-format status, and that to search format-agnostically you
+should omit `--format-name` entirely.
+
+## Acceptance criteria coverage
+
+- Why `--format-name unknown` top-level `type_name` was empty: explained (finding 1,
+  the `format_id == 0` / truthiness conflation) and fixed.
+- Relationship between top-level `format_name/type_name/alias/deprecated` and
+  `format_statuses`: documented (contract section + findings 2–3).
+- Bug fixed; non-bugs documented here.
+- How to read `search` output for #56 real-data examples: use `format_statuses[<format>]`
+  as the source of truth for per-format status; the top-level fields mirror the single
+  format named by `--format-name` (now correct for `unknown` too), and are left at
+  defaults when no single format is requested.
+
+## Recommendation on #63
+
+The concrete bug (finding 1) is fixed with tests. Findings 2–4 are expected behavior /
+doc-UX. Suggest **closing #63** once this PR merges, optionally spinning off a small
+follow-up doc/UX issue for finding 4 (clarify `--format-name unknown` filter semantics in
+CLI help / docs) and, if desired, exposing a top-level field that makes "no active
+format" explicit instead of relying on empty defaults.
+
+## Commands run
+
+```bash
+uv run tag-db ensure-dbs                                   # succeeded (3 DBs)
+uv run tag-db search --query sorceress  --format-name unknown  --include-aliases --include-deprecated --limit 10
+uv run tag-db search --query nekomimi   --format-name danbooru --include-aliases --include-deprecated --limit 10
+uv run tag-db search --query commentary --format-name unknown  --include-aliases --include-deprecated --limit 10
+uv run tag-db search --query "pixiv id" --format-name unknown  --include-aliases --include-deprecated --exact --limit 5
+uv run tag-db search --query "pixiv id" --format-name danbooru --include-aliases --include-deprecated --exact --limit 5
+```

--- a/src/genai_tag_db_tools/db/query_utils.py
+++ b/src/genai_tag_db_tools/db/query_utils.py
@@ -100,22 +100,23 @@ class TagSearchQueryBuilder:
         deprecated: bool | None = None,
         limit: int | None = None,
         offset: int = 0,
-    ) -> tuple[set[int], int]:
+    ) -> tuple[set[int], int | None]:
         """Return tag ids after applying search filters before limit/offset.
 
         The returned format id is only set when exactly one concrete format was
         requested; result row construction uses that to expose format-specific
-        status fields.
+        status fields. ``None`` means "no single concrete format" so that the
+        sentinel ``unknown`` format (``format_id == 0``) is not mistaken for it.
         """
         concrete_format_names = self._normalize_filter_names(format_names)
         format_ids = self._format_ids_for_names(concrete_format_names)
         if concrete_format_names and not format_ids:
-            return set(), 0
+            return set(), None
 
         concrete_type_names = self._normalize_filter_names(type_names)
         type_name_ids = self._type_name_ids_for_names(concrete_type_names)
         if concrete_type_names and not type_name_ids:
-            return set(), 0
+            return set(), None
 
         candidate = self._keyword_candidate_query(keyword, use_like).subquery()
         query = self.session.query(candidate.c.tag_id)
@@ -141,7 +142,7 @@ class TagSearchQueryBuilder:
         if limit is not None:
             query = query.limit(limit)
 
-        format_id = format_ids[0] if len(format_ids) == 1 else 0
+        format_id = format_ids[0] if len(format_ids) == 1 else None
         return {row[0] for row in query.all()}, format_id
 
     def _keyword_candidate_query(self, keyword: str, use_like: bool) -> Any:
@@ -310,13 +311,15 @@ class TagSearchQueryBuilder:
 
         return {keyword: ids for keyword, ids in tag_ids_by_keyword.items() if ids}
 
-    def apply_format_filter(self, tag_ids: set[int], format_name: str | None) -> tuple[set[int], int]:
+    def apply_format_filter(
+        self, tag_ids: set[int], format_name: str | None
+    ) -> tuple[set[int], int | None]:
         if not format_name or format_name.lower() == "all":
-            return tag_ids, 0
+            return tag_ids, None
 
         fmt_obj = self.session.query(TagFormat).filter(TagFormat.format_name == format_name).one_or_none()
         if not fmt_obj:
-            return set(), 0
+            return set(), None
 
         format_id = fmt_obj.format_id
         format_tag_ids = {
@@ -505,7 +508,7 @@ class TagSearchResultBuilder:
     def __init__(
         self,
         *,
-        format_id: int,
+        format_id: int | None,
         resolve_preferred: bool,
         logger: Logger | None = None,
     ) -> None:
@@ -569,7 +572,7 @@ class TagSearchResultBuilder:
         preferred_tag_id = tag_id
         deprecated = False
 
-        if self.format_id:
+        if self.format_id is not None:
             status_obj = status_by_tag_format.get((tag_id, self.format_id))
             if status_obj:
                 if status_obj.alias is None:
@@ -605,7 +608,7 @@ class TagSearchResultBuilder:
         tag_obj: Tag,
     ) -> tuple[int, Tag]:
         resolved_tag_id = tag_id
-        if self.resolve_preferred and self.format_id and preferred_tag_id != tag_id:
+        if self.resolve_preferred and self.format_id is not None and preferred_tag_id != tag_id:
             preferred_obj = tags_by_id.get(preferred_tag_id)
             if preferred_obj:
                 return preferred_tag_id, preferred_obj

--- a/tests/unit/test_query_utils.py
+++ b/tests/unit/test_query_utils.py
@@ -7,7 +7,11 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import StaticPool
 
-from genai_tag_db_tools.db.query_utils import TagSearchPreloader, TagSearchQueryBuilder
+from genai_tag_db_tools.db.query_utils import (
+    TagSearchPreloader,
+    TagSearchQueryBuilder,
+    TagSearchResultBuilder,
+)
 from genai_tag_db_tools.db.schema import (
     Base,
     Tag,
@@ -156,7 +160,57 @@ def test_filtered_tag_ids_treats_all_as_unfiltered(
         )
 
     assert sorted(ids) == [1, 2]
-    assert format_id == 0
+    # "all"/no concrete format is signalled by None so the sentinel "unknown"
+    # format (format_id == 0) is not mistaken for "no active format".
+    assert format_id is None
+
+
+def test_filtered_tag_ids_unknown_format_returns_id_zero_not_none(
+    session_factory: Callable[[], Session],
+) -> None:
+    """Requesting the sentinel "unknown" format must yield format_id == 0.
+
+    Regression for issue #63: format_id 0 (the real "unknown" format) used to be
+    indistinguishable from the "no active format" sentinel, which blanked the
+    top-level type fields in search output.
+    """
+    with session_factory() as session:
+        session.add(TagFormat(format_id=0, format_name="unknown"))
+        session.add(TagTypeName(type_name_id=0, type_name="unknown"))
+        session.add(TagTypeFormatMapping(format_id=0, type_id=0, type_name_id=0))
+        session.add(Tag(tag_id=1, source_tag="bad_id", tag="bad id"))
+        session.add(
+            TagStatus(
+                tag_id=1,
+                format_id=0,
+                type_id=0,
+                alias=False,
+                preferred_tag_id=1,
+                deprecated=False,
+            )
+        )
+        session.commit()
+
+        builder = TagSearchQueryBuilder(session)
+        ids, format_id = builder.filtered_tag_ids(
+            "%bad%",
+            use_like=True,
+            format_names=["unknown"],
+        )
+
+        assert sorted(ids) == [1]
+        assert format_id == 0
+
+        preloaded = TagSearchPreloader(session).load(ids)
+        result_builder = TagSearchResultBuilder(format_id=format_id, resolve_preferred=False)
+        row = result_builder.build_row(1, preloaded)
+
+    assert row is not None
+    # Top-level fields must reflect the unknown-format status, matching
+    # format_statuses["unknown"], rather than being blanked out.
+    assert row["type_name"] == "unknown"
+    assert row["type_id"] == 0
+    assert row["format_statuses"]["unknown"]["type_name"] == "unknown"
 
 
 def test_filtered_tag_ids_negative_status_filters_keep_statusless_tags(


### PR DESCRIPTION
## Summary

Investigation of issue #63 (tag-db CLI search/status output inconsistencies), with one bug fixed and the remaining observations documented.

Full write-up: `docs/investigations/issue-63-cli-search-output.md`.

## Bug fixed

`uv run tag-db search --format-name unknown ...` returned blank top-level
`type_name`/`type_id`/`alias`/`deprecated`/`usage_count` while
`format_statuses.unknown` was fully populated, e.g.:

```
TOP:        type_name="",        usage_count=0
fs.unknown: type_name="unknown", usage_count=1096310
```

**Root cause:** the sentinel `unknown` format has `format_id == 0`.
`TagSearchQueryBuilder.filtered_tag_ids()` / `apply_format_filter()` used `0` as
the "no concrete format" sentinel, and `TagSearchResultBuilder._resolve_status_info()`
guarded the active-status lookup with `if self.format_id:` (truthy) — so the real
`unknown` format (id 0) was treated as "no active format" and the top-level fields
fell back to defaults.

**Fix:** use `None` as the no-format sentinel and test `format_id is not None`, so id 0
is treated as a real format. Top-level fields now match `format_statuses["unknown"]`.

## Documented as expected behaviour (no change)

- Top-level `format_name` is an echo of the requested `--format-name` (labels which
  format the top-level status fields describe).
- Per-format `alias`/`deprecated`/`type` differences (nekomimi, commentary) are real
  per-booru data exposed via `format_statuses`.
- `pixiv` / `pixiv id` returning 0 under `--format-name unknown` is correct: those tags
  have no `unknown`-format status. Flagged as a doc/UX gap (the `unknown` filter is
  restrictive); suggested as an optional follow-up.

## Verification

- `uv run pytest -q` → 620 passed (baseline 619 + 1 new regression test)
- `uv run ruff check .` → clean
- `uv run mypy src` → clean
- `uv run tag-db ensure-dbs` succeeded (3 DBs); reproduced and confirmed the fix on real data.

## Recommendation

Bug is fixed with tests; remaining items are expected/doc. Recommend closing #63 on merge,
optionally opening a small doc-UX follow-up for `--format-name unknown` filter semantics.

Refs #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)