### PR TITLE
OverlayTagReader.search_tags: filters, translation/source/usage search (#82 #83 #84)

### DIFF
--- a/src/genai_tag_db_tools/db/overlay_reader.py
+++ b/src/genai_tag_db_tools/db/overlay_reader.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 from collections.abc import Callable
 from logging import getLogger
 
-from sqlalchemy import func
+from sqlalchemy import func, or_
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import Session
+from sqlalchemy.sql.elements import ColumnElement
 
 from genai_tag_db_tools.db.query_utils import normalize_search_keyword
 from genai_tag_db_tools.db.schema import (
@@ -163,65 +164,328 @@ class OverlayTagReader:
         limit: int | None = None,
         offset: int = 0,
     ) -> list[TagSearchRow]:
-        """USER_TAGS からキーワードマッチするタグを取得し、USER_TAG_STATUS_PATCH でステータスを付与して返す。"""
+        """USER_TAGS からキーワードマッチするタグを取得し、各 PATCH でステータス・使用回数・翻訳を付与して返す。
+
+        legacy ``TagReader.search_tags`` と同じ契約を満たす:
+
+        - キーワードは ``UserTag.tag`` / ``UserTag.source_tag`` /
+          ``USER_TAG_TRANSLATION_PATCH.translation`` に対して照合する (#83)。
+        - 完全一致 (``partial=False``) は ``COLLATE NOCASE`` で大文字小文字を無視する (#83)。
+        - ``format_names`` / ``type_names`` / ``alias`` / ``deprecated`` フィルタを
+          ``USER_TAG_STATUS_PATCH`` に対して適用する (#82)。
+        - ``min_usage`` / ``max_usage`` を ``USER_TAG_USAGE_PATCH`` に対して適用し、
+          単一 format 指定時は ``usage_count`` を実値で返す (#84)。
+        - ``language`` フィルタを ``USER_TAG_TRANSLATION_PATCH`` に対して適用する。
+        """
         keyword, use_like = normalize_search_keyword(keyword, partial)
+        concrete_format_names = self._concrete_names(
+            format_names or ([format_name] if format_name else None)
+        )
+        concrete_type_names = self._concrete_names(type_names or ([type_name] if type_name else None))
+
         with self.session_factory() as session:
-            query = session.query(UserTag)
-            if use_like:
-                query = query.filter(UserTag.tag.like(keyword))
-            else:
-                query = query.filter(UserTag.tag == keyword)
+            # format_id は best-effort 解決にとどめる。USER_TAG_*_PATCH は canonical (base)
+            # の format_id を保持するが、user DB は同名 format を別 id で持つことがあるため、
+            # format によるタグ除外 (hard filter) は行わず、usage scope / 行レベル値の決定に
+            # のみ用いる。format の有無判定は MergedTagReader / 下流の format_statuses に委ねる。
+            format_ids = self._format_ids_for_names(session, concrete_format_names)
+            type_name_ids = self._type_name_ids_for_names(session, concrete_type_names)
+            if concrete_type_names and not type_name_ids:
+                return []
+
+            user_tags = self._keyword_matched_user_tags(session, keyword, use_like)
+            if not user_tags:
+                return []
+            tag_by_id = {t.tag_id: t for t in user_tags}
+            candidate_ids = set(tag_by_id)
+
+            status_by_tag = self._load_status_patches(session, candidate_ids)
+            usage_by_tag = self._load_usage_patches(session, candidate_ids)
+            trans_by_tag = self._load_translation_patches(session, candidate_ids)
+            type_map = self._load_type_name_map(session)
+
+            kept_ids: list[int] = []
+            for tag_id in sorted(candidate_ids):
+                patches = status_by_tag.get(tag_id, [])
+                if not self._status_filter_ok(patches, type_map, type_name_ids, alias, deprecated):
+                    continue
+                if not self._usage_filter_ok(
+                    usage_by_tag.get(tag_id, []), format_ids, min_usage, max_usage
+                ):
+                    continue
+                if not self._language_filter_ok(trans_by_tag.get(tag_id, []), language):
+                    continue
+                kept_ids.append(tag_id)
+
             if offset:
-                query = query.offset(offset)
+                kept_ids = kept_ids[offset:]
             if limit is not None:
-                query = query.limit(limit)
-            user_tags = query.all()
+                kept_ids = kept_ids[:limit]
 
-        if not user_tags:
+            single_format_id = format_ids[0] if len(format_ids) == 1 else 0
+            return [
+                self._build_search_row(
+                    tag_by_id[tag_id],
+                    status_by_tag.get(tag_id, []),
+                    usage_by_tag.get(tag_id, []),
+                    trans_by_tag.get(tag_id, []),
+                    type_map,
+                    single_format_id,
+                )
+                for tag_id in kept_ids
+            ]
+
+    # ------------------------------------------------------------------
+    # search_tags ヘルパー
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _concrete_names(names: list[str] | None) -> list[str]:
+        """ "all" / 空文字を除いた具体的なフィルタ名のみを返す。"""
+        if not names:
             return []
+        return [name for name in names if name and name.lower() != "all"]
 
-        tag_ids = [t.tag_id for t in user_tags]
-        with self.session_factory() as session:
-            patches = (
-                session.query(UserTagStatusPatch)
-                .filter(UserTagStatusPatch.target_tag_id.in_(tag_ids))
+    def _format_ids_for_names(self, session: Session, names: list[str]) -> list[int]:
+        if not names:
+            return []
+        try:
+            rows = session.query(TagFormat.format_id).filter(TagFormat.format_name.in_(names)).all()
+        except OperationalError:
+            return []
+        return [row[0] for row in rows]
+
+    def _type_name_ids_for_names(self, session: Session, names: list[str]) -> list[int]:
+        if not names:
+            return []
+        try:
+            rows = session.query(TagTypeName.type_name_id).filter(TagTypeName.type_name.in_(names)).all()
+        except OperationalError:
+            return []
+        return [row[0] for row in rows]
+
+    def _keyword_matched_user_tags(self, session: Session, keyword: str, use_like: bool) -> list[UserTag]:
+        """tag / source_tag / 翻訳テキストのいずれかにキーワードがマッチする UserTag を返す。"""
+        tag_cond: ColumnElement[bool]
+        translation_cond: ColumnElement[bool]
+        if use_like:
+            tag_cond = or_(UserTag.tag.like(keyword), UserTag.source_tag.like(keyword))
+            translation_cond = UserTagTranslationPatch.translation.like(keyword)
+        else:
+            tag_cond = or_(
+                UserTag.tag.collate("NOCASE") == keyword,
+                UserTag.source_tag.collate("NOCASE") == keyword,
+            )
+            translation_cond = UserTagTranslationPatch.translation.collate("NOCASE") == keyword
+
+        direct = session.query(UserTag).filter(tag_cond).all()
+        direct_ids = {t.tag_id for t in direct}
+
+        translation_ids = {
+            row[0]
+            for row in session.query(UserTagTranslationPatch.target_tag_id).filter(translation_cond).all()
+        }
+        # 翻訳マッチのうち UserTag に存在するものだけを追加する (base scope の翻訳は除外)。
+        extra_ids = translation_ids - direct_ids
+        extra = session.query(UserTag).filter(UserTag.tag_id.in_(extra_ids)).all() if extra_ids else []
+        return direct + extra
+
+    def _load_status_patches(
+        self, session: Session, tag_ids: set[int]
+    ) -> dict[int, list[UserTagStatusPatch]]:
+        if not tag_ids:
+            return {}
+        patches = (
+            session.query(UserTagStatusPatch).filter(UserTagStatusPatch.target_tag_id.in_(tag_ids)).all()
+        )
+        result: dict[int, list[UserTagStatusPatch]] = {}
+        for p in patches:
+            result.setdefault(p.target_tag_id, []).append(p)
+        # format_id 昇順で並べ、format 未指定時の「先頭パッチ」を決定的にする。
+        for patch_list in result.values():
+            patch_list.sort(key=lambda p: p.format_id)
+        return result
+
+    def _load_usage_patches(
+        self, session: Session, tag_ids: set[int]
+    ) -> dict[int, list[UserTagUsagePatch]]:
+        if not tag_ids:
+            return {}
+        rows = session.query(UserTagUsagePatch).filter(UserTagUsagePatch.target_tag_id.in_(tag_ids)).all()
+        result: dict[int, list[UserTagUsagePatch]] = {}
+        for r in rows:
+            result.setdefault(r.target_tag_id, []).append(r)
+        return result
+
+    def _load_translation_patches(
+        self, session: Session, tag_ids: set[int]
+    ) -> dict[int, list[UserTagTranslationPatch]]:
+        if not tag_ids:
+            return {}
+        rows = (
+            session.query(UserTagTranslationPatch)
+            .filter(UserTagTranslationPatch.target_tag_id.in_(tag_ids))
+            .all()
+        )
+        result: dict[int, list[UserTagTranslationPatch]] = {}
+        for r in rows:
+            result.setdefault(r.target_tag_id, []).append(r)
+        return result
+
+    def _load_type_name_map(self, session: Session) -> dict[tuple[int, int], tuple[int, str]]:
+        """(format_id, type_id) → (type_name_id, type_name) のマップを返す。"""
+        try:
+            rows = (
+                session.query(
+                    TagTypeFormatMapping.format_id,
+                    TagTypeFormatMapping.type_id,
+                    TagTypeFormatMapping.type_name_id,
+                    TagTypeName.type_name,
+                )
+                .join(TagTypeName, TagTypeFormatMapping.type_name_id == TagTypeName.type_name_id)
                 .all()
             )
+        except OperationalError:
+            return {}
+        return {
+            (int(format_id), int(type_id)): (int(type_name_id), type_name)
+            for format_id, type_id, type_name_id, type_name in rows
+        }
 
-        # target_tag_id → list[UserTagStatusPatch] のマップ
-        patch_map: dict[int, list[UserTagStatusPatch]] = {}
+    def _status_filter_ok(
+        self,
+        patches: list[UserTagStatusPatch],
+        type_map: dict[tuple[int, int], tuple[int, str]],
+        type_name_ids: list[int],
+        alias: bool | None,
+        deprecated: bool | None,
+    ) -> bool:
+        """alias / deprecated / type_names フィルタを USER_TAG_STATUS_PATCH に適用する。
+
+        legacy ``filtered_tag_ids`` の status 判定に準ずる。format による除外は行わない
+        (canonical format_id を name から解決できないため、search_tags の docstring 参照)。
+        """
+        if not type_name_ids and alias is None and deprecated is None:
+            return True
+
+        if not type_name_ids:
+            if (alias is True or deprecated is True) and not any(
+                (alias is not True or p.alias is True)
+                and (deprecated is not True or bool(p.deprecated) is True)
+                for p in patches
+            ):
+                return False
+            if alias is False and any(p.alias is True for p in patches):
+                return False
+            if deprecated is False and any(bool(p.deprecated) is True for p in patches):
+                return False
+            return True
+
         for p in patches:
-            patch_map.setdefault(p.target_tag_id, []).append(p)
+            mapping = type_map.get((p.format_id, p.type_id))
+            if mapping is None or mapping[0] not in type_name_ids:
+                continue
+            if alias is not None and p.alias is not alias:
+                continue
+            if deprecated is not None and bool(p.deprecated) is not deprecated:
+                continue
+            return True
+        return False
 
-        rows: list[TagSearchRow] = []
-        for t in user_tags:
-            tag_patches = patch_map.get(t.tag_id, [])
-            first_patch = tag_patches[0] if tag_patches else None
+    def _usage_filter_ok(
+        self,
+        usages: list[UserTagUsagePatch],
+        format_ids: list[int],
+        min_usage: int | None,
+        max_usage: int | None,
+    ) -> bool:
+        if min_usage is None and max_usage is None:
+            return True
 
-            format_statuses: dict[str, dict[str, object]] = {
-                str(p.format_id): {
-                    "alias": p.alias,
-                    "deprecated": p.deprecated,
-                    "type_id": p.type_id,
-                    "preferred_tag_id": p.preferred_tag_id,
-                }
-                for p in tag_patches
+        def in_scope(usage: UserTagUsagePatch) -> bool:
+            return not format_ids or usage.format_id in format_ids
+
+        matching = any(
+            in_scope(usage)
+            and (min_usage is None or usage.count >= min_usage)
+            and (max_usage is None or usage.count <= max_usage)
+            for usage in usages
+        )
+        if matching:
+            return True
+        # usage パッチが無いタグは、しきい値が 0 を含むときのみ残す (legacy と同じ挙動)。
+        include_missing = (min_usage is None or min_usage <= 0) and (max_usage is None or max_usage >= 0)
+        if include_missing and not any(in_scope(usage) for usage in usages):
+            return True
+        return False
+
+    def _language_filter_ok(
+        self, translations: list[UserTagTranslationPatch], language: str | None
+    ) -> bool:
+        if not language or language.lower() == "all":
+            return True
+        return any(t.language == language for t in translations)
+
+    def _build_search_row(
+        self,
+        tag: UserTag,
+        patches: list[UserTagStatusPatch],
+        usages: list[UserTagUsagePatch],
+        translations: list[UserTagTranslationPatch],
+        type_map: dict[tuple[int, int], tuple[int, str]],
+        single_format_id: int,
+    ) -> TagSearchRow:
+        usage_by_format = {u.format_id: u.count for u in usages}
+
+        if single_format_id:
+            active = next((p for p in patches if p.format_id == single_format_id), None)
+        else:
+            active = patches[0] if patches else None
+
+        if active is not None:
+            mapping = type_map.get((active.format_id, active.type_id))
+            row_alias = active.alias
+            row_deprecated = bool(active.deprecated)
+            row_type_id: int | None = active.type_id
+            row_type_name = mapping[1] if mapping else ""
+            # legacy 同様、単一 format 指定時のみ usage_count を実値で返す。
+            row_usage = usage_by_format.get(active.format_id, 0) if single_format_id else 0
+        else:
+            row_alias = False
+            row_deprecated = False
+            row_type_id = None
+            row_type_name = ""
+            row_usage = 0
+
+        translations_dict: dict[str, list[str]] = {}
+        for t in translations:
+            if t.language and t.translation:
+                translations_dict.setdefault(t.language, []).append(t.translation)
+
+        format_statuses: dict[str, dict[str, object]] = {}
+        for p in patches:
+            mapping = type_map.get((p.format_id, p.type_id))
+            format_statuses[str(p.format_id)] = {
+                "alias": p.alias,
+                "deprecated": bool(p.deprecated),
+                "usage_count": usage_by_format.get(p.format_id, 0),
+                "type_id": p.type_id,
+                "type_name": mapping[1] if mapping else "",
+                "preferred_tag_id": p.preferred_tag_id,
             }
 
-            row: TagSearchRow = {
-                "tag_id": t.tag_id,
-                "tag": t.tag,
-                "source_tag": t.source_tag,
-                "usage_count": 0,
-                "alias": first_patch.alias if first_patch else False,
-                "deprecated": first_patch.deprecated if first_patch else False,
-                "type_id": first_patch.type_id if first_patch else None,
-                "type_name": "",
-                "translations": {},
-                "format_statuses": format_statuses,
-            }
-            rows.append(row)
-        return rows
+        return {
+            "tag_id": tag.tag_id,
+            "tag": tag.tag,
+            "source_tag": tag.source_tag,
+            "usage_count": row_usage,
+            "alias": row_alias,
+            "deprecated": row_deprecated,
+            "type_id": row_type_id,
+            "type_name": row_type_name,
+            "translations": translations_dict,
+            "format_statuses": format_statuses,
+        }
 
     # ------------------------------------------------------------------
     # 翻訳取得 (USER_TAG_TRANSLATION_PATCH)
@@ -416,8 +680,7 @@ class OverlayTagReader:
                 query = query.filter(UserTagUsagePatch.format_id == format_id)
             rows = query.all()
             return [
-                TagUsageCounts(tag_id=r.target_tag_id, format_id=r.format_id, count=r.count)
-                for r in rows
+                TagUsageCounts(tag_id=r.target_tag_id, format_id=r.format_id, count=r.count) for r in rows
             ]
 
     def get_tag_types(self, format_id: int) -> list[str]:

--- a/tests/unit/test_overlay_reader.py
+++ b/tests/unit/test_overlay_reader.py
@@ -1,4 +1,5 @@
 """OverlayTagReader の単体テスト。"""
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -21,6 +22,8 @@ from genai_tag_db_tools.db.schema import (
     UserOverlayBase,
     UserTag,
     UserTagStatusPatch,
+    UserTagTranslationPatch,
+    UserTagUsagePatch,
 )
 from genai_tag_db_tools.models import TagSearchRow
 
@@ -376,7 +379,9 @@ class TestOverlayTagReaderSearch:
         assert rows[0]["type_id"] == 5
         assert rows[0]["format_statuses"]["danbooru"]["deprecated"] is True
 
-    def test_merged_search_filters_after_base_scope_status_patch(self, overlay_reader, overlay_session_factory):
+    def test_merged_search_filters_after_base_scope_status_patch(
+        self, overlay_reader, overlay_session_factory
+    ):
         with overlay_session_factory() as session:
             session.add(
                 UserTagStatusPatch(
@@ -395,12 +400,16 @@ class TestOverlayTagReaderSearch:
         merged = MergedTagReader(base_repo=self._BaseSearchReader(), user_repo=overlay_reader)
 
         assert merged.search_tags("blue eyes", format_name="danbooru", deprecated=False) == []
-        rows = merged.search_tags("blue eyes", format_name="danbooru", deprecated=True, type_name="character")
+        rows = merged.search_tags(
+            "blue eyes", format_name="danbooru", deprecated=True, type_name="character"
+        )
         assert len(rows) == 1
         assert rows[0]["type_id"] == 4
         assert rows[0]["type_name"] == "character"
 
-    def test_merged_search_applies_base_scope_usage_patch_to_filters(self, overlay_reader, overlay_session_factory):
+    def test_merged_search_applies_base_scope_usage_patch_to_filters(
+        self, overlay_reader, overlay_session_factory
+    ):
         with overlay_session_factory() as session:
             session.add(
                 UserTagStatusPatch(
@@ -428,7 +437,9 @@ class TestOverlayTagReaderSearch:
         assert rows[0]["usage_count"] == 123
         assert rows[0]["format_statuses"]["danbooru"]["usage_count"] == 123
 
-    def test_merged_search_finds_base_scope_translation_patch(self, overlay_reader, overlay_session_factory):
+    def test_merged_search_finds_base_scope_translation_patch(
+        self, overlay_reader, overlay_session_factory
+    ):
         from genai_tag_db_tools.db.user_tag_repository import UserTagRepository
 
         user_repo = UserTagRepository(overlay_session_factory)
@@ -463,6 +474,242 @@ class TestOverlayTagReaderSearch:
 
         assert result["blue eyes"]["tag_id"] == 99
         assert result["blue eyes"]["tag"] == "azure eyes"
+
+
+class TestOverlayTagReaderSearchFilters:
+    """search_tags の filter / 翻訳 / source_tag / usage 実装を検証する (#82/#83/#84)。"""
+
+    def _make_status(
+        self,
+        tag_id: int,
+        format_id: int,
+        *,
+        type_id: int = 0,
+        alias: bool = False,
+        deprecated: bool = False,
+    ) -> UserTagStatusPatch:
+        # CHECK 制約: alias=True のときは preferred を target と別にする必要がある。
+        preferred_tag_id = tag_id if not alias else tag_id + 1
+        return UserTagStatusPatch(
+            target_scope="user",
+            target_tag_id=tag_id,
+            format_id=format_id,
+            type_id=type_id,
+            alias=alias,
+            preferred_scope="user",
+            preferred_tag_id=preferred_tag_id,
+            deprecated=deprecated,
+        )
+
+    # --- #83: source_tag / 翻訳 / case-insensitive 検索 ---
+
+    def test_search_matches_source_tag(self, overlay_reader, overlay_session_factory):
+        tag_id = USER_TAG_ID_OFFSET + 400
+        with overlay_session_factory() as session:
+            session.add(UserTag(tag_id=tag_id, source_tag="raw_source", tag="normalized tag"))
+            session.commit()
+
+        rows = overlay_reader.search_tags("raw_source")
+        assert len(rows) == 1
+        assert rows[0]["tag_id"] == tag_id
+
+    def test_search_exact_is_case_insensitive(self, overlay_reader, overlay_session_factory):
+        tag_id = USER_TAG_ID_OFFSET + 401
+        with overlay_session_factory() as session:
+            session.add(UserTag(tag_id=tag_id, source_tag="MixedCaseSrc", tag="MixedCase"))
+            session.commit()
+
+        assert overlay_reader.search_tags("mixedcase")[0]["tag_id"] == tag_id
+        assert overlay_reader.search_tags("MIXEDCASESRC")[0]["tag_id"] == tag_id
+
+    def test_search_matches_translation_text(self, overlay_reader, overlay_session_factory):
+        tag_id = USER_TAG_ID_OFFSET + 402
+        with overlay_session_factory() as session:
+            session.add(UserTag(tag_id=tag_id, source_tag="cat_src", tag="cat"))
+            session.add(
+                UserTagTranslationPatch(
+                    target_scope="user", target_tag_id=tag_id, language="ja", translation="猫"
+                )
+            )
+            session.commit()
+
+        rows = overlay_reader.search_tags("猫")
+        assert len(rows) == 1
+        assert rows[0]["tag_id"] == tag_id
+        assert rows[0]["translations"] == {"ja": ["猫"]}
+
+    def test_search_populates_translations(self, overlay_reader, overlay_session_factory):
+        tag_id = USER_TAG_ID_OFFSET + 403
+        with overlay_session_factory() as session:
+            session.add(UserTag(tag_id=tag_id, source_tag="dog_src", tag="dog"))
+            session.add(
+                UserTagTranslationPatch(
+                    target_scope="user", target_tag_id=tag_id, language="ja", translation="犬"
+                )
+            )
+            session.commit()
+
+        rows = overlay_reader.search_tags("dog")
+        assert rows[0]["translations"] == {"ja": ["犬"]}
+
+    # --- #82: alias / deprecated / type_names filters ---
+
+    def test_alias_false_excludes_alias_tags(self, overlay_reader, overlay_session_factory):
+        normal_id = USER_TAG_ID_OFFSET + 410
+        alias_id = USER_TAG_ID_OFFSET + 411
+        with overlay_session_factory() as session:
+            session.add(UserTag(tag_id=normal_id, source_tag="f1", tag="filter normal"))
+            session.add(UserTag(tag_id=alias_id, source_tag="f2", tag="filter alias"))
+            session.add(self._make_status(normal_id, 1000, alias=False))
+            session.add(self._make_status(alias_id, 1000, alias=True))
+            session.commit()
+
+        rows = overlay_reader.search_tags("filter", partial=True, alias=False)
+        ids = {r["tag_id"] for r in rows}
+        assert ids == {normal_id}
+
+    def test_alias_true_keeps_only_alias_tags(self, overlay_reader, overlay_session_factory):
+        normal_id = USER_TAG_ID_OFFSET + 412
+        alias_id = USER_TAG_ID_OFFSET + 413
+        with overlay_session_factory() as session:
+            session.add(UserTag(tag_id=normal_id, source_tag="g1", tag="aliasflag normal"))
+            session.add(UserTag(tag_id=alias_id, source_tag="g2", tag="aliasflag alias"))
+            session.add(self._make_status(normal_id, 1000, alias=False))
+            session.add(self._make_status(alias_id, 1000, alias=True))
+            session.commit()
+
+        rows = overlay_reader.search_tags("aliasflag", partial=True, alias=True)
+        assert {r["tag_id"] for r in rows} == {alias_id}
+
+    def test_deprecated_false_excludes_deprecated_tags(self, overlay_reader, overlay_session_factory):
+        live_id = USER_TAG_ID_OFFSET + 414
+        dead_id = USER_TAG_ID_OFFSET + 415
+        with overlay_session_factory() as session:
+            session.add(UserTag(tag_id=live_id, source_tag="h1", tag="depr live"))
+            session.add(UserTag(tag_id=dead_id, source_tag="h2", tag="depr dead"))
+            session.add(self._make_status(live_id, 1000, deprecated=False))
+            session.add(self._make_status(dead_id, 1000, deprecated=True))
+            session.commit()
+
+        rows = overlay_reader.search_tags("depr", partial=True, deprecated=False)
+        assert {r["tag_id"] for r in rows} == {live_id}
+
+    def test_type_names_filter(self, overlay_reader, overlay_session_factory):
+        char_id = USER_TAG_ID_OFFSET + 416
+        general_id = USER_TAG_ID_OFFSET + 417
+        with overlay_session_factory() as session:
+            session.add(TagFormat(format_id=1000, format_name="danbooru"))
+            session.add(TagTypeName(type_name_id=1, type_name="general"))
+            session.add(TagTypeName(type_name_id=4, type_name="character"))
+            session.add(TagTypeFormatMapping(format_id=1000, type_id=0, type_name_id=1))
+            session.add(TagTypeFormatMapping(format_id=1000, type_id=4, type_name_id=4))
+            session.add(UserTag(tag_id=char_id, source_tag="t1", tag="typefilter char"))
+            session.add(UserTag(tag_id=general_id, source_tag="t2", tag="typefilter general"))
+            session.add(self._make_status(char_id, 1000, type_id=4))
+            session.add(self._make_status(general_id, 1000, type_id=0))
+            session.commit()
+
+        rows = overlay_reader.search_tags("typefilter", partial=True, type_names=["character"])
+        assert {r["tag_id"] for r in rows} == {char_id}
+        assert rows[0]["type_name"] == "character"
+
+    def test_type_names_unknown_returns_empty(self, overlay_reader, overlay_session_factory):
+        tag_id = USER_TAG_ID_OFFSET + 418
+        with overlay_session_factory() as session:
+            session.add(UserTag(tag_id=tag_id, source_tag="u1", tag="unknowntype tag"))
+            session.add(self._make_status(tag_id, 1000))
+            session.commit()
+
+        assert overlay_reader.search_tags("unknowntype", partial=True, type_names=["nope"]) == []
+
+    # --- #84: usage filters & usage_count ---
+
+    def test_usage_count_populated_for_single_format(self, overlay_reader, overlay_session_factory):
+        tag_id = USER_TAG_ID_OFFSET + 420
+        with overlay_session_factory() as session:
+            session.add(TagFormat(format_id=1000, format_name="danbooru"))
+            session.add(UserTag(tag_id=tag_id, source_tag="uc_src", tag="usage tag"))
+            session.add(self._make_status(tag_id, 1000))
+            session.add(
+                UserTagUsagePatch(target_scope="user", target_tag_id=tag_id, format_id=1000, count=123)
+            )
+            session.commit()
+
+        rows = overlay_reader.search_tags("usage tag", format_name="danbooru")
+        assert len(rows) == 1
+        assert rows[0]["usage_count"] == 123
+        assert rows[0]["format_statuses"]["1000"]["usage_count"] == 123
+
+    def test_min_usage_filters_out_low_counts(self, overlay_reader, overlay_session_factory):
+        high_id = USER_TAG_ID_OFFSET + 421
+        low_id = USER_TAG_ID_OFFSET + 422
+        with overlay_session_factory() as session:
+            session.add(TagFormat(format_id=1000, format_name="danbooru"))
+            session.add(UserTag(tag_id=high_id, source_tag="m1", tag="minusage high"))
+            session.add(UserTag(tag_id=low_id, source_tag="m2", tag="minusage low"))
+            session.add(self._make_status(high_id, 1000))
+            session.add(self._make_status(low_id, 1000))
+            session.add(
+                UserTagUsagePatch(target_scope="user", target_tag_id=high_id, format_id=1000, count=500)
+            )
+            session.add(
+                UserTagUsagePatch(target_scope="user", target_tag_id=low_id, format_id=1000, count=5)
+            )
+            session.commit()
+
+        rows = overlay_reader.search_tags("minusage", partial=True, format_name="danbooru", min_usage=100)
+        assert {r["tag_id"] for r in rows} == {high_id}
+
+    def test_max_usage_filters_out_high_counts(self, overlay_reader, overlay_session_factory):
+        high_id = USER_TAG_ID_OFFSET + 423
+        low_id = USER_TAG_ID_OFFSET + 424
+        with overlay_session_factory() as session:
+            session.add(TagFormat(format_id=1000, format_name="danbooru"))
+            session.add(UserTag(tag_id=high_id, source_tag="x1", tag="maxusage high"))
+            session.add(UserTag(tag_id=low_id, source_tag="x2", tag="maxusage low"))
+            session.add(self._make_status(high_id, 1000))
+            session.add(self._make_status(low_id, 1000))
+            session.add(
+                UserTagUsagePatch(target_scope="user", target_tag_id=high_id, format_id=1000, count=500)
+            )
+            session.add(
+                UserTagUsagePatch(target_scope="user", target_tag_id=low_id, format_id=1000, count=5)
+            )
+            session.commit()
+
+        rows = overlay_reader.search_tags("maxusage", partial=True, format_name="danbooru", max_usage=100)
+        assert {r["tag_id"] for r in rows} == {low_id}
+
+    def test_language_filter(self, overlay_reader, overlay_session_factory):
+        ja_id = USER_TAG_ID_OFFSET + 425
+        en_id = USER_TAG_ID_OFFSET + 426
+        with overlay_session_factory() as session:
+            session.add(UserTag(tag_id=ja_id, source_tag="l1", tag="langfilter ja"))
+            session.add(UserTag(tag_id=en_id, source_tag="l2", tag="langfilter en"))
+            session.add(
+                UserTagTranslationPatch(
+                    target_scope="user", target_tag_id=ja_id, language="ja", translation="あ"
+                )
+            )
+            session.add(
+                UserTagTranslationPatch(
+                    target_scope="user", target_tag_id=en_id, language="en", translation="a"
+                )
+            )
+            session.commit()
+
+        rows = overlay_reader.search_tags("langfilter", partial=True, language="ja")
+        assert {r["tag_id"] for r in rows} == {ja_id}
+
+    def test_limit_and_offset_applied_after_filters(self, overlay_reader, overlay_session_factory):
+        ids = [USER_TAG_ID_OFFSET + 430 + i for i in range(3)]
+        with overlay_session_factory() as session:
+            for i, tag_id in enumerate(ids):
+                session.add(UserTag(tag_id=tag_id, source_tag=f"p{i}", tag=f"paging tag {i}"))
+            session.commit()
+
+        page = overlay_reader.search_tags("paging", partial=True, limit=2, offset=1)
+        assert [r["tag_id"] for r in page] == ids[1:3]
 
 
 class TestOverlayTagReaderMetadata:


### PR DESCRIPTION
## 概要

`OverlayTagReader.search_tags` を legacy `TagReader.search_tags` と同じ契約に揃え、
レガシー DB を user DB へ移行した後に失われていた検索挙動を復元する。3つの issue が
同一メソッドに集中しているため一括で対応した。

## 変更内容

### #83 翻訳テキスト / source_tag / 大小文字無視検索
- キーワードを `UserTag.tag` だけでなく `UserTag.source_tag` と
  `USER_TAG_TRANSLATION_PATCH.translation` にも照合する。
- 完全一致 (`partial=False`) を `COLLATE NOCASE` で大小文字無視にする。
- 結果行の `translations` を `USER_TAG_TRANSLATION_PATCH` から構築する。
- `language` フィルタを追加。

### #82 alias / deprecated / type_names フィルタ
- `alias` / `deprecated` / `type_names` を `USER_TAG_STATUS_PATCH` に対して適用する。
- `format` は best-effort 解決にとどめ、usage scope と行レベル値の決定のみに使用する。
  `USER_TAG_*_PATCH` は canonical (base) の `format_id` を保持し、user DB は同名 format を
  別 id で持つ場合があるため、format によるタグ除外 (hard filter) は行わず、format 有無の
  判定は MergedTagReader / 下流の `format_statuses` に委ねる。

### #84 min_usage / max_usage フィルタと usage_count
- `min_usage` / `max_usage` を `USER_TAG_USAGE_PATCH` に対して適用する。
- 単一 format 指定時は `usage_count` を実値で返す (legacy と同じ挙動)。
- `format_statuses` の各エントリに `usage_count` / `type_name` を付与 (既存の
  `str(format_id)` キーは維持)。

## テスト
- `tests/unit/test_overlay_reader.py` に source_tag / case-insensitive / 翻訳・言語検索、
  alias / deprecated / type_names フィルタ、usage_count 反映、min/max_usage フィルタ、
  limit/offset ページングのユニットテストを追加。
- `uv run pytest -q`: 633 passed (baseline 619 + 14)
- `uv run ruff check .` / `uv run ruff format --check`: pass
- `uv run mypy src`: pass

Closes #82
Closes #83
Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)