### PR TITLE
Base DB correction patch pipeline (#58, #61, #60)

### DIFF
--- a/src/genai_tag_db_tools/cli.py
+++ b/src/genai_tag_db_tools/cli.py
@@ -497,6 +497,11 @@ def build_parser(prog: str = "tag-db") -> argparse.ArgumentParser:
     )
     list_commands_parser.set_defaults(func=cmd_list_commands)
 
+    # Base DB correction patch pipeline (#58 / #60 / #61).
+    from genai_tag_db_tools.services.base_patch.cli import register_feedback_commands
+
+    register_feedback_commands(subparsers)
+
     return parser
 
 

--- a/src/genai_tag_db_tools/services/base_patch/__init__.py
+++ b/src/genai_tag_db_tools/services/base_patch/__init__.py
@@ -1,0 +1,59 @@
+"""Base DB correction patch pipeline (issues #58 / #60 / #61).
+
+This package implements the base DB correction-patch pipeline that sits between
+approved refinement feedback (#57) and the dataset-builder:
+
+- :mod:`validate` (#58): validate base DB correction patch JSONL before apply.
+- :mod:`export` (#61): export approved refinement feedback to a base patch JSONL.
+- :mod:`apply` (#60): apply validated patches to base DB build sources.
+
+The base correction patch is a name-based, builder-friendly envelope. It is
+intentionally separate from the overlay/id-based :class:`DbFeedbackProposal`
+used for user-local apply (#59).
+"""
+
+from __future__ import annotations
+
+from genai_tag_db_tools.services.base_patch.apply import (
+    BasePatchApplyResult,
+    BasePatchApplyRow,
+    BasePatchApplyService,
+    apply_base_patch_file,
+)
+from genai_tag_db_tools.services.base_patch.export import (
+    BasePatchExportResult,
+    BasePatchExportRow,
+    export_base_patch_file,
+    export_base_patches,
+)
+from genai_tag_db_tools.services.base_patch.models import (
+    SCHEMA_VERSION,
+    BaseCorrectionPatch,
+    PatchValidationIssue,
+    PatchValidationItemResult,
+    PatchValidationResult,
+    compute_patch_id,
+)
+from genai_tag_db_tools.services.base_patch.validate import (
+    validate_base_patch,
+    validate_base_patch_file,
+)
+
+__all__ = [
+    "SCHEMA_VERSION",
+    "BaseCorrectionPatch",
+    "BasePatchApplyResult",
+    "BasePatchApplyRow",
+    "BasePatchApplyService",
+    "BasePatchExportResult",
+    "BasePatchExportRow",
+    "PatchValidationIssue",
+    "PatchValidationItemResult",
+    "PatchValidationResult",
+    "apply_base_patch_file",
+    "compute_patch_id",
+    "export_base_patch_file",
+    "export_base_patches",
+    "validate_base_patch",
+    "validate_base_patch_file",
+]

--- a/src/genai_tag_db_tools/services/base_patch/apply.py
+++ b/src/genai_tag_db_tools/services/base_patch/apply.py
@@ -1,0 +1,453 @@
+"""Apply approved correction patches to base DB build sources (issue #60).
+
+This module reads a validated base correction patch JSONL and applies each patch to a base
+DB (the SQLite that the dataset-builder produces). It re-runs the minimal validation from
+#58 before applying and writes an apply report. It never touches a user-local overlay DB.
+
+The service is intentionally decoupled from runtime globals: it takes a writer
+(:class:`TagRepository`-like) and a read-only ``reader`` so it can be pointed at any build
+output / build source DB.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field, ValidationError
+
+from genai_tag_db_tools.services.base_patch.models import (
+    BaseCorrectionPatch,
+    PatchValidationItemResult,
+)
+from genai_tag_db_tools.services.base_patch.report import ReportFormat, write_report
+from genai_tag_db_tools.services.base_patch.validate import validate_base_patch
+
+REPORT_COLUMNS = (
+    "patch_id",
+    "patch_type",
+    "target_type",
+    "target_tag",
+    "format_name",
+    "field",
+    "status",
+    "reason",
+    "db_changes",
+)
+
+ApplyStatus = Literal["applied", "skipped", "rejected", "already_applied"]
+
+
+class BasePatchApplyRow(BaseModel):
+    """apply report の 1 行。"""
+
+    patch_id: str | None = None
+    patch_type: str | None = None
+    target_type: str | None = None
+    target_tag: str | None = None
+    format_name: str | None = None
+    field: str | None = None
+    status: ApplyStatus
+    reason: str | None = None
+    db_changes: list[str] = Field(default_factory=list)
+
+
+class BasePatchApplyResult(BaseModel):
+    """apply 結果のコンテナ。"""
+
+    rows: list[BasePatchApplyRow] = Field(default_factory=list)
+    dry_run: bool = False
+
+    @property
+    def ok(self) -> bool:
+        return self.rejected_count == 0
+
+    @property
+    def applied_count(self) -> int:
+        return sum(1 for row in self.rows if row.status == "applied")
+
+    @property
+    def already_applied_count(self) -> int:
+        return sum(1 for row in self.rows if row.status == "already_applied")
+
+    @property
+    def skipped_count(self) -> int:
+        return sum(1 for row in self.rows if row.status == "skipped")
+
+    @property
+    def rejected_count(self) -> int:
+        return sum(1 for row in self.rows if row.status == "rejected")
+
+
+class _ApplyReject(ValueError):
+    """patch を rejected にすべき状況で投げる内部例外。"""
+
+
+class BasePatchApplyService:
+    """validated base correction patch を base DB build source に反映する。"""
+
+    def __init__(self, repository: Any, reader: Any, *, dry_run: bool = False) -> None:
+        self._repo = repository
+        self._reader = reader
+        self._dry_run = dry_run
+        # TagRepository.create_tag は self._reader を使う。未注入なら補う。
+        if getattr(repository, "_reader", None) is None:
+            try:
+                repository._reader = reader
+            except AttributeError:
+                pass
+
+    def apply_patch(self, patch: BaseCorrectionPatch) -> BasePatchApplyRow:
+        item = validate_base_patch(patch, repo=self._reader)
+        if item.status == "invalid":
+            return self._row(patch, "rejected", _validation_reason(item))
+
+        try:
+            changes = self._dispatch(patch)
+        except _ApplyReject as exc:
+            return self._row(patch, "rejected", str(exc))
+
+        status: ApplyStatus = "applied"
+        reason: str | None = None
+        if changes is None:
+            status, reason, changes = "already_applied", "patch already reflected", []
+        return self._row(patch, status, reason, changes)
+
+    def apply_patches(self, patches: list[BaseCorrectionPatch]) -> BasePatchApplyResult:
+        result = BasePatchApplyResult(dry_run=self._dry_run)
+        for patch in patches:
+            result.rows.append(self.apply_patch(patch))
+        return result
+
+    # ------------------------------------------------------------------
+    # dispatch
+    # ------------------------------------------------------------------
+
+    def _dispatch(self, patch: BaseCorrectionPatch) -> list[str] | None:
+        match patch.patch_type:
+            case "alias_addition":
+                return self._apply_alias_addition(patch)
+            case "preferred_tag_correction":
+                return self._apply_preferred_correction(patch)
+            case "translation_correction":
+                return self._apply_translation(patch)
+            case "type_correction":
+                return self._apply_type_correction(patch)
+            case "status_correction":
+                return self._apply_status_correction(patch)
+            case "tag_name_correction":
+                return self._apply_tag_name(patch)
+            case _:  # pragma: no cover - guarded by validation
+                raise _ApplyReject(f"unsupported patch_type {patch.patch_type!r}")
+
+    def _apply_alias_addition(self, patch: BaseCorrectionPatch) -> list[str] | None:
+        alias_tag = _require(patch.target_tag, "target.tag")
+        preferred_tag = _require(_proposed_str(patch, "preferred_tag"), "proposed.preferred_tag")
+        format_id = self._resolve_or_create_format(patch.format_name)
+
+        preferred_id = self._ensure_tag(preferred_tag)
+        alias_id = self._ensure_tag(alias_tag)
+        if alias_id == preferred_id:
+            raise _ApplyReject("alias tag and preferred tag resolve to the same tag")
+
+        existing = self._tag_status(alias_id, format_id)
+        if existing is not None and existing.alias and existing.preferred_tag_id == preferred_id:
+            return None
+        type_id = self._alias_type_id(existing, preferred_id, format_id)
+        if self._dry_run:
+            return [f"TAG_STATUS.alias tag_id={alias_id} -> preferred_tag_id={preferred_id}"]
+        self._repo.update_tag_status(
+            tag_id=alias_id,
+            format_id=format_id,
+            alias=True,
+            preferred_tag_id=preferred_id,
+            type_id=type_id,
+        )
+        return [f"TAG_STATUS.alias tag_id={alias_id} -> preferred_tag_id={preferred_id}"]
+
+    def _apply_preferred_correction(self, patch: BaseCorrectionPatch) -> list[str] | None:
+        alias_tag = _require(patch.target_tag, "target.tag")
+        preferred_tag = _require(_proposed_str(patch, "preferred_tag"), "proposed.preferred_tag")
+        format_id = self._resolve_or_create_format(patch.format_name)
+
+        alias_id = self._resolve_tag_id(alias_tag)
+        if alias_id is None:
+            raise _ApplyReject(f"target alias tag {alias_tag!r} does not exist")
+        preferred_id = self._ensure_tag(preferred_tag)
+        if alias_id == preferred_id:
+            raise _ApplyReject("alias tag and preferred tag resolve to the same tag")
+
+        existing = self._tag_status(alias_id, format_id)
+        if existing is not None and existing.alias and existing.preferred_tag_id == preferred_id:
+            return None
+        type_id = self._alias_type_id(existing, preferred_id, format_id)
+        if self._dry_run:
+            return [f"TAG_STATUS.preferred_tag_id tag_id={alias_id} -> {preferred_id}"]
+        self._repo.update_tag_status(
+            tag_id=alias_id,
+            format_id=format_id,
+            alias=True,
+            preferred_tag_id=preferred_id,
+            type_id=type_id,
+        )
+        return [f"TAG_STATUS.preferred_tag_id tag_id={alias_id} -> {preferred_id}"]
+
+    def _apply_translation(self, patch: BaseCorrectionPatch) -> list[str] | None:
+        tag = _require(patch.target_tag, "target.tag")
+        language = _require(_field_language(patch.field), "target.field")
+        translation = _require(_proposed_str(patch, "translation"), "proposed.translation")
+        tag_id = self._ensure_tag(tag)
+        if self._translation_exists(tag_id, language, translation):
+            return None
+        if self._dry_run:
+            return [f"TAG_TRANSLATIONS tag_id={tag_id} +{language}"]
+        self._repo.add_or_update_translation(tag_id, language, translation)
+        return [f"TAG_TRANSLATIONS tag_id={tag_id} +{language}"]
+
+    def _apply_type_correction(self, patch: BaseCorrectionPatch) -> list[str] | None:
+        tag = _require(patch.target_tag, "target.tag")
+        type_name = _require(_proposed_str(patch, "type_name"), "proposed.type_name")
+        format_id = self._resolve_or_create_format(patch.format_name)
+        tag_id = self._ensure_tag(tag)
+
+        type_id = self._resolve_or_create_type_id(format_id, type_name)
+        existing = self._tag_status(tag_id, format_id)
+        if existing is not None and existing.type_id == type_id:
+            return None
+        alias, preferred_id, deprecated = self._existing_or_default(existing, tag_id)
+        if self._dry_run:
+            return [f"TAG_STATUS.type_id tag_id={tag_id} -> {type_id}"]
+        self._repo.update_tag_status(
+            tag_id=tag_id,
+            format_id=format_id,
+            alias=alias,
+            preferred_tag_id=preferred_id,
+            type_id=type_id,
+            deprecated=deprecated,
+        )
+        return [f"TAG_STATUS.type_id tag_id={tag_id} -> {type_id}"]
+
+    def _apply_status_correction(self, patch: BaseCorrectionPatch) -> list[str] | None:
+        tag = _require(patch.target_tag, "target.tag")
+        deprecated = patch.proposed.get("deprecated")
+        if not isinstance(deprecated, bool):
+            raise _ApplyReject("proposed.deprecated must be a boolean")
+        format_id = self._resolve_or_create_format(patch.format_name)
+        tag_id = self._ensure_tag(tag)
+
+        existing = self._tag_status(tag_id, format_id)
+        if existing is not None and bool(existing.deprecated) == deprecated:
+            return None
+        alias, preferred_id, _ = self._existing_or_default(existing, tag_id)
+        type_id = existing.type_id if existing is not None else self._unknown_type_id(format_id)
+        deprecated_at = datetime.now(UTC) if deprecated else None
+        if self._dry_run:
+            return [f"TAG_STATUS.deprecated tag_id={tag_id} -> {deprecated}"]
+        self._repo.update_tag_status(
+            tag_id=tag_id,
+            format_id=format_id,
+            alias=alias,
+            preferred_tag_id=preferred_id,
+            type_id=type_id,
+            deprecated=deprecated,
+            deprecated_at=deprecated_at,
+        )
+        return [f"TAG_STATUS.deprecated tag_id={tag_id} -> {deprecated}"]
+
+    def _apply_tag_name(self, patch: BaseCorrectionPatch) -> list[str] | None:
+        source_tag = patch.target.get("source_tag") or patch.target.get("tag")
+        proposed_tag = _require(_proposed_str(patch, "tag"), "proposed.tag")
+        if not isinstance(source_tag, str) or not source_tag:
+            raise _ApplyReject("tag_name_correction requires target.source_tag or target.tag")
+        if self._resolve_tag_id(proposed_tag) is not None:
+            return None
+        if self._dry_run:
+            return [f"TAGS +{proposed_tag!r}"]
+        tag_id = self._repo.create_tag(source_tag, proposed_tag)
+        return [f"TAGS +{proposed_tag!r} (tag_id={tag_id})"]
+
+    # ------------------------------------------------------------------
+    # reader / writer helpers
+    # ------------------------------------------------------------------
+
+    def _resolve_tag_id(self, tag: str) -> int | None:
+        try:
+            return self._reader.get_tag_id_by_name(tag, partial=False)
+        except ValueError:
+            return None
+
+    def _ensure_tag(self, tag: str) -> int:
+        tag_id = self._resolve_tag_id(tag)
+        if tag_id is not None:
+            return tag_id
+        if self._dry_run:
+            return -1
+        return self._repo.create_tag(tag, tag)
+
+    def _tag_status(self, tag_id: int, format_id: int) -> Any | None:
+        if tag_id < 0:
+            return None
+        getter = getattr(self._reader, "get_tag_status", None)
+        return getter(tag_id, format_id) if getter is not None else None
+
+    def _translation_exists(self, tag_id: int, language: str, translation: str) -> bool:
+        if tag_id < 0:
+            return False
+        getter = getattr(self._reader, "get_translations", None)
+        if getter is None:
+            return False
+        for row in getter(tag_id):
+            if (
+                getattr(row, "language", None) == language
+                and getattr(row, "translation", None) == translation
+            ):
+                return True
+        return False
+
+    def _resolve_or_create_format(self, format_name: str | None) -> int:
+        if not format_name:
+            raise _ApplyReject("format-dependent patch requires format_name")
+        try:
+            format_id = int(self._reader.get_format_id(format_name))
+        except ValueError:
+            format_id = 0
+        if format_id > 0:
+            return format_id
+        if self._dry_run:
+            return -1
+        return self._repo.create_format_if_not_exists(format_name)
+
+    def _resolve_or_create_type_id(self, format_id: int, type_name: str) -> int:
+        getter = getattr(self._reader, "get_type_id_for_format", None)
+        if getter is not None and format_id > 0:
+            resolved = getter(type_name, format_id)
+            if resolved is not None:
+                return int(resolved)
+        if self._dry_run:
+            return -1
+        type_name_id = self._repo.create_type_name_if_not_exists(type_name)
+        candidate = self._next_type_id(format_id)
+        return self._repo.create_type_format_mapping_if_not_exists(format_id, candidate, type_name_id)
+
+    def _unknown_type_id(self, format_id: int) -> int:
+        return self._resolve_or_create_type_id(format_id, "unknown")
+
+    def _alias_type_id(self, existing: Any | None, preferred_id: int, format_id: int) -> int:
+        if existing is not None:
+            return int(existing.type_id)
+        preferred_status = self._tag_status(preferred_id, format_id)
+        if preferred_status is not None:
+            return int(preferred_status.type_id)
+        return self._unknown_type_id(format_id)
+
+    def _next_type_id(self, format_id: int) -> int:
+        getter = getattr(self._reader, "list_tag_statuses", None)
+        # 既存 mapping を直接列挙する API が無いため、保守的に 0 から空き探索させる。
+        # create_type_format_mapping_if_not_exists が衝突時に繰り上げる。
+        if getter is None:
+            return 0
+        return 0
+
+    @staticmethod
+    def _existing_or_default(existing: Any | None, tag_id: int) -> tuple[bool, int, bool]:
+        if existing is not None:
+            return bool(existing.alias), int(existing.preferred_tag_id), bool(existing.deprecated)
+        return False, tag_id, False
+
+    def _row(
+        self,
+        patch: BaseCorrectionPatch,
+        status: ApplyStatus,
+        reason: str | None,
+        db_changes: list[str] | None = None,
+    ) -> BasePatchApplyRow:
+        return BasePatchApplyRow(
+            patch_id=patch.patch_id,
+            patch_type=patch.patch_type,
+            target_type=patch.target_type,
+            target_tag=patch.target_tag,
+            format_name=patch.format_name,
+            field=patch.field,
+            status=status,
+            reason=reason,
+            db_changes=db_changes or [],
+        )
+
+
+def apply_base_patch_file(
+    paths: str | Path | list[str | Path],
+    *,
+    repository: Any,
+    reader: Any,
+    dry_run: bool = False,
+    report: str | Path | None = None,
+    report_format: ReportFormat | None = None,
+) -> BasePatchApplyResult:
+    """1 つ以上の base patch JSONL を読み込み、build source に適用する。"""
+    if not isinstance(paths, list):
+        paths = [paths]
+    service = BasePatchApplyService(repository, reader, dry_run=dry_run)
+    result = BasePatchApplyResult(dry_run=dry_run)
+    for path in paths:
+        for patch, parse_error in _iter_patches(Path(path)):
+            if parse_error is not None:
+                result.rows.append(BasePatchApplyRow(status="rejected", reason=parse_error))
+                continue
+            assert patch is not None
+            result.rows.append(service.apply_patch(patch))
+    if report is not None:
+        write_apply_report(result, report, report_format=report_format)
+    return result
+
+
+def write_apply_report(
+    result: BasePatchApplyResult,
+    path: str | Path,
+    *,
+    report_format: ReportFormat | None = None,
+) -> None:
+    rows = [row.model_dump() for row in result.rows]
+    write_report(Path(path), REPORT_COLUMNS, rows, report_format=report_format)
+
+
+def _iter_patches(path: Path):
+    with path.open(encoding="utf-8") as fh:
+        for raw in fh:
+            stripped = raw.strip()
+            if not stripped:
+                continue
+            try:
+                data = json.loads(stripped)
+            except json.JSONDecodeError as exc:
+                yield None, f"invalid JSON: {exc}"
+                continue
+            if not isinstance(data, dict):
+                yield None, "patch must be a JSON object"
+                continue
+            try:
+                yield BaseCorrectionPatch.model_validate(data), None
+            except ValidationError as exc:
+                yield None, f"missing_required_field: {exc}"
+
+
+def _require(value: Any, field: str) -> Any:
+    if value is None:
+        raise _ApplyReject(f"{field} is required")
+    return value
+
+
+def _proposed_str(patch: BaseCorrectionPatch, key: str) -> str | None:
+    value = patch.proposed.get(key)
+    return value if isinstance(value, str) and value.strip() else None
+
+
+def _field_language(field: str | None) -> str | None:
+    if field and field.startswith("translation."):
+        return field.split(".", 1)[1] or None
+    return None
+
+
+def _validation_reason(item: PatchValidationItemResult) -> str:
+    return "; ".join(issue.code for issue in item.errors) or "validation failed"

--- a/src/genai_tag_db_tools/services/base_patch/cli.py
+++ b/src/genai_tag_db_tools/services/base_patch/cli.py
@@ -1,0 +1,173 @@
+"""CLI wiring for the base DB correction patch pipeline.
+
+Adds the ``feedback`` subcommand group to the ``tag-db`` CLI:
+
+- ``tag-db feedback validate-base-patches`` (#58)
+- ``tag-db feedback export-base-patches`` (#61)
+- ``tag-db feedback apply-base-patches`` (#60)
+
+Emit helpers are imported lazily from :mod:`genai_tag_db_tools.cli` to avoid an import
+cycle (the main CLI registers this module at parser-build time).
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Any
+
+from genai_tag_db_tools.services.base_patch.apply import apply_base_patch_file
+from genai_tag_db_tools.services.base_patch.export import export_base_patch_file
+from genai_tag_db_tools.services.base_patch.validate import validate_base_patch_file
+
+
+def _reader_for_base_db(args: argparse.Namespace) -> Any | None:
+    """``--base-db`` が指定されていれば read-only reader を返す。"""
+    if not getattr(args, "base_db", None):
+        return None
+    from genai_tag_db_tools.cli import _set_db_paths
+    from genai_tag_db_tools.db.repository import get_default_reader
+
+    _set_db_paths(args.base_db, getattr(args, "user_db_dir", None))
+    return get_default_reader()
+
+
+def cmd_validate_base_patches(args: argparse.Namespace) -> None:
+    from genai_tag_db_tools.cli import emit_item, emit_result
+
+    reader = _reader_for_base_db(args)
+    result = validate_base_patch_file(args.file, repo=reader, report=args.report)
+    for item in result.items:
+        emit_item(item)
+    emit_result(
+        "base patches validated",
+        ok=result.ok,
+        valid=result.valid_count,
+        warning=result.warning_count,
+        invalid=result.invalid_count,
+        report=args.report,
+    )
+
+
+def cmd_export_base_patches(args: argparse.Namespace) -> None:
+    from genai_tag_db_tools.cli import emit_item, emit_result
+
+    reader = _reader_for_base_db(args)
+    result = export_base_patch_file(
+        args.input,
+        args.output,
+        reader=reader,
+        validate=args.validate,
+        report=args.report,
+    )
+    for row in result.rows:
+        emit_item(row)
+    emit_result(
+        "base patches exported",
+        output=args.output,
+        exported=result.exported_count,
+        skipped=result.skipped_count,
+        failed=result.failed_count,
+        validated=args.validate,
+        report=args.report,
+    )
+
+
+def cmd_apply_base_patches(args: argparse.Namespace) -> None:
+    from genai_tag_db_tools.cli import emit_item, emit_result
+    from genai_tag_db_tools.db.repository import MergedTagReader, TagReader, TagRepository
+    from genai_tag_db_tools.db.runtime import create_session_factory
+
+    if not args.base_db or len(args.base_db) != 1:
+        raise ValueError("apply-base-patches requires exactly one --base-db (the build output)")
+
+    factory = create_session_factory(Path(args.base_db[0]))
+    reader = MergedTagReader(base_repo=TagReader(session_factory=factory))
+    repository = TagRepository(session_factory=factory, reader=reader)
+
+    dry_run = not args.apply
+    result = apply_base_patch_file(
+        [Path(p) for p in args.file],
+        repository=repository,
+        reader=reader,
+        dry_run=dry_run,
+        report=args.report,
+    )
+    for row in result.rows:
+        emit_item(row)
+    emit_result(
+        "dry-run complete" if dry_run else "base patches applied",
+        dry_run=dry_run,
+        ok=result.ok,
+        applied=result.applied_count,
+        already_applied=result.already_applied_count,
+        skipped=result.skipped_count,
+        rejected=result.rejected_count,
+        report=args.report,
+    )
+
+
+def register_feedback_commands(subparsers: argparse._SubParsersAction) -> None:
+    """``tag-db feedback ...`` サブコマンドを登録する。"""
+    feedback_parser = subparsers.add_parser("feedback", help="Base DB correction patch pipeline.")
+    feedback_subs = feedback_parser.add_subparsers(dest="feedback_command", required=True)
+
+    validate_parser = feedback_subs.add_parser(
+        "validate-base-patches",
+        help="Validate a base DB correction patch JSONL before apply (#58).",
+    )
+    validate_parser.add_argument("--file", required=True, help="Patch JSONL file path.")
+    validate_parser.add_argument("--report", help="Optional validation report path (.tsv or .jsonl).")
+    validate_parser.add_argument(
+        "--base-db",
+        action="append",
+        help="Optional base DB sqlite path for name/format/type resolution. Repeat for multiple.",
+    )
+    validate_parser.add_argument("--user-db-dir", help=argparse.SUPPRESS)
+    validate_parser.set_defaults(func=cmd_validate_base_patches)
+
+    export_parser = feedback_subs.add_parser(
+        "export-base-patches",
+        help="Export base DB correction patches from approved feedback JSONL (#61).",
+    )
+    export_parser.add_argument("--input", required=True, help="Approved feedback JSONL file path.")
+    export_parser.add_argument("--output", required=True, help="Output patch JSONL file path.")
+    export_parser.add_argument(
+        "--validate",
+        action="store_true",
+        default=False,
+        help="Validate exported patches and mark valid ones as validated.",
+    )
+    export_parser.add_argument("--report", help="Optional export report path (.tsv or .jsonl).")
+    export_parser.add_argument(
+        "--base-db",
+        action="append",
+        help="Optional base DB sqlite path for name/format/type resolution. Repeat for multiple.",
+    )
+    export_parser.add_argument("--user-db-dir", help=argparse.SUPPRESS)
+    export_parser.set_defaults(func=cmd_export_base_patches)
+
+    apply_parser = feedback_subs.add_parser(
+        "apply-base-patches",
+        help="Apply validated base correction patches to a base DB build source (#60).",
+    )
+    apply_parser.add_argument(
+        "--file",
+        required=True,
+        action="append",
+        help="Patch JSONL file path. Repeat for multiple patch files.",
+    )
+    apply_parser.add_argument(
+        "--base-db",
+        action="append",
+        required=True,
+        help="Base DB sqlite build output to write to (exactly one).",
+    )
+    apply_parser.add_argument(
+        "--apply",
+        action="store_true",
+        default=False,
+        help="Write to the base DB. Omit for dry-run (default).",
+    )
+    apply_parser.add_argument("--report", help="Optional apply report path (.tsv or .jsonl).")
+    apply_parser.set_defaults(func=cmd_apply_base_patches)

--- a/src/genai_tag_db_tools/services/base_patch/export.py
+++ b/src/genai_tag_db_tools/services/base_patch/export.py
@@ -1,0 +1,478 @@
+"""Export base DB correction proposals from approved refinement feedback (issue #61).
+
+This module converts approved, overlay/id-based :class:`DbFeedbackProposal` objects into
+name-based base correction patches (the same envelope the builder consumes in #60) and
+writes them as JSONL. It never applies anything to the base DB.
+
+Tag names are resolved from name hints carried in the proposal (``current`` / ``proposed``
+/ ``evidence``) and, when an optional read-only ``reader`` is supplied, from the base DB
+by ``tag_id``.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field, ValidationError
+
+from genai_tag_db_tools.models import ApprovedDbFeedback, DbFeedbackProposal, ProposalTarget
+from genai_tag_db_tools.services.base_patch.models import (
+    SCHEMA_VERSION,
+    BaseCorrectionPatch,
+    compute_patch_id,
+)
+from genai_tag_db_tools.services.base_patch.report import ReportFormat, write_report
+from genai_tag_db_tools.services.base_patch.validate import validate_base_patch
+
+# tools が base patch に export する proposal kind。usage_correction は base patch
+# 対象外 (#60 の対応 patch 種類に含まれない)。
+EXPORTABLE_KINDS: frozenset[str] = frozenset(
+    {
+        "alias_addition",
+        "preferred_tag_correction",
+        "translation_correction",
+        "type_correction",
+        "status_correction",
+        "tag_name_correction",
+    }
+)
+
+# review-only として export しない proposal kind。
+REVIEW_ONLY_KINDS: frozenset[str] = frozenset({"format_relation_review"})
+
+_TARGET_TYPE_BY_PROPOSAL_KIND: dict[str, str] = {
+    "alias_addition": "alias",
+    "preferred_tag_correction": "alias",
+    "translation_correction": "translation",
+    "type_correction": "tag_type",
+    "status_correction": "tag_status",
+    "tag_name_correction": "tag_name",
+}
+
+REPORT_COLUMNS = (
+    "patch_id",
+    "patch_type",
+    "target_type",
+    "target_tag",
+    "format_name",
+    "field",
+    "status",
+    "reason",
+)
+
+ExportStatus = Literal[
+    "exported",
+    "skipped_user_scope",
+    "skipped_review_only",
+    "skipped_unsupported_type",
+    "validation_failed",
+]
+
+
+class BasePatchExportRow(BaseModel):
+    """export report の 1 行。"""
+
+    patch_id: str | None = None
+    patch_type: str | None = None
+    target_type: str | None = None
+    target_tag: str | None = None
+    format_name: str | None = None
+    field: str | None = None
+    status: ExportStatus
+    reason: str | None = None
+
+
+class BasePatchExportResult(BaseModel):
+    """export 結果のコンテナ。"""
+
+    patches: list[BaseCorrectionPatch] = Field(default_factory=list)
+    rows: list[BasePatchExportRow] = Field(default_factory=list)
+
+    @property
+    def exported_count(self) -> int:
+        return sum(1 for row in self.rows if row.status == "exported")
+
+    @property
+    def skipped_count(self) -> int:
+        return sum(1 for row in self.rows if row.status.startswith("skipped_"))
+
+    @property
+    def failed_count(self) -> int:
+        return sum(1 for row in self.rows if row.status == "validation_failed")
+
+
+class _ExportError(ValueError):
+    """name 解決などで export 不能になったときに投げる内部例外。"""
+
+
+def export_base_patches(
+    feedbacks: Iterable[ApprovedDbFeedback],
+    *,
+    reader: Any | None = None,
+    validate: bool = False,
+    validate_repo: Any | None = None,
+) -> BasePatchExportResult:
+    """approved feedback の列から base correction patch を生成する。"""
+    result = BasePatchExportResult()
+    repo = validate_repo if validate_repo is not None else reader
+    for feedback in feedbacks:
+        _export_one(feedback, reader=reader, validate=validate, repo=repo, result=result)
+    return result
+
+
+def export_base_patch_file(
+    input_path: str | Path,
+    output_path: str | Path,
+    *,
+    reader: Any | None = None,
+    validate: bool = False,
+    validate_repo: Any | None = None,
+    report: str | Path | None = None,
+    report_format: ReportFormat | None = None,
+) -> BasePatchExportResult:
+    """approved-feedback JSONL を読み、base patch JSONL を書き出す。"""
+    input_path = Path(input_path)
+    result = BasePatchExportResult()
+    repo = validate_repo if validate_repo is not None else reader
+
+    with input_path.open(encoding="utf-8") as fh:
+        for raw in fh:
+            stripped = raw.strip()
+            if not stripped:
+                continue
+            feedback = _load_feedback(stripped, result)
+            if feedback is None:
+                continue
+            _export_one(feedback, reader=reader, validate=validate, repo=repo, result=result)
+
+    _write_patches(result.patches, Path(output_path))
+    if report is not None:
+        write_export_report(result, report, report_format=report_format)
+    return result
+
+
+def write_export_report(
+    result: BasePatchExportResult,
+    path: str | Path,
+    *,
+    report_format: ReportFormat | None = None,
+) -> None:
+    rows = [row.model_dump() for row in result.rows]
+    write_report(Path(path), REPORT_COLUMNS, rows, report_format=report_format)
+
+
+# ---------------------------------------------------------------------------
+# internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_feedback(stripped: str, result: BasePatchExportResult) -> ApprovedDbFeedback | None:
+    try:
+        data = json.loads(stripped)
+    except json.JSONDecodeError:
+        result.rows.append(BasePatchExportRow(status="validation_failed", reason="invalid JSON"))
+        return None
+    if not isinstance(data, dict):
+        result.rows.append(
+            BasePatchExportRow(status="validation_failed", reason="feedback must be an object")
+        )
+        return None
+    if data.get("approved") is not True:
+        result.rows.append(
+            BasePatchExportRow(status="skipped_review_only", reason="feedback is not approved")
+        )
+        return None
+    try:
+        return ApprovedDbFeedback.model_validate(data)
+    except ValidationError as exc:
+        result.rows.append(
+            BasePatchExportRow(status="validation_failed", reason=f"invalid feedback: {exc}")
+        )
+        return None
+
+
+def _export_one(
+    feedback: ApprovedDbFeedback,
+    *,
+    reader: Any | None,
+    validate: bool,
+    repo: Any | None,
+    result: BasePatchExportResult,
+) -> None:
+    proposal = feedback.proposal
+
+    skip = _skip_status(proposal)
+    if skip is not None:
+        status, reason = skip
+        result.rows.append(
+            BasePatchExportRow(
+                patch_type=proposal.kind,
+                target_type=proposal.target.kind,
+                format_name=proposal.target.format_name,
+                status=status,
+                reason=reason,
+            )
+        )
+        return
+
+    try:
+        patch = _build_patch(feedback, reader=reader)
+    except _ExportError as exc:
+        result.rows.append(
+            BasePatchExportRow(
+                patch_type=proposal.kind,
+                target_type=proposal.target.kind,
+                format_name=proposal.target.format_name,
+                status="validation_failed",
+                reason=str(exc),
+            )
+        )
+        return
+
+    if validate:
+        item = validate_base_patch(patch, repo=repo)
+        if item.status == "invalid":
+            result.rows.append(
+                BasePatchExportRow(
+                    patch_id=patch.patch_id,
+                    patch_type=patch.patch_type,
+                    target_type=patch.target_type,
+                    target_tag=patch.target_tag,
+                    format_name=patch.format_name,
+                    field=patch.field,
+                    status="validation_failed",
+                    reason="; ".join(issue.code for issue in item.errors),
+                )
+            )
+            return
+        patch.validated = True
+        patch.validated_at = _now_iso()
+
+    result.patches.append(patch)
+    result.rows.append(
+        BasePatchExportRow(
+            patch_id=patch.patch_id,
+            patch_type=patch.patch_type,
+            target_type=patch.target_type,
+            target_tag=patch.target_tag,
+            format_name=patch.format_name,
+            field=patch.field,
+            status="exported",
+            reason=None,
+        )
+    )
+
+
+def _skip_status(proposal: DbFeedbackProposal) -> tuple[ExportStatus, str] | None:
+    if proposal.kind in REVIEW_ONLY_KINDS:
+        return "skipped_review_only", f"{proposal.kind} is review-only"
+    if proposal.kind not in EXPORTABLE_KINDS:
+        return "skipped_unsupported_type", f"{proposal.kind} is not a base patch type"
+    if proposal.target.target_scope != "base":
+        return "skipped_user_scope", f"target_scope={proposal.target.target_scope!r} is not base"
+    return None
+
+
+def _build_patch(feedback: ApprovedDbFeedback, *, reader: Any | None) -> BaseCorrectionPatch:
+    proposal = feedback.proposal
+    target_type = _TARGET_TYPE_BY_PROPOSAL_KIND[proposal.kind]
+    target, proposed = _build_target_and_proposed(proposal, target_type, reader)
+
+    patch = BaseCorrectionPatch(
+        schema_version=SCHEMA_VERSION,
+        scope="base",
+        patch_type=proposal.kind,
+        target=target,
+        proposed=proposed,
+        current=proposal.current,
+        approved=True,
+        approved_by=feedback.approved_by,
+        approved_at=_to_iso(feedback.approved_at),
+        # validated は export 直後は付けない (#61)。--validate 時のみ True を立てる。
+        source_proposal={"proposal_type": proposal.kind},
+        reason_codes=list(proposal.reason_codes),
+        evidence=_merge_evidence(proposal.evidence),
+        note=feedback.approval_note,
+    )
+    patch.patch_id = compute_patch_id(patch)
+    return patch
+
+
+def _build_target_and_proposed(
+    proposal: DbFeedbackProposal,
+    target_type: str,
+    reader: Any | None,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    target: dict[str, Any] = {"target_type": target_type}
+    proposed: dict[str, Any] = {}
+
+    if proposal.kind in ("alias_addition", "preferred_tag_correction"):
+        tag = _resolve_tag_name(proposal, reader)
+        target.update({"tag": tag, "format_name": _require_format(proposal.target)})
+        preferred = _resolve_preferred_name(proposal, reader)
+        proposed["preferred_tag"] = preferred
+        if proposal.kind == "alias_addition":
+            proposed["alias"] = True
+    elif proposal.kind == "translation_correction":
+        tag = _resolve_tag_name(proposal, reader)
+        language = _translation_language(proposal)
+        target.update({"tag": tag, "field": f"translation.{language}"})
+        proposed["translation"] = _require_proposed_str(proposal, "translation")
+        proposed["language"] = language
+    elif proposal.kind == "type_correction":
+        tag = _resolve_tag_name(proposal, reader)
+        target.update({"tag": tag, "format_name": _require_format(proposal.target)})
+        proposed["type_name"] = _require_proposed_str(proposal, "type_name")
+    elif proposal.kind == "status_correction":
+        tag = _resolve_tag_name(proposal, reader)
+        target.update(
+            {
+                "tag": tag,
+                "format_name": _require_format(proposal.target),
+                "field": "TAG_STATUS.deprecated",
+            }
+        )
+        proposed["deprecated"] = _require_proposed_bool(proposal, "deprecated")
+    elif proposal.kind == "tag_name_correction":
+        source_tag = _source_tag(proposal)
+        target.update({"source_tag": source_tag})
+        proposed["tag"] = _require_proposed_str(proposal, "tag")
+    else:  # pragma: no cover - guarded by EXPORTABLE_KINDS
+        raise _ExportError(f"unsupported proposal kind {proposal.kind!r}")
+
+    return target, proposed
+
+
+def _resolve_tag_name(proposal: DbFeedbackProposal, reader: Any | None) -> str:
+    for source in (proposal.proposed, proposal.current):
+        name = _name_from_mapping(source, ("tag", "alias_tag", "source_tag"))
+        if name is not None:
+            return name
+    name = _name_from_evidence(proposal.evidence, ("tag", "alias_tag", "source_tag"))
+    if name is not None:
+        return name
+    resolved = _name_by_tag_id(reader, proposal.target.target_tag_id)
+    if resolved is not None:
+        return resolved
+    raise _ExportError("could not resolve target tag name")
+
+
+def _resolve_preferred_name(proposal: DbFeedbackProposal, reader: Any | None) -> str:
+    name = _name_from_mapping(proposal.proposed, ("preferred_tag",))
+    if name is not None:
+        return name
+    name = _name_from_evidence(proposal.evidence, ("preferred_tag", "candidate"))
+    if name is not None:
+        return name
+    resolved = _name_by_tag_id(reader, proposal.target.preferred_tag_id)
+    if resolved is not None:
+        return resolved
+    raise _ExportError("could not resolve preferred tag name")
+
+
+def _source_tag(proposal: DbFeedbackProposal) -> str:
+    name = _name_from_mapping(proposal.current, ("source_tag", "tag"))
+    if name is not None:
+        return name
+    name = _name_from_mapping(proposal.proposed, ("source_tag",))
+    if name is not None:
+        return name
+    name = _name_from_evidence(proposal.evidence, ("source_tag",))
+    if name is not None:
+        return name
+    raise _ExportError("tag_name_correction requires a source_tag")
+
+
+def _translation_language(proposal: DbFeedbackProposal) -> str:
+    if proposal.target.language:
+        return proposal.target.language
+    if proposal.proposed and isinstance(proposal.proposed.get("language"), str):
+        return str(proposal.proposed["language"])
+    if proposal.current and isinstance(proposal.current.get("language"), str):
+        return str(proposal.current["language"])
+    raise _ExportError("translation_correction requires a language")
+
+
+def _require_format(target: ProposalTarget) -> str:
+    if not target.format_name:
+        raise _ExportError("format-dependent proposal requires format_name")
+    return target.format_name
+
+
+def _require_proposed_str(proposal: DbFeedbackProposal, key: str) -> str:
+    if proposal.proposed is None:
+        raise _ExportError(f"{proposal.kind} requires proposed values")
+    value = proposal.proposed.get(key)
+    if isinstance(value, str) and value.strip():
+        return value
+    raise _ExportError(f"{proposal.kind} requires non-empty proposed.{key}")
+
+
+def _require_proposed_bool(proposal: DbFeedbackProposal, key: str) -> bool:
+    if proposal.proposed is None:
+        raise _ExportError(f"{proposal.kind} requires proposed values")
+    value = proposal.proposed.get(key)
+    if isinstance(value, bool):
+        return value
+    raise _ExportError(f"{proposal.kind} requires boolean proposed.{key}")
+
+
+def _name_from_mapping(mapping: dict[str, Any] | None, keys: tuple[str, ...]) -> str | None:
+    if not mapping:
+        return None
+    for key in keys:
+        value = mapping.get(key)
+        if isinstance(value, str) and value.strip():
+            return value
+    return None
+
+
+def _name_from_evidence(evidence: list[dict[str, Any]] | None, keys: tuple[str, ...]) -> str | None:
+    for entry in evidence or []:
+        name = _name_from_mapping(entry, keys)
+        if name is not None:
+            return name
+    return None
+
+
+def _name_by_tag_id(reader: Any | None, tag_id: int | None) -> str | None:
+    if reader is None or tag_id is None:
+        return None
+    getter = getattr(reader, "get_tag_by_id", None)
+    if getter is None:
+        return None
+    tag = getter(tag_id)
+    name = getattr(tag, "tag", None) if tag is not None else None
+    return name if isinstance(name, str) and name else None
+
+
+def _merge_evidence(evidence: list[dict[str, Any]] | None) -> dict[str, Any] | None:
+    if not evidence:
+        return None
+    merged: dict[str, Any] = {}
+    for entry in evidence:
+        if isinstance(entry, dict):
+            merged.update(entry)
+    return merged or None
+
+
+def _write_patches(patches: list[BaseCorrectionPatch], output_path: Path) -> None:
+    if output_path.parent and not output_path.parent.exists():
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", encoding="utf-8") as fh:
+        for patch in patches:
+            payload = patch.model_dump(mode="json", exclude_none=True)
+            fh.write(json.dumps(payload, ensure_ascii=False))
+            fh.write("\n")
+
+
+def _to_iso(value: datetime) -> str:
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")

--- a/src/genai_tag_db_tools/services/base_patch/models.py
+++ b/src/genai_tag_db_tools/services/base_patch/models.py
@@ -1,0 +1,205 @@
+"""Models and shared constants for the base DB correction patch pipeline.
+
+The base correction patch is a name-based, builder-friendly JSONL envelope. Only four
+keys are required for a patch to be well-formed:
+
+``schema_version``, ``patch_type``, ``target``, ``proposed``.
+
+Everything else (``patch_id``, ``scope``, ``current``, ``approved*``, ``validated*``,
+``source_proposal``, ``reason_codes``, ``evidence``, ``note``) is optional. Hand-written
+PR patch files may omit all optional keys; PR review and CI validation take the role of
+approval / validation in that flow.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, ClassVar, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+# MVP のスキーマバージョン。これ以外は unsupported_schema_version として拒否する。
+SCHEMA_VERSION = 1
+
+# builder apply / export 対象になる patch type。
+SUPPORTED_PATCH_TYPES: frozenset[str] = frozenset(
+    {
+        "alias_addition",
+        "preferred_tag_correction",
+        "translation_correction",
+        "type_correction",
+        "status_correction",
+        "tag_name_correction",
+    }
+)
+
+# apply patch としては明示的に拒否する patch type。
+REJECTED_PATCH_TYPES: frozenset[str] = frozenset(
+    {
+        "metadata_correction",
+        "training_policy_correction",
+        "format_relation_review",
+    }
+)
+
+# patch_type ごとに矛盾してはいけない target.target_type。
+TARGET_TYPE_BY_PATCH_TYPE: dict[str, str] = {
+    "alias_addition": "alias",
+    "preferred_tag_correction": "alias",
+    "translation_correction": "translation",
+    "type_correction": "tag_type",
+    "status_correction": "tag_status",
+    "tag_name_correction": "tag_name",
+}
+
+# target.format_name が必須な patch type。format_name=None は「全 format」として扱わない。
+FORMAT_DEPENDENT_PATCH_TYPES: frozenset[str] = frozenset(
+    {
+        "alias_addition",
+        "preferred_tag_correction",
+        "type_correction",
+        "status_correction",
+    }
+)
+
+# status_correction で許可する target.field。
+ALLOWED_STATUS_FIELDS: frozenset[str] = frozenset({"TAG_STATUS.deprecated"})
+
+ValidationStatus = Literal["valid", "invalid", "warning"]
+
+
+class BaseCorrectionPatch(BaseModel):
+    """base DB に渡す correction patch の最小エンベロープ。
+
+    必須キーは ``schema_version`` / ``patch_type`` / ``target`` / ``proposed`` のみ。
+    その他はレビュー・監査・生成出力のための任意キー。
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    schema_version: int = Field(..., description="Patch schema version (MVP only accepts 1)")
+    patch_type: str = Field(..., description="Correction patch type")
+    target: dict[str, Any] = Field(..., description="Patch target object")
+    proposed: dict[str, Any] = Field(..., description="Proposed values object")
+
+    patch_id: str | None = Field(default=None, description="Stable sha256:<hex> patch id")
+    scope: str | None = Field(default=None, description='Optional scope. Tools emit "base".')
+    current: dict[str, Any] | None = Field(default=None, description="Observed current values")
+    approved: bool | None = Field(default=None, description="Explicit approval flag")
+    approved_by: str | None = Field(default=None, description="Approver identifier")
+    approved_at: str | None = Field(default=None, description="Approval timestamp (ISO-8601)")
+    validated: bool | None = Field(default=None, description="Explicit validation flag")
+    validated_at: str | None = Field(default=None, description="Validation timestamp (ISO-8601)")
+    source_proposal: dict[str, Any] | None = Field(default=None, description="Originating proposal")
+    reason_codes: list[str] = Field(default_factory=list, description="Stable reason codes")
+    evidence: dict[str, Any] | None = Field(default=None, description="Supporting evidence")
+    note: str | None = Field(default=None, description="Human readable note")
+
+    # patch_id の入力に含めるキー (承認者 / evidence は含めない)。
+    _PATCH_ID_KEYS: ClassVar[tuple[str, ...]] = (
+        "schema_version",
+        "scope",
+        "patch_type",
+        "target",
+        "proposed",
+    )
+
+    @property
+    def target_type(self) -> str | None:
+        value = self.target.get("target_type")
+        return value if isinstance(value, str) else None
+
+    @property
+    def target_tag(self) -> str | None:
+        for key in ("tag", "source_tag"):
+            value = self.target.get(key)
+            if isinstance(value, str) and value:
+                return value
+        return None
+
+    @property
+    def format_name(self) -> str | None:
+        value = self.target.get("format_name")
+        return value if isinstance(value, str) else None
+
+    @property
+    def field(self) -> str | None:
+        value = self.target.get("field")
+        return value if isinstance(value, str) else None
+
+    def patch_id_payload(self) -> dict[str, Any]:
+        """patch_id 計算に使う正規化前 payload を返す。"""
+        return {
+            "schema_version": self.schema_version,
+            "scope": self.scope,
+            "patch_type": self.patch_type,
+            "target": self.target,
+            "proposed": self.proposed,
+        }
+
+
+def compute_patch_id(patch: BaseCorrectionPatch) -> str:
+    """同じ内容なら同じ値になる安定 patch_id を計算する。
+
+    ``schema_version`` / ``scope`` / ``patch_type`` / ``target`` / ``proposed`` を
+    正規化 JSON にして SHA-256 を取る。``approved_by`` / ``approved_at`` / ``evidence``
+    は入力に含めない (承認者や根拠が変わっても同じ DB mutation を重複扱いできるように)。
+    """
+    canonical = json.dumps(
+        patch.patch_id_payload(),
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    return f"sha256:{digest}"
+
+
+class PatchValidationIssue(BaseModel):
+    """構造化された validation error / warning。"""
+
+    code: str = Field(..., description="Stable error or warning code")
+    message: str = Field(..., description="Human-readable message")
+    field: str | None = Field(default=None, description="Related field, if any")
+
+
+class PatchValidationItemResult(BaseModel):
+    """1 patch の validation 結果。"""
+
+    line_number: int | None = Field(default=None, description="1-based JSONL line number")
+    patch_id: str | None = Field(default=None, description="Patch id (provided or computed)")
+    patch_type: str | None = Field(default=None, description="Patch type")
+    target_type: str | None = Field(default=None, description="Target type")
+    target_tag: str | None = Field(default=None, description="Target tag")
+    format_name: str | None = Field(default=None, description="Format name")
+    status: ValidationStatus = Field(..., description="valid / invalid / warning")
+    errors: list[PatchValidationIssue] = Field(default_factory=list, description="Blocking errors")
+    warnings: list[PatchValidationIssue] = Field(default_factory=list, description="Non-blocking warnings")
+
+    @property
+    def ok(self) -> bool:
+        """invalid でなければ True (warning は apply 可能)。"""
+        return self.status != "invalid"
+
+
+class PatchValidationResult(BaseModel):
+    """patch file 全体の validation 結果。"""
+
+    items: list[PatchValidationItemResult] = Field(default_factory=list, description="Per-patch results")
+
+    @property
+    def ok(self) -> bool:
+        return all(item.ok for item in self.items)
+
+    @property
+    def valid_count(self) -> int:
+        return sum(1 for item in self.items if item.status == "valid")
+
+    @property
+    def warning_count(self) -> int:
+        return sum(1 for item in self.items if item.status == "warning")
+
+    @property
+    def invalid_count(self) -> int:
+        return sum(1 for item in self.items if item.status == "invalid")

--- a/src/genai_tag_db_tools/services/base_patch/report.py
+++ b/src/genai_tag_db_tools/services/base_patch/report.py
@@ -1,0 +1,55 @@
+"""Report writers (TSV / JSONL) for the base patch pipeline."""
+
+from __future__ import annotations
+
+import csv
+import json
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any, Literal
+
+ReportFormat = Literal["tsv", "jsonl"]
+
+
+def infer_report_format(path: Path, *, default: ReportFormat = "tsv") -> ReportFormat:
+    suffix = path.suffix.lower()
+    if suffix in (".jsonl", ".ndjson", ".json"):
+        return "jsonl"
+    if suffix in (".tsv", ".tab", ".csv", ".txt"):
+        return "tsv"
+    return default
+
+
+def write_report(
+    path: Path,
+    columns: Sequence[str],
+    rows: Sequence[dict[str, Any]],
+    *,
+    report_format: ReportFormat | None = None,
+) -> None:
+    """Write report rows to ``path`` as TSV (header + tab-separated) or JSONL."""
+    path = Path(path)
+    if path.parent and not path.parent.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+    fmt = report_format or infer_report_format(path)
+
+    if fmt == "jsonl":
+        with path.open("w", encoding="utf-8") as fh:
+            for row in rows:
+                fh.write(json.dumps(row, ensure_ascii=False, default=str))
+                fh.write("\n")
+        return
+
+    with path.open("w", encoding="utf-8", newline="") as fh:
+        writer = csv.writer(fh, delimiter="\t", lineterminator="\n")
+        writer.writerow(columns)
+        for row in rows:
+            writer.writerow(["" if row.get(col) is None else _cell(row.get(col)) for col in columns])
+
+
+def _cell(value: Any) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (list, dict)):
+        return json.dumps(value, ensure_ascii=False, default=str)
+    return str(value)

--- a/src/genai_tag_db_tools/services/base_patch/validate.py
+++ b/src/genai_tag_db_tools/services/base_patch/validate.py
@@ -1,0 +1,555 @@
+"""Validate base DB correction patches before apply (issue #58).
+
+This module validates the minimal base correction patch envelope. It never mutates any
+DB. When a ``repo`` (read-only :class:`MergedTagReader`-like object) is supplied, the
+validator additionally resolves format names, tag names, type names, and alias cycles.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from pydantic import ValidationError
+
+from genai_tag_db_tools.services.base_patch.models import (
+    ALLOWED_STATUS_FIELDS,
+    FORMAT_DEPENDENT_PATCH_TYPES,
+    REJECTED_PATCH_TYPES,
+    SCHEMA_VERSION,
+    SUPPORTED_PATCH_TYPES,
+    TARGET_TYPE_BY_PATCH_TYPE,
+    BaseCorrectionPatch,
+    PatchValidationIssue,
+    PatchValidationItemResult,
+    PatchValidationResult,
+    compute_patch_id,
+)
+from genai_tag_db_tools.services.base_patch.report import ReportFormat, write_report
+
+# validation report の列順。
+REPORT_COLUMNS = (
+    "line_number",
+    "patch_id",
+    "patch_type",
+    "target_type",
+    "target_tag",
+    "format_name",
+    "status",
+    "error_code",
+    "message",
+)
+
+
+class _Issues:
+    """error / warning を蓄積するヘルパー。"""
+
+    def __init__(self) -> None:
+        self.errors: list[PatchValidationIssue] = []
+        self.warnings: list[PatchValidationIssue] = []
+
+    def error(self, code: str, message: str, *, field: str | None = None) -> None:
+        self.errors.append(PatchValidationIssue(code=code, message=message, field=field))
+
+    def warn(self, code: str, message: str, *, field: str | None = None) -> None:
+        self.warnings.append(PatchValidationIssue(code=code, message=message, field=field))
+
+
+def validate_base_patch(
+    patch: BaseCorrectionPatch,
+    *,
+    repo: Any | None = None,
+    line_number: int | None = None,
+) -> PatchValidationItemResult:
+    """1 つの base correction patch を検証する。DB は変更しない。"""
+    issues = _Issues()
+
+    if patch.schema_version != SCHEMA_VERSION:
+        issues.error(
+            "unsupported_schema_version",
+            f"schema_version must be {SCHEMA_VERSION}, got {patch.schema_version}",
+            field="schema_version",
+        )
+
+    _validate_scope(patch, issues)
+    _validate_approval_metadata(patch, issues)
+
+    if patch.patch_id is None:
+        issues.warn("missing_patch_id", "patch_id is missing; it will be computed", field="patch_id")
+
+    patch_type = patch.patch_type
+    if patch_type in REJECTED_PATCH_TYPES:
+        issues.error(
+            "unsupported_patch_type",
+            f"patch_type {patch_type!r} is not an apply patch type",
+            field="patch_type",
+        )
+    elif patch_type not in SUPPORTED_PATCH_TYPES:
+        issues.error(
+            "unsupported_patch_type",
+            f"unknown patch_type {patch_type!r}",
+            field="patch_type",
+        )
+    else:
+        _validate_target_type(patch, issues)
+        _dispatch_patch_type(patch, repo, issues)
+
+    status = "invalid" if issues.errors else ("warning" if issues.warnings else "valid")
+    return PatchValidationItemResult(
+        line_number=line_number,
+        patch_id=patch.patch_id or _safe_patch_id(patch),
+        patch_type=patch_type,
+        target_type=patch.target_type,
+        target_tag=patch.target_tag,
+        format_name=patch.format_name,
+        status=status,
+        errors=issues.errors,
+        warnings=issues.warnings,
+    )
+
+
+def validate_base_patch_file(
+    path: str | Path,
+    *,
+    repo: Any | None = None,
+    report: str | Path | None = None,
+    report_format: ReportFormat | None = None,
+) -> PatchValidationResult:
+    """JSONL patch file を読み込んで全行を検証する。
+
+    必須キー欠落で patch を構築できない行は ``missing_required_field`` として invalid に
+    する (ファイル全体の読み込みは止めない)。
+    """
+    path = Path(path)
+    items: list[PatchValidationItemResult] = []
+    with path.open(encoding="utf-8") as fh:
+        for line_number, raw in enumerate(fh, start=1):
+            stripped = raw.strip()
+            if not stripped:
+                continue
+            items.append(_validate_line(stripped, line_number, repo))
+
+    result = PatchValidationResult(items=items)
+    if report is not None:
+        write_validation_report(result, report, report_format=report_format)
+    return result
+
+
+def write_validation_report(
+    result: PatchValidationResult,
+    path: str | Path,
+    *,
+    report_format: ReportFormat | None = None,
+) -> None:
+    """validation report を TSV / JSONL で出力する。issue ごとに 1 行。"""
+    rows: list[dict[str, object]] = []
+    for item in result.items:
+        base = {
+            "line_number": item.line_number,
+            "patch_id": item.patch_id,
+            "patch_type": item.patch_type,
+            "target_type": item.target_type,
+            "target_tag": item.target_tag,
+            "format_name": item.format_name,
+            "status": item.status,
+        }
+        issues = item.errors or item.warnings
+        if not issues:
+            rows.append({**base, "error_code": None, "message": None})
+            continue
+        for issue in issues:
+            rows.append({**base, "error_code": issue.code, "message": issue.message})
+    write_report(Path(path), REPORT_COLUMNS, rows, report_format=report_format)
+
+
+# ---------------------------------------------------------------------------
+# internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _validate_line(stripped: str, line_number: int, repo: Any | None) -> PatchValidationItemResult:
+    try:
+        data = json.loads(stripped)
+    except json.JSONDecodeError as exc:
+        return PatchValidationItemResult(
+            line_number=line_number,
+            status="invalid",
+            errors=[PatchValidationIssue(code="invalid_json", message=f"invalid JSON: {exc}")],
+        )
+    if not isinstance(data, dict):
+        return PatchValidationItemResult(
+            line_number=line_number,
+            status="invalid",
+            errors=[
+                PatchValidationIssue(code="missing_required_field", message="patch must be a JSON object")
+            ],
+        )
+    try:
+        patch = BaseCorrectionPatch.model_validate(data)
+    except ValidationError as exc:
+        return _missing_field_result(data, line_number, exc)
+    return validate_base_patch(patch, repo=repo, line_number=line_number)
+
+
+def _missing_field_result(
+    data: dict[str, Any], line_number: int, exc: ValidationError
+) -> PatchValidationItemResult:
+    issues: list[PatchValidationIssue] = []
+    for err in exc.errors():
+        loc = ".".join(str(part) for part in err["loc"])
+        code = "missing_required_field" if err["type"] in ("missing", "none_required") else "invalid_field"
+        issues.append(PatchValidationIssue(code=code, message=f"{loc}: {err['msg']}", field=loc or None))
+    if not issues:
+        issues.append(PatchValidationIssue(code="missing_required_field", message=str(exc)))
+    patch_type = data.get("patch_type") if isinstance(data.get("patch_type"), str) else None
+    return PatchValidationItemResult(
+        line_number=line_number,
+        patch_type=patch_type,
+        status="invalid",
+        errors=issues,
+    )
+
+
+def _validate_scope(patch: BaseCorrectionPatch, issues: _Issues) -> None:
+    scope = patch.scope
+    if scope is None:
+        return
+    if scope in ("user", "local"):
+        issues.error("invalid_scope", f"scope {scope!r} is not a base patch", field="scope")
+    elif scope != "base":
+        issues.error("invalid_scope", f"scope {scope!r} is not supported", field="scope")
+
+
+def _validate_approval_metadata(patch: BaseCorrectionPatch, issues: _Issues) -> None:
+    if patch.approved is False:
+        issues.error("explicitly_unapproved", "approved=false patches are rejected", field="approved")
+    if patch.validated is False:
+        issues.error("explicitly_unvalidated", "validated=false patches are rejected", field="validated")
+    if patch.approved is True and (not patch.approved_by or not patch.approved_at):
+        issues.warn(
+            "missing_approval_metadata",
+            "approved=true without approved_by/approved_at",
+            field="approved_by",
+        )
+
+
+def _validate_target_type(patch: BaseCorrectionPatch, issues: _Issues) -> None:
+    expected = TARGET_TYPE_BY_PATCH_TYPE.get(patch.patch_type)
+    if expected is None:
+        return
+    actual = patch.target_type
+    if actual is not None and actual != expected:
+        issues.error(
+            "invalid_target_type",
+            f"target.target_type {actual!r} does not match patch_type {patch.patch_type!r} "
+            f"(expected {expected!r})",
+            field="target.target_type",
+        )
+
+
+def _dispatch_patch_type(patch: BaseCorrectionPatch, repo: Any | None, issues: _Issues) -> None:
+    if patch.patch_type in FORMAT_DEPENDENT_PATCH_TYPES:
+        _validate_format(patch, repo, issues)
+
+    match patch.patch_type:
+        case "alias_addition":
+            _validate_alias_addition(patch, repo, issues)
+        case "preferred_tag_correction":
+            _validate_preferred_correction(patch, repo, issues)
+        case "translation_correction":
+            _validate_translation(patch, issues)
+        case "type_correction":
+            _validate_type_correction(patch, repo, issues)
+        case "status_correction":
+            _validate_status_correction(patch, issues)
+        case "tag_name_correction":
+            _validate_tag_name_correction(patch, repo, issues)
+
+
+def _validate_format(patch: BaseCorrectionPatch, repo: Any | None, issues: _Issues) -> None:
+    format_name = patch.target.get("format_name")
+    if not isinstance(format_name, str) or not format_name:
+        issues.error(
+            "missing_format_name",
+            "format-dependent patch requires target.format_name",
+            field="target.format_name",
+        )
+        return
+    if format_name == "unknown":
+        return
+    if repo is not None and _resolve_format_id(repo, format_name) is None:
+        issues.error(
+            "invalid_format_name",
+            f"format_name {format_name!r} could not be resolved",
+            field="target.format_name",
+        )
+
+
+def _validate_alias_addition(patch: BaseCorrectionPatch, repo: Any | None, issues: _Issues) -> None:
+    tag = patch.target_tag
+    if tag is None:
+        issues.error("missing_target_tag", "alias_addition requires target.tag", field="target.tag")
+    if patch.proposed.get("alias") is not True:
+        issues.error(
+            "invalid_target_type", "alias_addition requires proposed.alias=true", field="proposed.alias"
+        )
+    preferred = _proposed_str(patch, "preferred_tag")
+    if preferred is None:
+        issues.error(
+            "missing_preferred_tag",
+            "alias_addition requires proposed.preferred_tag",
+            field="proposed.preferred_tag",
+        )
+        return
+    _check_alias_relation(tag, preferred, patch, repo, issues)
+
+
+def _validate_preferred_correction(patch: BaseCorrectionPatch, repo: Any | None, issues: _Issues) -> None:
+    tag = patch.target_tag
+    if tag is None:
+        issues.error(
+            "missing_target_tag", "preferred_tag_correction requires target.tag", field="target.tag"
+        )
+    preferred = _proposed_str(patch, "preferred_tag")
+    if preferred is None:
+        issues.error(
+            "missing_preferred_tag",
+            "preferred_tag_correction requires proposed.preferred_tag",
+            field="proposed.preferred_tag",
+        )
+        return
+    _check_alias_relation(tag, preferred, patch, repo, issues)
+
+
+def _check_alias_relation(
+    tag: str | None,
+    preferred: str,
+    patch: BaseCorrectionPatch,
+    repo: Any | None,
+    issues: _Issues,
+) -> None:
+    if tag is not None and tag == preferred:
+        issues.error(
+            "self_alias", "alias tag and preferred tag must differ", field="proposed.preferred_tag"
+        )
+        return
+    if repo is None or tag is None:
+        return
+    format_name = patch.format_name
+    if format_name is None:
+        return
+    if _has_alias_cycle(repo, alias_tag=tag, preferred_tag=preferred, format_name=format_name):
+        issues.error(
+            "alias_cycle", f"alias {tag!r} -> {preferred!r} forms a cycle", field="proposed.preferred_tag"
+        )
+
+
+def _validate_translation(patch: BaseCorrectionPatch, issues: _Issues) -> None:
+    if patch.target_tag is None:
+        issues.error("missing_target_tag", "translation_correction requires target.tag", field="target.tag")
+    field = patch.field
+    if not field:
+        issues.error(
+            "invalid_field",
+            "translation_correction requires target.field (e.g. translation.ja)",
+            field="target.field",
+        )
+    translation = patch.proposed.get("translation")
+    if not isinstance(translation, str) or not translation.strip():
+        issues.error(
+            "empty_translation",
+            "proposed.translation must be a non-empty string",
+            field="proposed.translation",
+        )
+    field_lang = _field_language(field)
+    proposed_lang = patch.proposed.get("language")
+    if field_lang and isinstance(proposed_lang, str) and proposed_lang and proposed_lang != field_lang:
+        issues.error(
+            "translation_language_mismatch",
+            f"proposed.language {proposed_lang!r} does not match field language {field_lang!r}",
+            field="proposed.language",
+        )
+    elif (
+        field_lang == "ja"
+        and isinstance(translation, str)
+        and translation.strip()
+        and _has_cjk_but_no_japanese(translation)
+    ):
+        # #54 の軽量チェック: ja 欄に CJK があるのに仮名/和文が無い値 (中国語語彙の疑い)。
+        # 誤検出を避けるため warning に留める (romaji 等を error にしない)。
+        issues.warn(
+            "translation_language_mismatch",
+            "translation.ja value contains CJK characters but no kana",
+            field="proposed.translation",
+        )
+
+
+def _validate_type_correction(patch: BaseCorrectionPatch, repo: Any | None, issues: _Issues) -> None:
+    if patch.target_tag is None:
+        issues.error("missing_target_tag", "type_correction requires target.tag", field="target.tag")
+    type_name = _proposed_str(patch, "type_name")
+    if type_name is None:
+        issues.error(
+            "invalid_type_name", "type_correction requires proposed.type_name", field="proposed.type_name"
+        )
+        return
+    format_name = patch.format_name
+    if repo is None or format_name is None or format_name == "unknown":
+        return
+    format_id = _resolve_format_id(repo, format_name)
+    if format_id is None:
+        return
+    if _resolve_type_id(repo, type_name, format_id) is None:
+        issues.warn(
+            "type_mapping_will_be_created",
+            f"type_name {type_name!r} has no mapping for format {format_name!r}; builder may create it",
+            field="proposed.type_name",
+        )
+
+
+def _validate_status_correction(patch: BaseCorrectionPatch, issues: _Issues) -> None:
+    if patch.target_tag is None:
+        issues.error("missing_target_tag", "status_correction requires target.tag", field="target.tag")
+    field = patch.field
+    if field not in ALLOWED_STATUS_FIELDS:
+        issues.error(
+            "status_field_not_allowed",
+            f"status_correction field must be one of {sorted(ALLOWED_STATUS_FIELDS)}, got {field!r}",
+            field="target.field",
+        )
+    deprecated = patch.proposed.get("deprecated")
+    if not isinstance(deprecated, bool):
+        issues.error(
+            "invalid_deprecated_value", "proposed.deprecated must be a boolean", field="proposed.deprecated"
+        )
+
+
+def _validate_tag_name_correction(patch: BaseCorrectionPatch, repo: Any | None, issues: _Issues) -> None:
+    source = patch.target.get("source_tag") or patch.target.get("tag")
+    if not isinstance(source, str) or not source:
+        issues.error(
+            "missing_target_tag",
+            "tag_name_correction requires target.source_tag or target.tag",
+            field="target.source_tag",
+        )
+    proposed_tag = _proposed_str(patch, "tag")
+    if proposed_tag is None:
+        issues.error(
+            "empty_proposed_tag",
+            "tag_name_correction requires non-empty proposed.tag",
+            field="proposed.tag",
+        )
+        return
+    if proposed_tag != proposed_tag.strip() or "  " in proposed_tag:
+        issues.warn("missing_patch_id", "proposed.tag is not normalized", field="proposed.tag")
+    # MVP: 既存 TAGS.tag の rename は保守的に rejected にする。
+    if repo is not None and isinstance(source, str) and source and source != proposed_tag:
+        if _resolve_tag_id(repo, source) is not None:
+            issues.error(
+                "empty_proposed_tag",
+                f"tag_name_correction would rename existing tag {source!r}; rejected in MVP",
+                field="target.tag",
+            )
+
+
+# ---------------------------------------------------------------------------
+# reader / parsing helpers
+# ---------------------------------------------------------------------------
+
+
+def _proposed_str(patch: BaseCorrectionPatch, key: str) -> str | None:
+    value = patch.proposed.get(key)
+    return value if isinstance(value, str) and value.strip() else None
+
+
+def _field_language(field: str | None) -> str | None:
+    if field and field.startswith("translation."):
+        return field.split(".", 1)[1] or None
+    return None
+
+
+def _has_cjk_but_no_japanese(text: str) -> bool:
+    """CJK 表意文字を含むのに仮名が 1 つも無い (中国語の疑い) なら True。"""
+    has_cjk = False
+    has_kana = False
+    for char in text:
+        code = ord(char)
+        if 0x4E00 <= code <= 0x9FFF:  # CJK Unified Ideographs
+            has_cjk = True
+        elif (0x3040 <= code <= 0x30FF) or (0xFF66 <= code <= 0xFF9D):  # Hiragana / Katakana
+            has_kana = True
+    return has_cjk and not has_kana
+
+
+def _resolve_format_id(repo: Any, format_name: str) -> int | None:
+    getter = getattr(repo, "get_format_id", None)
+    if getter is None:
+        return None
+    try:
+        format_id = int(getter(format_name))
+    except ValueError:
+        return None
+    return format_id if format_id > 0 else None
+
+
+def _resolve_tag_id(repo: Any, tag: str) -> int | None:
+    getter = getattr(repo, "get_tag_id_by_name", None)
+    if getter is None:
+        return None
+    try:
+        return getter(tag, partial=False)
+    except ValueError:
+        return None
+
+
+def _resolve_type_id(repo: Any, type_name: str, format_id: int) -> int | None:
+    getter = getattr(repo, "get_type_id_for_format", None)
+    if getter is None:
+        return None
+    return getter(type_name, format_id)
+
+
+def _has_alias_cycle(repo: Any, *, alias_tag: str, preferred_tag: str, format_name: str) -> bool:
+    """preferred tag の alias chain を辿り、alias_tag に戻れば cycle とみなす。"""
+    format_id = _resolve_format_id(repo, format_name)
+    get_status = getattr(repo, "get_tag_status", None)
+    if format_id is None or get_status is None:
+        return False
+    current = preferred_tag
+    seen: set[str] = set()
+    for _ in range(64):
+        if current == alias_tag:
+            return True
+        if current in seen:
+            return False
+        seen.add(current)
+        tag_id = _resolve_tag_id(repo, current)
+        if tag_id is None:
+            return False
+        status = get_status(tag_id, format_id)
+        if status is None or not getattr(status, "alias", False):
+            return False
+        preferred_id = getattr(status, "preferred_tag_id", None)
+        if preferred_id is None or preferred_id == tag_id:
+            return False
+        next_tag = _tag_name_by_id(repo, preferred_id)
+        if next_tag is None:
+            return False
+        current = next_tag
+    return False
+
+
+def _tag_name_by_id(repo: Any, tag_id: int) -> str | None:
+    getter = getattr(repo, "get_tag_by_id", None)
+    if getter is None:
+        return None
+    tag = getter(tag_id)
+    return getattr(tag, "tag", None) if tag is not None else None
+
+
+def _safe_patch_id(patch: BaseCorrectionPatch) -> str | None:
+    try:
+        return compute_patch_id(patch)
+    except (TypeError, ValueError):
+        return None

--- a/tests/unit/test_base_patch_apply.py
+++ b/tests/unit/test_base_patch_apply.py
@@ -1,0 +1,302 @@
+"""Tests for applying base correction patches to a base DB build source (#60)."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from genai_tag_db_tools.db.repository import MergedTagReader, TagReader, TagRepository
+from genai_tag_db_tools.db.schema import (
+    Base,
+    Tag,
+    TagFormat,
+    TagStatus,
+    TagTranslation,
+    TagTypeFormatMapping,
+    TagTypeName,
+)
+from genai_tag_db_tools.services.base_patch.apply import (
+    BasePatchApplyService,
+    apply_base_patch_file,
+)
+from genai_tag_db_tools.services.base_patch.models import BaseCorrectionPatch
+
+pytestmark = pytest.mark.db_tools
+
+
+@pytest.fixture()
+def session_factory() -> Callable[[], Session]:
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    factory = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    with factory() as session:
+        session.add(TagFormat(format_id=1, format_name="danbooru"))
+        session.add(TagFormat(format_id=999, format_name="unknown"))
+        session.add(TagTypeName(type_name_id=1, type_name="general"))
+        session.add(TagTypeName(type_name_id=2, type_name="character"))
+        session.add(TagTypeName(type_name_id=3, type_name="unknown"))
+        session.add(TagTypeFormatMapping(format_id=1, type_id=0, type_name_id=1))
+        session.add(TagTypeFormatMapping(format_id=1, type_id=4, type_name_id=2))
+        session.add(TagTypeFormatMapping(format_id=999, type_id=0, type_name_id=3))
+        # base tags
+        session.add(Tag(tag_id=1, source_tag="black hair", tag="black hair"))
+        session.add(Tag(tag_id=3, source_tag="blue eyes", tag="blue eyes"))
+        session.add(Tag(tag_id=7, source_tag="pixiv id", tag="pixiv id"))
+        session.add(Tag(tag_id=5, source_tag="example character", tag="example character"))
+        session.add(
+            TagStatus(tag_id=5, format_id=1, type_id=0, alias=False, preferred_tag_id=5, deprecated=False)
+        )
+        session.add(
+            TagStatus(tag_id=7, format_id=999, type_id=0, alias=False, preferred_tag_id=7, deprecated=False)
+        )
+        session.commit()
+    return factory
+
+
+@pytest.fixture()
+def service(session_factory: Callable[[], Session]) -> BasePatchApplyService:
+    reader = MergedTagReader(base_repo=TagReader(session_factory))
+    repo = TagRepository(session_factory, reader=reader)
+    return BasePatchApplyService(repo, reader)
+
+
+def _patch(patch_type: str, target: dict, proposed: dict, **extra) -> BaseCorrectionPatch:
+    data = {
+        "schema_version": 1,
+        "scope": "base",
+        "patch_type": patch_type,
+        "target": target,
+        "proposed": proposed,
+        "approved": True,
+        "validated": True,
+    }
+    data.update(extra)
+    return BaseCorrectionPatch.model_validate(data)
+
+
+def test_apply_alias_addition(service: BasePatchApplyService, session_factory) -> None:
+    patch = _patch(
+        "alias_addition",
+        {"target_type": "alias", "tag": "blakc hair", "format_name": "danbooru"},
+        {"alias": True, "preferred_tag": "black hair"},
+    )
+    row = service.apply_patch(patch)
+    assert row.status == "applied"
+    with session_factory() as session:
+        alias_tag = session.query(Tag).filter(Tag.tag == "blakc hair").one()
+        status = (
+            session.query(TagStatus)
+            .filter(TagStatus.tag_id == alias_tag.tag_id, TagStatus.format_id == 1)
+            .one()
+        )
+        assert status.alias is True
+        assert status.preferred_tag_id == 1
+
+
+def test_apply_translation(service: BasePatchApplyService, session_factory) -> None:
+    patch = _patch(
+        "translation_correction",
+        {"target_type": "translation", "tag": "blue eyes", "field": "translation.ja"},
+        {"translation": "青い目", "language": "ja"},
+    )
+    row = service.apply_patch(patch)
+    assert row.status == "applied"
+    with session_factory() as session:
+        trans = session.query(TagTranslation).filter(TagTranslation.tag_id == 3).one()
+        assert trans.language == "ja"
+        assert trans.translation == "青い目"
+    # second apply is idempotent
+    assert service.apply_patch(patch).status == "already_applied"
+
+
+def test_apply_type_correction(service: BasePatchApplyService, session_factory) -> None:
+    patch = _patch(
+        "type_correction",
+        {"target_type": "tag_type", "tag": "example character", "format_name": "danbooru"},
+        {"type_name": "character"},
+    )
+    row = service.apply_patch(patch)
+    assert row.status == "applied"
+    with session_factory() as session:
+        status = session.query(TagStatus).filter(TagStatus.tag_id == 5, TagStatus.format_id == 1).one()
+        assert status.type_id == 4
+
+
+def test_apply_status_deprecated(service: BasePatchApplyService, session_factory) -> None:
+    patch = _patch(
+        "status_correction",
+        {
+            "target_type": "tag_status",
+            "tag": "pixiv id",
+            "format_name": "unknown",
+            "field": "TAG_STATUS.deprecated",
+        },
+        {"deprecated": True},
+    )
+    row = service.apply_patch(patch)
+    assert row.status == "applied"
+    with session_factory() as session:
+        status = session.query(TagStatus).filter(TagStatus.tag_id == 7, TagStatus.format_id == 999).one()
+        assert status.deprecated is True
+    assert service.apply_patch(patch).status == "already_applied"
+
+
+def test_apply_preferred_tag_correction(service: BasePatchApplyService, session_factory) -> None:
+    # first create an alias blakc hair -> black hair
+    service.apply_patch(
+        _patch(
+            "alias_addition",
+            {"target_type": "alias", "tag": "blakc hair", "format_name": "danbooru"},
+            {"alias": True, "preferred_tag": "black hair"},
+        )
+    )
+    # now repoint it to blue eyes
+    row = service.apply_patch(
+        _patch(
+            "preferred_tag_correction",
+            {"target_type": "alias", "tag": "blakc hair", "format_name": "danbooru"},
+            {"preferred_tag": "blue eyes"},
+        )
+    )
+    assert row.status == "applied"
+    with session_factory() as session:
+        alias_tag = session.query(Tag).filter(Tag.tag == "blakc hair").one()
+        status = session.query(TagStatus).filter(TagStatus.tag_id == alias_tag.tag_id).one()
+        assert status.preferred_tag_id == 3
+
+
+def test_apply_tag_name_correction_creates_tag(service: BasePatchApplyService, session_factory) -> None:
+    patch = _patch(
+        "tag_name_correction",
+        {"target_type": "tag_name", "source_tag": "blue__eyes"},
+        {"tag": "blue green eyes"},
+    )
+    row = service.apply_patch(patch)
+    assert row.status == "applied"
+    with session_factory() as session:
+        assert session.query(Tag).filter(Tag.tag == "blue green eyes").one_or_none() is not None
+
+
+def test_unsupported_patch_type_rejected(service: BasePatchApplyService) -> None:
+    patch = _patch(
+        "format_relation_review",
+        {"target_type": "format_relation", "tag": "wolf"},
+        {},
+    )
+    row = service.apply_patch(patch)
+    assert row.status == "rejected"
+
+
+def test_explicitly_unvalidated_rejected(service: BasePatchApplyService) -> None:
+    patch = _patch(
+        "status_correction",
+        {
+            "target_type": "tag_status",
+            "tag": "pixiv id",
+            "format_name": "unknown",
+            "field": "TAG_STATUS.deprecated",
+        },
+        {"deprecated": True},
+        validated=False,
+    )
+    assert service.apply_patch(patch).status == "rejected"
+
+
+def test_wrong_scope_rejected(service: BasePatchApplyService) -> None:
+    patch = _patch(
+        "status_correction",
+        {
+            "target_type": "tag_status",
+            "tag": "pixiv id",
+            "format_name": "unknown",
+            "field": "TAG_STATUS.deprecated",
+        },
+        {"deprecated": True},
+        scope="user",
+    )
+    assert service.apply_patch(patch).status == "rejected"
+
+
+def test_dry_run_does_not_write(session_factory) -> None:
+    reader = MergedTagReader(base_repo=TagReader(session_factory))
+    repo = TagRepository(session_factory, reader=reader)
+    dry = BasePatchApplyService(repo, reader, dry_run=True)
+    patch = _patch(
+        "status_correction",
+        {
+            "target_type": "tag_status",
+            "tag": "pixiv id",
+            "format_name": "unknown",
+            "field": "TAG_STATUS.deprecated",
+        },
+        {"deprecated": True},
+    )
+    row = dry.apply_patch(patch)
+    assert row.status == "applied"
+    with session_factory() as session:
+        status = session.query(TagStatus).filter(TagStatus.tag_id == 7, TagStatus.format_id == 999).one()
+        assert status.deprecated is False
+
+
+def test_apply_file_with_report_and_jsonl_load(session_factory, tmp_path: Path) -> None:
+    reader = MergedTagReader(base_repo=TagReader(session_factory))
+    repo = TagRepository(session_factory, reader=reader)
+    patches = [
+        _patch(
+            "translation_correction",
+            {"target_type": "translation", "tag": "blue eyes", "field": "translation.ja"},
+            {"translation": "青い目", "language": "ja"},
+        ),
+        _patch(
+            "status_correction",
+            {
+                "target_type": "tag_status",
+                "tag": "pixiv id",
+                "format_name": "unknown",
+                "field": "TAG_STATUS.deprecated",
+            },
+            {"deprecated": True},
+        ),
+    ]
+    patch_file = tmp_path / "patches.jsonl"
+    patch_file.write_text(
+        "\n".join(json.dumps(p.model_dump(mode="json", exclude_none=True)) for p in patches),
+        encoding="utf-8",
+    )
+    report = tmp_path / "apply.tsv"
+
+    result = apply_base_patch_file(patch_file, repository=repo, reader=reader, report=report)
+    assert result.ok
+    assert result.applied_count == 2
+
+    lines = report.read_text(encoding="utf-8").splitlines()
+    assert lines[0].split("\t")[0] == "patch_id"
+    assert "db_changes" in lines[0]
+
+
+def test_invalid_patch_does_not_break_db(service: BasePatchApplyService, session_factory) -> None:
+    patch = _patch(
+        "status_correction",
+        {
+            "target_type": "tag_status",
+            "tag": "pixiv id",
+            "format_name": "unknown",
+            "field": "TAG_STATUS.alias",
+        },
+        {"deprecated": True},
+    )
+    row = service.apply_patch(patch)
+    assert row.status == "rejected"
+    with session_factory() as session:
+        status = session.query(TagStatus).filter(TagStatus.tag_id == 7, TagStatus.format_id == 999).one()
+        assert status.deprecated is False

--- a/tests/unit/test_base_patch_export.py
+++ b/tests/unit/test_base_patch_export.py
@@ -1,0 +1,222 @@
+"""Tests for exporting base correction patches from approved feedback (#61)."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from types import SimpleNamespace
+
+from genai_tag_db_tools.models import ApprovedDbFeedback, DbFeedbackProposal, ProposalTarget
+from genai_tag_db_tools.services.base_patch.export import (
+    export_base_patch_file,
+    export_base_patches,
+)
+
+APPROVED_AT = datetime(2026, 6, 27, tzinfo=UTC)
+
+
+def _feedback(proposal: DbFeedbackProposal, *, approved: bool = True) -> ApprovedDbFeedback:
+    return ApprovedDbFeedback(
+        proposal=proposal,
+        approved=approved,
+        approved_by="maintainer",
+        approved_at=APPROVED_AT,
+    )
+
+
+def _proposal(**kwargs) -> DbFeedbackProposal:
+    defaults = {"confidence": 0.8, "source": "unit_test", "reason_codes": [], "evidence": []}
+    defaults.update(kwargs)
+    return DbFeedbackProposal(**defaults)
+
+
+def _alias_proposal(scope: str = "base") -> DbFeedbackProposal:
+    return _proposal(
+        kind="alias_addition",
+        target=ProposalTarget(
+            kind="alias",
+            target_scope=scope,
+            target_tag_id=2,
+            format_name="unknown",
+            preferred_scope="base",
+            preferred_tag_id=1,
+        ),
+        current={"alias": False, "preferred_tag": None},
+        proposed={"alias": True, "preferred_tag": "black hair", "tag": "blakc hair"},
+        reason_codes=["typo_alias_candidate"],
+        evidence=[{"candidate": "black hair", "distance": 1}],
+    )
+
+
+def _translation_proposal() -> DbFeedbackProposal:
+    return _proposal(
+        kind="translation_correction",
+        target=ProposalTarget(
+            kind="translation",
+            target_scope="base",
+            target_tag_id=3,
+            language="ja",
+        ),
+        current={"language": "ja", "translation": "蓝眼睛", "tag": "blue eyes"},
+        proposed={"translation": "青い目", "language": "ja"},
+        reason_codes=["wrong_language_translation"],
+    )
+
+
+def _status_proposal() -> DbFeedbackProposal:
+    return _proposal(
+        kind="status_correction",
+        target=ProposalTarget(
+            kind="tag_status",
+            target_scope="base",
+            target_tag_id=7,
+            format_name="unknown",
+            field="TAG_STATUS.deprecated",
+        ),
+        current={"deprecated": False, "tag": "pixiv id"},
+        proposed={"deprecated": True},
+        reason_codes=["training_unsuitable", "external_id_tag"],
+    )
+
+
+def _type_proposal() -> DbFeedbackProposal:
+    return _proposal(
+        kind="type_correction",
+        target=ProposalTarget(
+            kind="tag_type",
+            target_scope="base",
+            target_tag_id=5,
+            format_name="danbooru",
+        ),
+        current={"type_name": "general", "tag": "example character"},
+        proposed={"type_name": "character"},
+    )
+
+
+def test_export_alias_addition() -> None:
+    result = export_base_patches([_feedback(_alias_proposal())])
+    assert result.exported_count == 1
+    patch = result.patches[0]
+    assert patch.patch_type == "alias_addition"
+    assert patch.scope == "base"
+    assert patch.target == {"target_type": "alias", "tag": "blakc hair", "format_name": "unknown"}
+    assert patch.proposed["preferred_tag"] == "black hair"
+    assert patch.proposed["alias"] is True
+    assert patch.approved is True
+    assert patch.approved_by == "maintainer"
+    assert patch.patch_id and patch.patch_id.startswith("sha256:")
+
+
+def test_export_translation_and_status_and_type() -> None:
+    feedbacks = [
+        _feedback(_translation_proposal()),
+        _feedback(_status_proposal()),
+        _feedback(_type_proposal()),
+    ]
+    result = export_base_patches(feedbacks)
+    assert result.exported_count == 3
+    by_type = {p.patch_type: p for p in result.patches}
+    assert by_type["translation_correction"].target["field"] == "translation.ja"
+    assert by_type["translation_correction"].proposed["translation"] == "青い目"
+    assert by_type["status_correction"].target["field"] == "TAG_STATUS.deprecated"
+    assert by_type["status_correction"].proposed["deprecated"] is True
+    assert by_type["type_correction"].proposed["type_name"] == "character"
+
+
+def test_patch_id_is_stable_across_export_runs() -> None:
+    a = export_base_patches([_feedback(_alias_proposal())]).patches[0]
+    b = export_base_patches([_feedback(_alias_proposal())]).patches[0]
+    assert a.patch_id == b.patch_id
+
+
+def test_user_scope_proposal_is_skipped() -> None:
+    result = export_base_patches([_feedback(_alias_proposal(scope="user"))])
+    assert result.exported_count == 0
+    assert result.rows[0].status == "skipped_user_scope"
+
+
+def test_review_only_proposal_is_skipped() -> None:
+    proposal = _proposal(
+        kind="format_relation_review",
+        target=ProposalTarget(kind="format_relation", target_scope="base"),
+        proposed=None,
+    )
+    result = export_base_patches([_feedback(proposal)])
+    assert result.rows[0].status == "skipped_review_only"
+
+
+def test_usage_correction_is_unsupported_for_base_patch() -> None:
+    proposal = _proposal(
+        kind="usage_correction",
+        target=ProposalTarget(kind="usage", target_scope="base", target_tag_id=1, format_name="danbooru"),
+        proposed={"count": 5},
+    )
+    result = export_base_patches([_feedback(proposal)])
+    assert result.rows[0].status == "skipped_unsupported_type"
+
+
+def test_unapproved_feedback_filtered_from_file(tmp_path: Path) -> None:
+    approved = _feedback(_alias_proposal()).model_dump(mode="json")
+    unapproved = approved.copy()
+    unapproved["approved"] = False
+    input_file = tmp_path / "feedback.jsonl"
+    input_file.write_text(json.dumps(approved) + "\n" + json.dumps(unapproved) + "\n", encoding="utf-8")
+    output_file = tmp_path / "patches.jsonl"
+
+    result = export_base_patch_file(input_file, output_file)
+    assert result.exported_count == 1
+    written = [json.loads(line) for line in output_file.read_text(encoding="utf-8").splitlines()]
+    assert len(written) == 1
+    assert written[0]["patch_type"] == "alias_addition"
+
+
+def test_export_validate_mode_marks_validated_and_reports(tmp_path: Path) -> None:
+    good = _feedback(_status_proposal()).model_dump(mode="json")
+    input_file = tmp_path / "feedback.jsonl"
+    input_file.write_text(json.dumps(good) + "\n", encoding="utf-8")
+    output_file = tmp_path / "patches.jsonl"
+    report = tmp_path / "export.tsv"
+
+    result = export_base_patch_file(input_file, output_file, validate=True, report=report)
+    assert result.exported_count == 1
+    patch = result.patches[0]
+    assert patch.validated is True
+    assert patch.validated_at is not None
+
+    report_lines = report.read_text(encoding="utf-8").splitlines()
+    assert report_lines[0].split("\t")[0] == "patch_id"
+    assert any("exported" in line for line in report_lines[1:])
+
+
+def test_export_file_is_loadable_by_validator(tmp_path: Path) -> None:
+    from genai_tag_db_tools.services.base_patch.validate import validate_base_patch_file
+
+    out = tmp_path / "patches.jsonl"
+    # write via file API
+    input_file = tmp_path / "feedback.jsonl"
+    input_file.write_text(
+        "\n".join(
+            json.dumps(_feedback(p).model_dump(mode="json"))
+            for p in (_alias_proposal(), _translation_proposal())
+        ),
+        encoding="utf-8",
+    )
+    export_base_patch_file(input_file, out)
+    validation = validate_base_patch_file(out)
+    assert validation.ok
+    assert len(validation.items) == 2
+
+
+def test_reader_resolves_names_when_proposal_lacks_hints() -> None:
+    proposal = _proposal(
+        kind="translation_correction",
+        target=ProposalTarget(kind="translation", target_scope="base", target_tag_id=3, language="ja"),
+        current={"language": "ja", "translation": "x"},
+        proposed={"translation": "青い目", "language": "ja"},
+    )
+    reader = SimpleNamespace(
+        get_tag_by_id=lambda tid: SimpleNamespace(tag="blue eyes") if tid == 3 else None
+    )
+    result = export_base_patches([_feedback(proposal)], reader=reader)
+    assert result.patches[0].target["tag"] == "blue eyes"

--- a/tests/unit/test_base_patch_models.py
+++ b/tests/unit/test_base_patch_models.py
@@ -1,0 +1,76 @@
+"""Tests for base correction patch models and stable patch_id (#58/#60/#61)."""
+
+from __future__ import annotations
+
+from genai_tag_db_tools.services.base_patch.models import (
+    SCHEMA_VERSION,
+    BaseCorrectionPatch,
+    compute_patch_id,
+)
+
+
+def _patch(**overrides) -> BaseCorrectionPatch:
+    data = {
+        "schema_version": SCHEMA_VERSION,
+        "patch_type": "translation_correction",
+        "target": {"target_type": "translation", "tag": "blue eyes", "field": "translation.ja"},
+        "proposed": {"translation": "青い目", "language": "ja"},
+        "scope": "base",
+    }
+    data.update(overrides)
+    return BaseCorrectionPatch.model_validate(data)
+
+
+def test_patch_id_is_stable_for_same_content() -> None:
+    a = _patch(approved_by="alice", evidence={"detected_language": "zh"})
+    b = _patch(approved_by="bob", evidence={"detected_language": "en"})
+    assert compute_patch_id(a) == compute_patch_id(b)
+    assert compute_patch_id(a).startswith("sha256:")
+
+
+def test_patch_id_changes_when_proposed_changes() -> None:
+    a = _patch()
+    b = _patch(proposed={"translation": "蒼い目", "language": "ja"})
+    assert compute_patch_id(a) != compute_patch_id(b)
+
+
+def test_patch_id_changes_when_scope_changes() -> None:
+    a = _patch(scope="base")
+    b = _patch(scope=None)
+    assert compute_patch_id(a) != compute_patch_id(b)
+
+
+def test_optional_keys_default_to_none_or_empty() -> None:
+    patch = BaseCorrectionPatch.model_validate(
+        {
+            "schema_version": 1,
+            "patch_type": "status_correction",
+            "target": {
+                "target_type": "tag_status",
+                "tag": "pixiv id",
+                "format_name": "unknown",
+                "field": "TAG_STATUS.deprecated",
+            },
+            "proposed": {"deprecated": True},
+        }
+    )
+    assert patch.patch_id is None
+    assert patch.scope is None
+    assert patch.reason_codes == []
+    assert patch.target_type == "tag_status"
+    assert patch.target_tag == "pixiv id"
+    assert patch.format_name == "unknown"
+    assert patch.field == "TAG_STATUS.deprecated"
+
+
+def test_extra_keys_are_allowed() -> None:
+    patch = BaseCorrectionPatch.model_validate(
+        {
+            "schema_version": 1,
+            "patch_type": "translation_correction",
+            "target": {"target_type": "translation", "tag": "x", "field": "translation.ja"},
+            "proposed": {"translation": "y"},
+            "future_key": {"nested": 1},
+        }
+    )
+    assert patch.model_dump()["future_key"] == {"nested": 1}

--- a/tests/unit/test_base_patch_validate.py
+++ b/tests/unit/test_base_patch_validate.py
@@ -1,0 +1,323 @@
+"""Tests for base DB correction patch validation (#58)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from genai_tag_db_tools.services.base_patch.models import BaseCorrectionPatch
+from genai_tag_db_tools.services.base_patch.validate import (
+    validate_base_patch,
+    validate_base_patch_file,
+)
+
+
+class FakeReader:
+    """Minimal read-only reader for validation tests."""
+
+    def __init__(self) -> None:
+        self._tags = {"black hair": 1, "blakc hair": 2, "blue eyes": 3, "loop a": 10, "loop b": 11}
+        self._formats = {"danbooru": 1, "unknown": 999}
+        self._types = {("danbooru", "character"): 4, ("danbooru", "general"): 1}
+        # alias cycle fixture: loop a -> loop b -> loop a
+        self._status = {
+            (10, 1): SimpleNamespace(alias=True, preferred_tag_id=11, type_id=1, deprecated=False),
+            (11, 1): SimpleNamespace(alias=True, preferred_tag_id=10, type_id=1, deprecated=False),
+        }
+
+    def get_format_id(self, format_name: str) -> int:
+        if format_name in self._formats:
+            return self._formats[format_name]
+        raise ValueError(format_name)
+
+    def get_tag_id_by_name(self, name: str, partial: bool = False) -> int | None:
+        return self._tags.get(name)
+
+    def get_type_id_for_format(self, type_name: str, format_id: int) -> int | None:
+        name = {v: k for k, v in self._formats.items()}.get(format_id)
+        return self._types.get((name, type_name)) if name else None
+
+    def get_tag_status(self, tag_id: int, format_id: int):
+        return self._status.get((tag_id, format_id))
+
+    def get_tag_by_id(self, tag_id: int):
+        name = {v: k for k, v in self._tags.items()}.get(tag_id)
+        return SimpleNamespace(tag=name) if name else None
+
+
+def _patch(patch_type: str, target: dict, proposed: dict, **extra) -> BaseCorrectionPatch:
+    data = {"schema_version": 1, "patch_type": patch_type, "target": target, "proposed": proposed}
+    data.update(extra)
+    return BaseCorrectionPatch.model_validate(data)
+
+
+def _codes(result) -> set[str]:
+    return {issue.code for issue in result.errors}
+
+
+def test_valid_translation_patch_passes_without_db_change() -> None:
+    patch = _patch(
+        "translation_correction",
+        {"target_type": "translation", "tag": "blue eyes", "field": "translation.ja"},
+        {"translation": "青い目", "language": "ja"},
+        patch_id="sha256:x",
+    )
+    result = validate_base_patch(patch)
+    assert result.status == "valid"
+    assert result.errors == []
+
+
+def test_missing_required_field_rejected_in_file() -> None:
+    # proposed が無いので構築に失敗 -> missing_required_field
+    line = json.dumps({"schema_version": 1, "patch_type": "translation_correction", "target": {}})
+    result_items = _validate_lines([line])
+    assert result_items[0].status == "invalid"
+    assert "missing_required_field" in {e.code for e in result_items[0].errors}
+
+
+def test_unsupported_schema_version_rejected() -> None:
+    patch = _patch(
+        "translation_correction",
+        {"target_type": "translation", "tag": "x", "field": "translation.ja"},
+        {"translation": "y"},
+        schema_version=2,
+    )
+    result = validate_base_patch(patch)
+    assert "unsupported_schema_version" in _codes(result)
+
+
+@pytest.mark.parametrize("scope", ["user", "local"])
+def test_user_local_scope_rejected(scope: str) -> None:
+    patch = _patch(
+        "translation_correction",
+        {"target_type": "translation", "tag": "x", "field": "translation.ja"},
+        {"translation": "y"},
+        scope=scope,
+    )
+    assert "invalid_scope" in _codes(validate_base_patch(patch))
+
+
+def test_explicit_unapproved_and_unvalidated_rejected() -> None:
+    patch = _patch(
+        "translation_correction",
+        {"target_type": "translation", "tag": "x", "field": "translation.ja"},
+        {"translation": "y"},
+        approved=False,
+        validated=False,
+    )
+    codes = _codes(validate_base_patch(patch))
+    assert "explicitly_unapproved" in codes
+    assert "explicitly_unvalidated" in codes
+
+
+def test_missing_optional_metadata_is_not_failure() -> None:
+    patch = _patch(
+        "translation_correction",
+        {"target_type": "translation", "tag": "x", "field": "translation.ja"},
+        {"translation": "y"},
+    )
+    result = validate_base_patch(patch)
+    assert result.ok
+    # patch_id 欠落は warning に留まる
+    assert "missing_patch_id" in {w.code for w in result.warnings}
+
+
+def test_approved_without_metadata_is_warning_only() -> None:
+    patch = _patch(
+        "translation_correction",
+        {"target_type": "translation", "tag": "x", "field": "translation.ja"},
+        {"translation": "y"},
+        approved=True,
+        patch_id="sha256:x",
+    )
+    result = validate_base_patch(patch)
+    assert result.ok
+    assert "missing_approval_metadata" in {w.code for w in result.warnings}
+
+
+@pytest.mark.parametrize(
+    "patch_type", ["metadata_correction", "training_policy_correction", "format_relation_review", "made_up"]
+)
+def test_unsupported_patch_types_rejected(patch_type: str) -> None:
+    patch = _patch(patch_type, {"target_type": "translation", "tag": "x"}, {})
+    assert "unsupported_patch_type" in _codes(validate_base_patch(patch))
+
+
+def test_invalid_target_type_rejected() -> None:
+    patch = _patch(
+        "translation_correction",
+        {"target_type": "tag_status", "tag": "x", "field": "translation.ja"},
+        {"translation": "y"},
+    )
+    assert "invalid_target_type" in _codes(validate_base_patch(patch))
+
+
+def test_alias_self_reference_rejected() -> None:
+    patch = _patch(
+        "alias_addition",
+        {"target_type": "alias", "tag": "black hair", "format_name": "unknown"},
+        {"alias": True, "preferred_tag": "black hair"},
+    )
+    assert "self_alias" in _codes(validate_base_patch(patch))
+
+
+def test_alias_missing_preferred_detected() -> None:
+    patch = _patch(
+        "alias_addition",
+        {"target_type": "alias", "tag": "blakc hair", "format_name": "unknown"},
+        {"alias": True},
+    )
+    assert "missing_preferred_tag" in _codes(validate_base_patch(patch))
+
+
+def test_alias_cycle_detected_with_reader() -> None:
+    patch = _patch(
+        "preferred_tag_correction",
+        {"target_type": "alias", "tag": "loop b", "format_name": "danbooru"},
+        {"preferred_tag": "loop a"},
+    )
+    assert "alias_cycle" in _codes(validate_base_patch(patch, repo=FakeReader()))
+
+
+def test_missing_format_name_for_format_dependent_patch() -> None:
+    patch = _patch(
+        "status_correction",
+        {"target_type": "tag_status", "tag": "x", "field": "TAG_STATUS.deprecated"},
+        {"deprecated": True},
+    )
+    assert "missing_format_name" in _codes(validate_base_patch(patch))
+
+
+def test_invalid_format_name_with_reader() -> None:
+    patch = _patch(
+        "status_correction",
+        {"target_type": "tag_status", "tag": "x", "format_name": "nope", "field": "TAG_STATUS.deprecated"},
+        {"deprecated": True},
+    )
+    assert "invalid_format_name" in _codes(validate_base_patch(patch, repo=FakeReader()))
+
+
+def test_empty_translation_rejected() -> None:
+    patch = _patch(
+        "translation_correction",
+        {"target_type": "translation", "tag": "x", "field": "translation.ja"},
+        {"translation": "   "},
+    )
+    assert "empty_translation" in _codes(validate_base_patch(patch))
+
+
+def test_translation_language_mismatch_detected() -> None:
+    patch = _patch(
+        "translation_correction",
+        {"target_type": "translation", "tag": "x", "field": "translation.ja"},
+        {"translation": "青い目", "language": "zh"},
+    )
+    assert "translation_language_mismatch" in _codes(validate_base_patch(patch))
+
+
+def test_status_correction_only_allows_deprecated_field() -> None:
+    patch = _patch(
+        "status_correction",
+        {"target_type": "tag_status", "tag": "x", "format_name": "unknown", "field": "TAG_STATUS.alias"},
+        {"deprecated": True},
+    )
+    assert "status_field_not_allowed" in _codes(validate_base_patch(patch))
+
+
+def test_status_correction_invalid_deprecated_value() -> None:
+    patch = _patch(
+        "status_correction",
+        {
+            "target_type": "tag_status",
+            "tag": "x",
+            "format_name": "unknown",
+            "field": "TAG_STATUS.deprecated",
+        },
+        {"deprecated": "yes"},
+    )
+    assert "invalid_deprecated_value" in _codes(validate_base_patch(patch))
+
+
+def test_invalid_type_name_missing() -> None:
+    patch = _patch(
+        "type_correction",
+        {"target_type": "tag_type", "tag": "x", "format_name": "danbooru"},
+        {},
+    )
+    assert "invalid_type_name" in _codes(validate_base_patch(patch))
+
+
+def test_type_mapping_will_be_created_warning() -> None:
+    patch = _patch(
+        "type_correction",
+        {"target_type": "tag_type", "tag": "x", "format_name": "danbooru"},
+        {"type_name": "brand_new_type"},
+        patch_id="sha256:x",
+    )
+    result = validate_base_patch(patch, repo=FakeReader())
+    assert result.ok
+    assert "type_mapping_will_be_created" in {w.code for w in result.warnings}
+
+
+def test_format_name_none_is_not_all_formats() -> None:
+    patch = _patch(
+        "type_correction",
+        {"target_type": "tag_type", "tag": "x", "format_name": None},
+        {"type_name": "character"},
+    )
+    assert "missing_format_name" in _codes(validate_base_patch(patch))
+
+
+def test_validate_file_and_report_output(tmp_path: Path) -> None:
+    patches = [
+        {
+            "schema_version": 1,
+            "patch_id": "sha256:a",
+            "patch_type": "translation_correction",
+            "target": {"target_type": "translation", "tag": "blue eyes", "field": "translation.ja"},
+            "proposed": {"translation": "青い目", "language": "ja"},
+        },
+        {
+            "schema_version": 1,
+            "patch_type": "status_correction",
+            "target": {"target_type": "tag_status", "tag": "x", "field": "TAG_STATUS.alias"},
+            "proposed": {"deprecated": True},
+        },
+    ]
+    patch_file = tmp_path / "patches.jsonl"
+    patch_file.write_text("\n".join(json.dumps(p) for p in patches), encoding="utf-8")
+    report = tmp_path / "report.tsv"
+
+    result = validate_base_patch_file(patch_file, report=report)
+    assert result.valid_count == 1
+    assert result.invalid_count == 1
+    assert not result.ok
+
+    lines = report.read_text(encoding="utf-8").splitlines()
+    assert lines[0].split("\t") == [
+        "line_number",
+        "patch_id",
+        "patch_type",
+        "target_type",
+        "target_tag",
+        "format_name",
+        "status",
+        "error_code",
+        "message",
+    ]
+    assert any("status_field_not_allowed" in line for line in lines[1:])
+
+
+def _validate_lines(lines: list[str]):
+    import tempfile
+
+    with tempfile.NamedTemporaryFile("w", suffix=".jsonl", delete=False, encoding="utf-8") as fh:
+        fh.write("\n".join(lines))
+        path = Path(fh.name)
+    try:
+        return validate_base_patch_file(path).items
+    finally:
+        path.unlink(missing_ok=True)

--- a/tests/unit/test_cli_feedback.py
+++ b/tests/unit/test_cli_feedback.py
@@ -1,0 +1,97 @@
+"""CLI smoke tests for the base patch pipeline subcommands (#58/#60/#61)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import genai_tag_db_tools.cli as cli
+
+
+def _run(argv: list[str], capsys: pytest.CaptureFixture[str]) -> list[dict]:
+    cli.main(argv)
+    return [json.loads(line) for line in capsys.readouterr().out.splitlines() if line.strip()]
+
+
+def test_validate_base_patches_cli(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    patch_file = tmp_path / "patches.jsonl"
+    patch_file.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "patch_id": "sha256:a",
+                "patch_type": "translation_correction",
+                "target": {"target_type": "translation", "tag": "blue eyes", "field": "translation.ja"},
+                "proposed": {"translation": "青い目", "language": "ja"},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    objs = _run(["feedback", "validate-base-patches", "--file", str(patch_file)], capsys)
+    result = objs[-1]
+    assert result["kind"] == "result"
+    assert result["ok"] is True
+    assert result["valid"] == 1
+
+
+def test_export_then_apply_cli(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    # A hand-written base patch file (export already covered by unit tests);
+    # here we exercise validate -> apply CLI against an empty base DB build output.
+    from sqlalchemy import create_engine
+
+    from genai_tag_db_tools.db.schema import Base, Tag, TagFormat, TagTypeFormatMapping, TagTypeName
+
+    base_db = tmp_path / "base.sqlite"
+    engine = create_engine(f"sqlite:///{base_db}")
+    Base.metadata.create_all(engine)
+    from sqlalchemy.orm import sessionmaker
+
+    with sessionmaker(bind=engine)() as session:
+        session.add(TagFormat(format_id=999, format_name="unknown"))
+        session.add(TagTypeName(type_name_id=3, type_name="unknown"))
+        session.add(TagTypeFormatMapping(format_id=999, type_id=0, type_name_id=3))
+        session.add(Tag(tag_id=7, source_tag="pixiv id", tag="pixiv id"))
+        session.commit()
+    engine.dispose()
+
+    patch_file = tmp_path / "patches.jsonl"
+    patch_file.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "scope": "base",
+                "patch_type": "status_correction",
+                "target": {
+                    "target_type": "tag_status",
+                    "tag": "pixiv id",
+                    "format_name": "unknown",
+                    "field": "TAG_STATUS.deprecated",
+                },
+                "proposed": {"deprecated": True},
+                "approved": True,
+                "validated": True,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    objs = _run(
+        ["feedback", "apply-base-patches", "--file", str(patch_file), "--base-db", str(base_db), "--apply"],
+        capsys,
+    )
+    result = objs[-1]
+    assert result["kind"] == "result"
+    assert result["ok"] is True
+    assert result["applied"] == 1
+
+
+def test_list_commands_unchanged_by_feedback_group(capsys: pytest.CaptureFixture[str]) -> None:
+    # feedback subcommands are intentionally not registered as tool specs,
+    # so the introspection command set stays stable.
+    objs = _run(["list-commands"], capsys)
+    names = {o["name"] for o in objs if o["kind"] == "tool"}
+    assert "feedback" not in names


### PR DESCRIPTION
## Summary

Implements the base-DB correction-patch pipeline (parent #2) as a self-contained `services/base_patch` package, sitting between approved refinement feedback (#57) and the dataset-builder. Three coherent steps:

### #58 — validate base patches before apply (`validate.py`)
- Validates the minimal envelope: required `schema_version` / `patch_type` / `target` / `proposed`; all other keys optional (missing optional keys are never a failure).
- Rejects: `scope=user`/`local`, explicit `approved=false`/`validated=false`, `metadata_correction`/`training_policy_correction`/`format_relation_review`/unknown patch types, target-type mismatch, alias self-reference, alias cycle, missing preferred tag, invalid type name, empty translation, language mismatch, non-`TAG_STATUS.deprecated` status fields, missing/unresolvable `format_name` (never treats `None` as all-formats).
- Warnings (non-blocking): missing `patch_id`, missing approval metadata, `type_mapping_will_be_created`.
- Structured error/warning codes + TSV/JSONL validation report. Never mutates the DB. Optional read-only `repo` enables name/format/type/alias-cycle resolution.

### #61 — export approved feedback to base patch JSONL (`export.py`)
- Converts approved overlay/id-based `DbFeedbackProposal` into name-based base patches with a stable `sha256:` `patch_id` (scope-aware; approver/evidence excluded from the hash).
- Filters user-scope / review-only / unsupported / unapproved feedback with explicit report statuses.
- `--validate` runs the #58 validator, stamps `validated`/`validated_at` on valid rows, and reports rejects. Produces the same envelope the builder consumes; **does not** apply to the base DB.

### #60 — apply validated patches to base DB build sources (`apply.py`)
- Applies patches to a base DB build output via the existing `TagRepository`/`TagReader`, re-running minimal validation first.
- Covers alias_addition, preferred_tag_correction, translation_correction, type_correction, status_correction (deprecated), tag_name_correction (new-tag only). Idempotent (`already_applied`), dry-run aware, invalid patches rejected without corrupting the DB.
- Apply report (`applied`/`skipped`/`rejected`/`already_applied`) with `db_changes`.

### CLI
`tag-db feedback validate-base-patches | export-base-patches | apply-base-patches`. Intentionally not registered as introspection tool specs, so the existing command set stays stable.

## Tests
56 new unit tests across models / validate / export / apply / CLI. Full suite: **675 passed** (619 baseline + 56). `ruff check`, `ruff format`, and `mypy src` all clean.

## Scope notes
- New modules only; the single edit to a shared file is a 5-line wiring addition in `cli.py`. No changes to `core_api.py` or other agents' surfaces.
- Builder-side import (separate `genai_tag_db_dataset_builder` repo) is out of this repo's reach; the apply library + a base-DB apply CLI provide the tools-side equivalent against a build-output SQLite.

Closes #58
Closes #61
Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)