### PR TITLE
feat(overlay): implement type-method stubs in OverlayTagReader (#100)

### DIFF
--- a/src/genai_tag_db_tools/db/overlay_reader.py
+++ b/src/genai_tag_db_tools/db/overlay_reader.py
@@ -684,13 +684,76 @@ class OverlayTagReader:
             ]
 
     def get_tag_types(self, format_id: int) -> list[str]:
-        return []
+        """指定 format で使われている type_name の一覧を返す。
+
+        ``TAG_TYPE_FORMAT_MAPPING JOIN TAG_TYPE_NAME`` を ``format_id`` で絞り込み、
+        distinct な type_name を返す。
+        """
+        try:
+            with self.session_factory() as session:
+                rows = (
+                    session.query(TagTypeName.type_name)
+                    .join(
+                        TagTypeFormatMapping,
+                        TagTypeName.type_name_id == TagTypeFormatMapping.type_name_id,
+                    )
+                    .filter(TagTypeFormatMapping.format_id == format_id)
+                    .distinct()
+                    .all()
+                )
+        except OperationalError:
+            return []
+        return [row[0] for row in rows]
 
     def get_all_types(self) -> list[str]:
-        return []
+        """user DB の ``TAG_TYPE_NAME.type_name`` を全件返す。"""
+        try:
+            with self.session_factory() as session:
+                rows = session.query(TagTypeName.type_name).all()
+        except OperationalError:
+            return []
+        return [row[0] for row in rows]
 
     def get_unknown_type_tag_ids(self, format_id: int) -> list[int]:
-        return []
+        """指定 format で type_name="unknown" にマップされる tag_id 一覧を返す。
+
+        ``TAG_TYPE_NAME`` から "unknown" の type_name_id を解決し、
+        ``TAG_TYPE_FORMAT_MAPPING`` で当該 format の type_id を求めた上で、
+        ``USER_TAG_STATUS_PATCH`` の target_tag_id を重複なく返す。
+        """
+        try:
+            with self.session_factory() as session:
+                unknown_type = (
+                    session.query(TagTypeName.type_name_id)
+                    .filter(TagTypeName.type_name == "unknown")
+                    .one_or_none()
+                )
+                if unknown_type is None:
+                    return []
+
+                mapping = (
+                    session.query(TagTypeFormatMapping.type_id)
+                    .filter(
+                        TagTypeFormatMapping.format_id == format_id,
+                        TagTypeFormatMapping.type_name_id == unknown_type[0],
+                    )
+                    .one_or_none()
+                )
+                if mapping is None:
+                    return []
+
+                rows = (
+                    session.query(UserTagStatusPatch.target_tag_id)
+                    .filter(
+                        UserTagStatusPatch.format_id == format_id,
+                        UserTagStatusPatch.type_id == mapping[0],
+                    )
+                    .distinct()
+                    .all()
+                )
+        except OperationalError:
+            return []
+        return [row[0] for row in rows]
 
     def get_metadata_value(self, key: str) -> str | None:
         return None

--- a/tests/unit/test_overlay_reader.py
+++ b/tests/unit/test_overlay_reader.py
@@ -740,6 +740,128 @@ class TestOverlayTagReaderMetadata:
         assert overlay_reader.get_type_id_for_format("meta", 3001) == 5
 
 
+class TestOverlayTagReaderTypeMethods:
+    """get_all_types / get_tag_types / get_unknown_type_tag_ids を検証する (#100)。"""
+
+    def _seed_types(self, session) -> None:
+        session.add(TagFormat(format_id=3001, format_name="lorairo"))
+        session.add(TagFormat(format_id=3002, format_name="other"))
+        session.add(TagTypeName(type_name_id=1, type_name="general"))
+        session.add(TagTypeName(type_name_id=4, type_name="character"))
+        session.add(TagTypeName(type_name_id=99, type_name="unknown"))
+        # lorairo: general(0) / character(4) / unknown(7)
+        session.add(TagTypeFormatMapping(format_id=3001, type_id=0, type_name_id=1))
+        session.add(TagTypeFormatMapping(format_id=3001, type_id=4, type_name_id=4))
+        session.add(TagTypeFormatMapping(format_id=3001, type_id=7, type_name_id=99))
+        # other: general(0) のみ
+        session.add(TagTypeFormatMapping(format_id=3002, type_id=0, type_name_id=1))
+
+    def test_get_all_types(self, overlay_reader, overlay_session_factory):
+        with overlay_session_factory() as session:
+            self._seed_types(session)
+            session.commit()
+
+        assert set(overlay_reader.get_all_types()) == {"general", "character", "unknown"}
+
+    def test_get_all_types_empty(self, overlay_reader):
+        assert overlay_reader.get_all_types() == []
+
+    def test_get_tag_types_filters_by_format(self, overlay_reader, overlay_session_factory):
+        with overlay_session_factory() as session:
+            self._seed_types(session)
+            session.commit()
+
+        assert set(overlay_reader.get_tag_types(3001)) == {"general", "character", "unknown"}
+        assert overlay_reader.get_tag_types(3002) == ["general"]
+
+    def test_get_tag_types_unknown_format(self, overlay_reader, overlay_session_factory):
+        with overlay_session_factory() as session:
+            self._seed_types(session)
+            session.commit()
+
+        assert overlay_reader.get_tag_types(9999) == []
+
+    def test_get_unknown_type_tag_ids(self, overlay_reader, overlay_session_factory):
+        unknown_id = USER_TAG_ID_OFFSET + 500
+        general_id = USER_TAG_ID_OFFSET + 501
+        with overlay_session_factory() as session:
+            self._seed_types(session)
+            session.add(UserTag(tag_id=unknown_id, source_tag="u_src", tag="unknown tag"))
+            session.add(UserTag(tag_id=general_id, source_tag="g_src", tag="general tag"))
+            session.add(
+                UserTagStatusPatch(
+                    target_scope="user",
+                    target_tag_id=unknown_id,
+                    format_id=3001,
+                    type_id=7,  # unknown
+                    alias=False,
+                    preferred_scope="user",
+                    preferred_tag_id=unknown_id,
+                    deprecated=False,
+                )
+            )
+            session.add(
+                UserTagStatusPatch(
+                    target_scope="user",
+                    target_tag_id=general_id,
+                    format_id=3001,
+                    type_id=0,  # general
+                    alias=False,
+                    preferred_scope="user",
+                    preferred_tag_id=general_id,
+                    deprecated=False,
+                )
+            )
+            session.commit()
+
+        assert overlay_reader.get_unknown_type_tag_ids(3001) == [unknown_id]
+
+    def test_get_unknown_type_tag_ids_no_unknown_mapping(self, overlay_reader, overlay_session_factory):
+        with overlay_session_factory() as session:
+            self._seed_types(session)
+            session.commit()
+
+        # format 3002 には unknown のマッピングが無い
+        assert overlay_reader.get_unknown_type_tag_ids(3002) == []
+
+    def test_get_unknown_type_tag_ids_empty(self, overlay_reader):
+        assert overlay_reader.get_unknown_type_tag_ids(3001) == []
+
+    def test_merged_aggregates_type_methods(self, overlay_reader, overlay_session_factory):
+        """MergedTagReader 経由でも overlay の type 系メソッドが集約されることを確認する。"""
+        unknown_id = USER_TAG_ID_OFFSET + 510
+        with overlay_session_factory() as session:
+            self._seed_types(session)
+            session.add(UserTag(tag_id=unknown_id, source_tag="m_src", tag="merged unknown"))
+            session.add(
+                UserTagStatusPatch(
+                    target_scope="user",
+                    target_tag_id=unknown_id,
+                    format_id=3001,
+                    type_id=7,
+                    alias=False,
+                    preferred_scope="user",
+                    preferred_tag_id=unknown_id,
+                    deprecated=False,
+                )
+            )
+            session.commit()
+
+        class _EmptyBase:
+            def _empty(self, *a, **k):
+                return []
+
+            get_all_types = get_tag_types = get_unknown_type_tag_ids = _empty
+
+            def _iter_repos_marker(self):  # pragma: no cover - not used
+                return []
+
+        merged = MergedTagReader(base_repo=_EmptyBase(), user_repo=overlay_reader)
+        assert set(merged.get_all_types()) == {"general", "character", "unknown"}
+        assert set(merged.get_tag_types(3001)) == {"general", "character", "unknown"}
+        assert merged.get_unknown_type_tag_ids(3001) == [unknown_id]
+
+
 class TestOverlayTagReaderEmpty:
     """空 DB で各メソッドが安全にデフォルト値を返すことを検証する。"""
 


### PR DESCRIPTION
## 概要

`OverlayTagReader` の以下3メソッドが空スタブ（`return []`）のままだったのを、user DB を参照する実装に置き換える。LoRAIro #938 (TagManagementService overlay 対応) のブロッカーを解消する。Closes #100。

## 実装

| メソッド | クエリ |
|---|---|
| `get_all_types()` | `TAG_TYPE_NAME.type_name` 全件 |
| `get_tag_types(format_id)` | `TAG_TYPE_FORMAT_MAPPING JOIN TAG_TYPE_NAME` を `format_id` で絞り込み distinct type_name |
| `get_unknown_type_tag_ids(format_id)` | `TAG_TYPE_NAME` から `"unknown"` を解決 → 当該 format の type_id → `USER_TAG_STATUS_PATCH.target_tag_id` を distinct |

- `OverlayTagReader` の他メソッドと同様、`OperationalError` は `[]` にフォールバック。
- `get_unknown_type_tag_ids` は `TagReader` の参考実装と同じ「unknown type_name → format ごとの type_id 解決」ロジックだが、参照先を base の `TAG_STATUS` ではなく user の `USER_TAG_STATUS_PATCH` にしている。

## テスト

`tests/unit/test_overlay_reader.py` に `TestOverlayTagReaderTypeMethods` を追加（空DB・format絞り込み・unknown解決・`MergedTagReader` 経由の集約）。

- 新規テスト含め `test_overlay_reader.py` 59 passed
- 全 unit スイート 634 passed
- `ruff check` / `ruff format --check` / `mypy src/.../overlay_reader.py` すべて green

🤖 Generated with [Claude Code](https://claude.com/claude-code)