### PR TITLE
docs: apply OKF YAML frontmatter policy to all docs (#103)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 ---
-type: doc
+type: Reference
 title: genai-tag-db-tools
 status: Accepted
 timestamp: 2026-06-29
-tags: [readme, overview]
+tags: [overview, cli, search, overlay, recommendation]
+depends_on: [pyside6, sqlalchemy, sqlite, pydantic, polars, huggingface-hub]
 ---
 
 # genai-tag-db-tools

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,9 +1,10 @@
 ---
-type: doc
+type: Contract
 title: tag-db CLI Contract
 status: Accepted
 timestamp: 2026-06-29
-tags: [cli, contract]
+tags: [cli, search, db-read, db-write, tag-conversion]
+depends_on: [pydantic, sqlalchemy, sqlite]
 ---
 
 # tag-db CLI Contract

--- a/docs/decisions/0001-cli-default-database-source-policy.md
+++ b/docs/decisions/0001-cli-default-database-source-policy.md
@@ -4,7 +4,8 @@ title: "ADR 0001: CLI Default Database Source Policy"
 status: Accepted
 timestamp: 2026-06-02
 deciders: NEXTAltair
-tags: []
+tags: [cli, config, db-read]
+depends_on: [sqlite, huggingface-hub]
 ---
 
 # ADR 0001: CLI Default Database Source Policy

--- a/docs/decisions/0002-cli-gui-entrypoint-policy.md
+++ b/docs/decisions/0002-cli-gui-entrypoint-policy.md
@@ -4,7 +4,8 @@ title: "ADR 0002: CLI and GUI Entrypoint Policy"
 status: Accepted
 timestamp: 2026-06-02
 deciders: NEXTAltair
-tags: []
+tags: [cli, gui-view, packaging]
+depends_on: [pyside6, argparse]
 ---
 
 # ADR 0002: CLI and GUI Entrypoint Policy

--- a/docs/decisions/0003-cli-jsonl-output-and-error-contract.md
+++ b/docs/decisions/0003-cli-jsonl-output-and-error-contract.md
@@ -4,7 +4,8 @@ title: "ADR 0003: CLI JSONL Output and Structured Error Contract"
 status: Accepted
 timestamp: 2026-06-02
 deciders: NEXTAltair
-tags: []
+tags: [cli, error-handling, validation]
+depends_on: [pydantic]
 ---
 
 # ADR 0003: CLI JSONL Output and Structured Error Contract

--- a/docs/decisions/0004-search-bounded-and-correct-pagination.md
+++ b/docs/decisions/0004-search-bounded-and-correct-pagination.md
@@ -4,7 +4,8 @@ title: "ADR 0004: Bounded and Correct Search Pagination"
 status: Accepted
 timestamp: 2026-06-02
 deciders: NEXTAltair
-tags: []
+tags: [search, pagination, db-read]
+depends_on: [sqlalchemy, sqlite]
 ---
 
 # ADR 0004: Bounded and Correct Search Pagination

--- a/docs/decisions/0005-cli-command-introspection.md
+++ b/docs/decisions/0005-cli-command-introspection.md
@@ -4,7 +4,8 @@ title: "ADR 0005: CLI Command Introspection Contract"
 status: Accepted
 timestamp: 2026-06-02
 deciders: NEXTAltair
-tags: []
+tags: [cli, introspection]
+depends_on: [pydantic]
 ---
 
 # ADR 0005: CLI Command Introspection Contract

--- a/docs/decisions/0006-search-filter-pushdown-and-merged-pagination.md
+++ b/docs/decisions/0006-search-filter-pushdown-and-merged-pagination.md
@@ -4,7 +4,8 @@ title: "ADR 0006: Search Filter Pushdown and Merged Pagination"
 status: Accepted
 timestamp: 2026-06-03
 deciders: NEXTAltair
-tags: []
+tags: [search, pagination, db-read, overlay]
+depends_on: [sqlalchemy, sqlite]
 ---
 
 # ADR 0006: Search Filter Pushdown and Merged Pagination

--- a/docs/decisions/0007-user-overlay-patch-db.md
+++ b/docs/decisions/0007-user-overlay-patch-db.md
@@ -4,7 +4,8 @@ title: "ADR 0007: User Overlay Patch DB"
 status: Accepted
 timestamp: 2026-06-29
 deciders: NEXTAltair
-tags: [database, overlay, schema]
+tags: [overlay, db-read, db-write, schema]
+depends_on: [sqlalchemy, sqlite]
 ---
 
 # ADR 0007: User Overlay Patch DB

--- a/docs/decisions/0008-stable-public-api-boundary.md
+++ b/docs/decisions/0008-stable-public-api-boundary.md
@@ -4,7 +4,8 @@ title: "ADR 0008: Stable Public API Boundary"
 status: Accepted
 timestamp: 2026-06-29
 deciders: NEXTAltair
-tags: [api, boundary, packaging]
+tags: [public-api, packaging, service-layer]
+depends_on: [pydantic]
 ---
 
 # ADR 0008: Stable Public API Boundary

--- a/docs/decisions/0009-recommendation-advisory-and-feedback-routing.md
+++ b/docs/decisions/0009-recommendation-advisory-and-feedback-routing.md
@@ -5,6 +5,7 @@ status: Accepted
 timestamp: 2026-06-29
 deciders: NEXTAltair
 tags: [recommendation, feedback, advisory]
+depends_on: [pydantic]
 ---
 
 # ADR 0009: Recommendation Advisory and Feedback Routing

--- a/docs/decisions/0010-okf-frontmatter-for-docs.md
+++ b/docs/decisions/0010-okf-frontmatter-for-docs.md
@@ -1,0 +1,133 @@
+---
+type: ADR
+title: "ADR 0010: OKF YAML Frontmatter for Documentation"
+status: Accepted
+timestamp: 2026-06-29
+deciders: NEXTAltair
+tags: [docs, frontmatter, metadata]
+depends_on: [yaml]
+---
+
+# ADR 0010: OKF YAML Frontmatter for Documentation
+
+## Context
+
+ADR 0001–0009 までは ADR 限定で YAML frontmatter（`type` / `title` / `status` /
+`timestamp` / `deciders` / `tags`）を導入した（#103, PR #104）。しかし `docs/` 配下の
+非 ADR ドキュメント（`README.md` / `docs/cli.md` / `docs/investigations/**` /
+`docs/superpowers/**`）には共通の frontmatter 規約が無く、種別もまちまちだった。
+
+下流の LoRAIro は ADR 0069 で OKF（Open Knowledge Foundation 風）YAML frontmatter を
+ドキュメントの SSoT として扱う方針を採り、通常ドキュメントへも拡張する方針を
+LoRAIro#971 で定義している。本リポジトリは LoRAIro に消費される下流パッケージであり、
+横断検索・索引生成・エージェント参照を揃えるため、同じ frontmatter 規約に寄せる。
+
+参考: LoRAIro ADR 0069 / LoRAIro#971（OKF frontmatter policy for documentation）。
+
+## Decision
+
+`docs/` 配下の Markdown ドキュメントは、先頭に **YAML frontmatter（`---` で囲む）** を
+持つことを規約とする。LoRAIro#971 の OKF 仕様に準拠する。
+
+### フィールド
+
+| キー | 必須 | 説明 |
+|------|------|------|
+| `type` | ✅ | 文書種別（下記語彙） |
+| `title` | ✅ | 表示タイトル |
+| `status` | ✅ | 状態（下記語彙） |
+| `timestamp` | ✅ | 作成日・決定日・最終重要更新日。`YYYY-MM-DD` |
+| `tags` | 任意 | 機能・責務・動作の抽象分類（技術名は入れない） |
+| `depends_on` | 任意 | 強く依存する技術・ライブラリ・外部仕様 |
+| `deciders` | ADR のみ | 決定者 |
+
+- `version` は**持たない**。版・鮮度は `timestamp` と Git 履歴で扱う。
+- `type` と重複する分類は `tags` に入れない（例: `type: Contract` の文書で `tags: [contract]` としない）。
+- 内部 package 名はファイルパスで判別できるため、`packages` のような frontmatter は持たない。
+
+### `type` 語彙
+
+`ADR` / `Guide` / `Reference` / `Contract` / `Plan` / `Investigation` / `Report`
+
+| type | 用途 | 本リポジトリでの例 |
+|------|------|--------------------|
+| `ADR` | 設計判断記録 | `docs/decisions/0001–0010` |
+| `Contract` | 機械可読な入出力契約 | `docs/cli.md` |
+| `Reference` | 概要・設計・参照資料 | `README.md`, `docs/decisions/README.md`, 設計 spec |
+| `Plan` | 実装計画 | `docs/superpowers/plans/**` |
+| `Investigation` | 調査記録 | `docs/investigations/**` |
+| `Guide` | 手順・ハウツー | （現状なし） |
+| `Report` | 結果報告 | （現状なし） |
+
+### `status` 語彙
+
+`Draft` / `Accepted` / `Implemented` / `Deprecated` / `Superseded`
+
+- ADR は従来どおり `Proposed` / `Accepted` / `Deprecated` / `Superseded by [XXXX]` を使う。
+- 計画・設計など「記述対象が実装済み」の文書は `Implemented` を使ってよい。
+
+### `tags` 語彙（抽象的な機能・責務・動作）
+
+技術名ではなく機能分類に寄せる。本リポジトリで使う最小語彙:
+
+`cli` / `gui-view` / `search` / `pagination` / `db-read` / `db-write` /
+`db-migration` / `schema` / `overlay` / `tag-normalization` / `tag-conversion` /
+`recommendation` / `feedback` / `advisory` / `public-api` / `service-layer` /
+`introspection` / `validation` / `error-handling` / `config` / `packaging` /
+`overview` / `adr` / `index` / `docs` / `frontmatter` / `metadata`
+
+新しい分類が必要になったら、まず既存語彙で表せないか確認し、足りなければ本 ADR の
+語彙表に追記する。
+
+### `depends_on` 語彙（技術・ライブラリ・外部仕様）
+
+`pyside6` / `sqlalchemy` / `sqlite` / `alembic` / `pydantic` / `polars` / `numpy` /
+`huggingface-hub` / `argparse` / `yaml`
+
+### 適用範囲
+
+必須対象:
+
+- `docs/**/*.md`
+- `README.md`（プロジェクト概要として `type: Reference` を付与する）
+
+対象外（frontmatter を付けない）:
+
+- `CHANGELOG.md` / `CLAUDE.md` / `AGENTS.md` / `GEMINI.md`
+- 外部ツールが固定フォーマットを要求するファイル
+- 生成物（generated docs）、`.pytest_cache/**` などのキャッシュ
+
+### 移行方針
+
+- 既存 ADR 0001–0009 は PR #104 で frontmatter 化済み。本 ADR で `tags` を抽象語彙へ
+  見直し、必要に応じ `depends_on` を補う。
+- 非 ADR の既存ドキュメントは本 ADR と同じ変更で frontmatter を付与・整合する。
+- 以後の新規ドキュメントは本規約に従って作成する。
+
+## Rationale
+
+- `type` を必須・語彙固定にすることで、種別ごとの索引・フィルタが安定する。
+- 技術依存を `tags` から `depends_on` に分離することで、`tags` を「何をするか」、
+  `depends_on` を「何の上で動くか」に役割分担でき、検索ノイズが減る。
+- LoRAIro と同一規約にすることで、モノレポ横断のドキュメントツール（okf-bundle 等）を
+  そのまま下流パッケージへ適用できる。
+
+## Consequences
+
+- 全 `docs/**` と `README.md` が機械可読な frontmatter を持つ。
+- `docs/decisions/README.md` の ADR テンプレートは frontmatter 付きを継続する。
+- validation（CI / Make target / okf-bundle の validate）を将来導入する場合、対象は
+  「適用範囲」節のディレクトリ、除外は「対象外」節のファイルとする（本 ADR では
+  validation 自動化までは行わない。語彙・対象の定義のみ）。
+
+## Alternatives Considered
+
+- **ADR のみ frontmatter を維持**: 非 ADR ドキュメントの横断索引ができず、LoRAIro 規約と
+  乖離するため不採用。
+- **`tags` に技術名も混在**: `tags: [cli, sqlalchemy]` のように混ぜる案。機能分類と技術
+  依存が混ざり検索性が落ちるため、`depends_on` への分離を採用。
+
+## References
+
+- #103（docs 整合 issue）/ PR #104（ADR frontmatter 導入）
+- LoRAIro ADR 0069 / LoRAIro#971

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -1,5 +1,5 @@
 ---
-type: doc
+type: Reference
 title: Architecture Decision Records
 status: Accepted
 timestamp: 2026-06-29
@@ -9,10 +9,12 @@ tags: [adr, index]
 # Architecture Decision Records
 
 genai-tag-db-tools の重要な設計判断を記録するドキュメント群。各 ADR は先頭に YAML
-frontmatter（`type` / `title` / `status` / `timestamp` / `deciders` / `tags`）を持つ。
+frontmatter（`type` / `title` / `status` / `timestamp` / `deciders` / `tags`、必要に応じ
+`depends_on`）を持つ。docs 全体の frontmatter 規約は [ADR 0010](0010-okf-frontmatter-for-docs.md) を参照。
 
 | ADR | タイトル | 日付 | ステータス |
 |-----|---------|------|-----------|
+| [0010](0010-okf-frontmatter-for-docs.md) | OKF YAML Frontmatter for Documentation | 2026-06-29 | Accepted |
 | [0009](0009-recommendation-advisory-and-feedback-routing.md) | Recommendation Advisory and Feedback Routing | 2026-06-29 | Accepted |
 | [0008](0008-stable-public-api-boundary.md) | Stable Public API Boundary | 2026-06-29 | Accepted |
 | [0007](0007-user-overlay-patch-db.md) | User Overlay Patch DB | 2026-06-29 | Accepted |
@@ -33,6 +35,7 @@ status: Proposed | Accepted | Deprecated | Superseded by [XXXX]
 timestamp: YYYY-MM-DD
 deciders: NEXTAltair
 tags: []
+depends_on: []
 ---
 
 # ADR XXXX: タイトル

--- a/docs/investigations/issue-63-cli-search-output.md
+++ b/docs/investigations/issue-63-cli-search-output.md
@@ -1,3 +1,12 @@
+---
+type: Investigation
+title: "Issue #63: tag-db CLI search/status output inconsistencies"
+status: Accepted
+timestamp: 2026-06-28
+tags: [cli, search, db-read]
+depends_on: [sqlalchemy, sqlite]
+---
+
 # Issue #63 — tag-db CLI search/status output inconsistencies
 
 Status: investigated, one bug fixed, remaining items documented as expected behavior / doc-UX gaps.

--- a/docs/superpowers/plans/2026-06-08-aliases-register.md
+++ b/docs/superpowers/plans/2026-06-08-aliases-register.md
@@ -1,3 +1,12 @@
+---
+type: Plan
+title: "aliases register Implementation Plan"
+status: Implemented
+timestamp: 2026-06-08
+tags: [cli, db-write, tag-normalization, service-layer]
+depends_on: [argparse, pydantic, sqlalchemy, polars]
+---
+
 # aliases register Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

--- a/docs/superpowers/specs/2026-06-08-aliases-register-design.md
+++ b/docs/superpowers/specs/2026-06-08-aliases-register-design.md
@@ -1,3 +1,12 @@
+---
+type: Reference
+title: "Design: tag-db aliases register"
+status: Implemented
+timestamp: 2026-06-08
+tags: [cli, db-write, tag-normalization, service-layer]
+depends_on: [argparse, pydantic, sqlalchemy]
+---
+
 # Design: `tag-db aliases register` — 誤字alias一括登録CLI
 
 **Issue:** NEXTAltair/genai-tag-db-tools#47  


### PR DESCRIPTION
## 概要

LoRAIro#971 の OKF YAML frontmatter 方針を本リポジトリへ適用し、#103 の残 frontmatter タスク（README/cli.md 以外の非 ADR ドキュメントへの frontmatter 適用線引き）を完了する。

## 変更

### ADR 0010 を新規追加
`docs/decisions/0010-okf-frontmatter-for-docs.md` で docs 全体の frontmatter 規約を明文化:
- `type` 語彙（ADR/Contract/Reference/Plan/Investigation/Guide/Report）、`status` 語彙、`tags` 語彙（抽象的機能分類）、`depends_on` 語彙（技術依存）
- 適用範囲（`docs/**` + `README.md`）と除外（CHANGELOG/CLAUDE/AGENTS/キャッシュ等）
- `version` 不採用（鮮度は `timestamp` + Git 履歴）、移行方針

### 未付与の 3 ドキュメントに frontmatter 付与
- `docs/investigations/issue-63-cli-search-output.md` → `Investigation`
- `docs/superpowers/plans/2026-06-08-aliases-register.md` → `Plan`
- `docs/superpowers/specs/2026-06-08-aliases-register-design.md` → `Reference`

### 既存 frontmatter を OKF へ再整合
- `type: doc`（汎用）→ 具体語彙化: README=`Reference` / cli.md=`Contract` / decisions/README=`Reference`
- 技術依存を `tags` から `depends_on` へ分離（pyproject 実依存で裏取り: pyside6/sqlalchemy/sqlite/pydantic/polars/huggingface-hub）
- ADR 0001-0009 の空/技術混在 tags を抽象機能分類へ見直し ＋ `depends_on` 補完
- `docs/decisions/README.md`: index に 0010 追加、テンプレに `depends_on` 追加

## 検証
全 16 ドキュメントの frontmatter が YAML パース成功・`type`/`title` 必須充足を確認。

## スコープ外（#103 の残、#102 完了後に対応）
- `recommend` コマンドの doc 追記（#102 実装後）
- introspection registry の**コード**同期（`feedback` 群の `TOOL_SPECS` 登録方針確定）

Refs #103, LoRAIro#971

🤖 Generated with [Claude Code](https://claude.com/claude-code)