### PR TITLE
feat(cli): expose refinement recommendation via tag-db CLI (#102)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -112,6 +112,8 @@ The classification below is the **steady state** (base DBs already present, no
 | `search` | `db_read` | conditional (see notes) |
 | `stats` | `db_read` | conditional (see notes) |
 | `convert` | `db_read` | conditional (see notes) |
+| `recommend tag` | `db_read` | conditional (see notes) |
+| `recommend translation` | none (pure compute) | yes |
 | `register` | `db_write` | no |
 | `ensure-dbs` | `network_read`, `file_write` | no |
 
@@ -194,6 +196,47 @@ tag-db convert --tags "cat,1girl" --format-name danbooru
 
 ```jsonl
 {"kind": "result", "ok": true, "message": "tags converted", "input": "cat,1girl", "output": "cat, 1girl", "format": "danbooru"}
+```
+
+### recommend tag — advisory refinement recommendation (`db_read`)
+
+Advisory only: **read-only, non-blocking, never auto-replaces**. Evaluates whether
+each tag needs manual refinement before registration and emits an `item` line per
+tag (a `RefinementRecommendation`), then a final `result` with the counts. The
+exit code is **always 0** on success even when tags need refinement — read
+`needs_refinement` per item / `needs_refinement_count` on the result rather than
+branching on the exit code.
+
+Tags come from `--tag` (comma-separated and/or repeated), `--file` (one tag per
+line), or stdin (one tag per line), resolved in that precedence. Reasons are
+rule-based; when a base DB is present, alias / deprecated / preferred-status
+reasons are added. With no DB hit it falls back to rule-only reasons.
+
+```bash
+tag-db recommend tag --tag "flower,1girl" --format-name danbooru
+printf 'flower\n1girl\n' | tag-db recommend tag        # via stdin
+```
+
+```jsonl
+{"kind": "item", "source_tag": "flower", "normalized_tag": "flower", "needs_refinement": true, "score": 0.5, "reasons": [{"code": "broad_single_word", "message": "...", "field": null, "evidence": []}], "suggestions": [{"kind": "review_only", "tag": null}], "proposals": []}
+{"kind": "item", "source_tag": "1girl", "normalized_tag": "1girl", "needs_refinement": false, "score": 0.0, "reasons": [], "suggestions": [], "proposals": []}
+{"kind": "result", "ok": true, "message": "recommendations completed", "total": 2, "needs_refinement_count": 1}
+```
+
+### recommend translation — advisory translation-quality recommendation (no DB)
+
+Advisory only and **DB-independent** (pure compute, no side effects). Evaluates a
+single `--source-tag` / `--translation` pair and emits the `RefinementRecommendation`
+on the `result` line. Omit / empty `--translation` runs a missing-translation
+check. Exit code is always 0 on success. `proposals` is always empty in the CLI
+(target-scoped proposals are tracked in the follow-up issue #105).
+
+```bash
+tag-db recommend translation --source-tag flower --translation "花" --language ja
+```
+
+```jsonl
+{"kind": "result", "ok": true, "message": "translation recommendation", "source_tag": "flower", "normalized_tag": "flower", "needs_refinement": false, "score": 0.0, "reasons": [], "suggestions": [], "proposals": []}
 ```
 
 ### ensure-dbs — download base DBs (`network_read`, `file_write`)

--- a/src/genai_tag_db_tools/cli.py
+++ b/src/genai_tag_db_tools/cli.py
@@ -29,9 +29,11 @@ from genai_tag_db_tools.models import (
     DbCacheConfig,
     DbSourceRef,
     EnsureDbRequest,
+    RefinementRecommendRequest,
     TagRegisterRequest,
     TagSearchRequest,
     TagTranslationInput,
+    TranslationRecommendRequest,
 )
 from genai_tag_db_tools.services.tag_register import TagRegisterService
 
@@ -347,6 +349,87 @@ def cmd_convert(args: argparse.Namespace) -> None:
     )
 
 
+def _clean_tag_lines(lines: Iterable[str]) -> list[str]:
+    """1 行 1 タグ。前後空白を除去し、空行は捨てる。"""
+    return [stripped for line in lines if (stripped := line.strip())]
+
+
+def _collect_recommend_tags(args: argparse.Namespace) -> list[str]:
+    """`recommend tag` の入力を解決する。
+
+    優先順位: ``--tag``（カンマ区切り / 複数指定可）> ``--file``（1行1タグ）>
+    stdin（パイプ時のみ、1行1タグ）。いずれも無ければ空リスト。
+    """
+    if args.tag:
+        tags: list[str] = []
+        for value in args.tag:
+            tags.extend(part.strip() for part in value.split(",") if part.strip())
+        return tags
+    if args.file:
+        from pathlib import Path
+
+        return _clean_tag_lines(Path(args.file).read_text(encoding="utf-8").splitlines())
+    if not sys.stdin.isatty():
+        return _clean_tag_lines(sys.stdin)
+    return []
+
+
+def cmd_recommend_tag(args: argparse.Namespace) -> None:
+    """`recommend tag`: タグの手動 refinement を advisory 判定する (read-only, batch)。
+
+    ロジックは core_api に委譲する薄いアダプタ。base DB のヒットが無ければ
+    rule-only の理由付けへ自動フォールバックする (core 側の repo 経路)。
+    """
+    from genai_tag_db_tools.core_api import recommend_manual_refinement
+
+    tags = _collect_recommend_tags(args)
+    if not tags:
+        emit_error(
+            errors.INVALID_INPUT,
+            "no tags provided (use --tag, --file, or pipe via stdin)",
+            retryable=False,
+            user_action_required=True,
+        )
+        sys.exit(2)
+
+    # introspection 契約 (RefinementRecommendRequest) で format_name を検証/正規化。
+    request = RefinementRecommendRequest(tags=",".join(tags), format_name=args.format_name)
+
+    _set_db_paths(args.base_db, args.user_db_dir)
+    repo = get_default_reader()
+
+    needs_refinement_count = 0
+    for tag in tags:
+        recommendation = recommend_manual_refinement(tag, repo, format_name=request.format_name)
+        emit_item(recommendation)
+        if recommendation.needs_refinement:
+            needs_refinement_count += 1
+
+    # advisory: 要 refinement が出ても exit 0。判定件数は result 行に載せる (#102)。
+    emit_result(
+        "recommendations completed",
+        total=len(tags),
+        needs_refinement_count=needs_refinement_count,
+    )
+
+
+def cmd_recommend_translation(args: argparse.Namespace) -> None:
+    """`recommend translation`: 翻訳品質を advisory 判定する (rule-only, DB 非依存)。"""
+    from genai_tag_db_tools.core_api import recommend_translation_quality
+
+    request = TranslationRecommendRequest(
+        source_tag=args.source_tag,
+        translation=args.translation,
+        language=args.language,
+    )
+    recommendation = recommend_translation_quality(
+        request.source_tag,
+        request.translation,
+        language=request.language,
+    )
+    emit_result("translation recommendation", **recommendation.model_dump())
+
+
 def cmd_describe(args: argparse.Namespace) -> None:
     spec = get_tool_spec(args.target_command)
     if args.schema == "json_schema":
@@ -490,6 +573,49 @@ def build_parser(prog: str = "tag-db") -> argparse.ArgumentParser:
     )
     _add_base_db_args(aliases_register_parser)
     aliases_register_parser.set_defaults(func=cmd_aliases_register)
+
+    recommend_parser = subparsers.add_parser(
+        "recommend",
+        help="Advisory refinement recommendations (read-only, non-blocking).",
+    )
+    recommend_subs = recommend_parser.add_subparsers(dest="recommend_command", required=True)
+
+    recommend_tag_parser = recommend_subs.add_parser(
+        "tag",
+        help="Recommend manual refinement for one or more tags (batch).",
+    )
+    recommend_tag_parser.add_argument(
+        "--tag",
+        action="append",
+        help="Tag to evaluate. Comma-separated values and/or repeated flags are accepted.",
+    )
+    recommend_tag_parser.add_argument(
+        "--file",
+        help="Input file path (one tag per line).",
+    )
+    recommend_tag_parser.add_argument(
+        "--format-name",
+        default="unknown",
+        help="Target format name for DB-backed reasons (default: unknown).",
+    )
+    _add_base_db_args(recommend_tag_parser)
+    recommend_tag_parser.set_defaults(func=cmd_recommend_tag)
+
+    recommend_translation_parser = recommend_subs.add_parser(
+        "translation",
+        help="Recommend translation quality for a source tag (rule-only, no DB).",
+    )
+    recommend_translation_parser.add_argument("--source-tag", required=True)
+    recommend_translation_parser.add_argument(
+        "--translation",
+        help="Observed translation. Omit or pass empty for a missing-translation check.",
+    )
+    recommend_translation_parser.add_argument(
+        "--language",
+        default="ja",
+        help="Translation language code (default: ja).",
+    )
+    recommend_translation_parser.set_defaults(func=cmd_recommend_translation)
 
     list_commands_parser = subparsers.add_parser(
         "list-commands",

--- a/src/genai_tag_db_tools/introspection.py
+++ b/src/genai_tag_db_tools/introspection.py
@@ -30,11 +30,14 @@ from genai_tag_db_tools.models import (
     ConvertTagsResult,
     EnsureDbRequest,
     EnsureDbResult,
+    RefinementRecommendation,
+    RefinementRecommendRequest,
     TagRegisterRequest,
     TagRegisterResult,
     TagSearchRequest,
     TagSearchResult,
     TagStatisticsResult,
+    TranslationRecommendRequest,
 )
 
 SchemaMode = Literal["compact", "json_schema"]
@@ -117,6 +120,22 @@ TOOL_SPECS: dict[str, ToolSpec] = {
         read_only=False,
         input_model=AliasRegisterInput,
         output_model=AliasRegisterResult,
+    ),
+    "recommend/tag": ToolSpec(
+        name="recommend/tag",
+        description="Advisory refinement recommendation for tags (read-only, non-blocking).",
+        side_effects=("db_read",),
+        read_only=True,
+        input_model=RefinementRecommendRequest,
+        output_model=RefinementRecommendation,
+    ),
+    "recommend/translation": ToolSpec(
+        name="recommend/translation",
+        description="Advisory translation-quality recommendation (rule-only, no DB).",
+        side_effects=(),
+        read_only=True,
+        input_model=TranslationRecommendRequest,
+        output_model=RefinementRecommendation,
     ),
 }
 

--- a/src/genai_tag_db_tools/models.py
+++ b/src/genai_tag_db_tools/models.py
@@ -417,6 +417,28 @@ class RefinementRecommendation(BaseModel):
     )
 
 
+class RefinementRecommendRequest(BaseModel):
+    """`recommend tag` リクエスト（CLI/introspection 契約用）。
+
+    CLI は `--tag a,b,c`（カンマ区切り）/ `--file`（1行1タグ）/ stdin の
+    いずれかを `tags` の論理表現（カンマ区切り文字列）へ正規化して渡す。
+    """
+
+    tags: str = Field(..., description="Comma-separated input tags")
+    format_name: str = Field(default="unknown", description="Target format name for DB-backed reasons")
+
+
+class TranslationRecommendRequest(BaseModel):
+    """`recommend translation` リクエスト（CLI/introspection 契約用）。
+
+    DB を一切引かない純計算の advisory リクエスト。
+    """
+
+    source_tag: str = Field(..., description="Original source tag")
+    translation: str | None = Field(default=None, description="Observed translation (None/empty = missing)")
+    language: str = Field(default="ja", description="Translation language code")
+
+
 class ApprovedDbFeedback(BaseModel):
     """人間承認済みの DB feedback proposal。"""
 

--- a/tests/unit/test_cli_integration.py
+++ b/tests/unit/test_cli_integration.py
@@ -22,11 +22,16 @@ import pytest
 
 from genai_tag_db_tools.cli import (
     cmd_convert,
+    cmd_recommend_tag,
+    cmd_recommend_translation,
     cmd_register,
     cmd_search,
     cmd_stats,
 )
 from genai_tag_db_tools.models import (
+    RefinementReason,
+    RefinementRecommendation,
+    RefinementSuggestion,
     TagRecordPublic,
     TagRegisterResult,
     TagSearchResult,
@@ -441,3 +446,167 @@ class TestCmdConvert:
 
         # Verify separator parameter
         assert mock_convert.call_args[1]["separator"] == "|"
+
+
+class TestCmdRecommendTag:
+    """Test cmd_recommend_tag command (thin adapter, batch, read-only)."""
+
+    @patch("genai_tag_db_tools.cli.get_default_reader")
+    @patch("genai_tag_db_tools.core_api.recommend_manual_refinement")
+    def test_batch_emits_item_per_tag_plus_result(
+        self,
+        mock_recommend: MagicMock,
+        mock_reader: MagicMock,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """複数タグで kind=item×N + kind=result(件数サマリ)を出す。"""
+
+        def _fake(tag: str, repo: object, *, format_name: str) -> RefinementRecommendation:
+            needs = tag == "flower"
+            return RefinementRecommendation(
+                source_tag=tag,
+                normalized_tag=tag,
+                needs_refinement=needs,
+                score=1.0 if needs else 0.0,
+                reasons=[RefinementReason(code="broad_single_word", message="x")] if needs else [],
+                suggestions=[RefinementSuggestion(kind="review_only")] if needs else [],
+            )
+
+        mock_recommend.side_effect = _fake
+
+        base_db = tmp_path / "base.db"
+        base_db.touch()
+        args = argparse.Namespace(
+            tag=["flower,1girl"],
+            file=None,
+            format_name="danbooru",
+            base_db=[str(base_db)],
+            user_db_dir=None,
+        )
+        cmd_recommend_tag(args)
+
+        # core_api へ委譲。format_name と repo が配線される。
+        assert mock_recommend.call_count == 2
+        assert mock_recommend.call_args_list[0].kwargs["format_name"] == "danbooru"
+        assert mock_recommend.call_args_list[0].args[1] is mock_reader.return_value
+
+        lines = _parse_jsonl(capsys.readouterr().out)
+        items = [line for line in lines if line["kind"] == "item"]
+        assert [item["source_tag"] for item in items] == ["flower", "1girl"]
+        assert lines[-1]["kind"] == "result"
+        assert lines[-1]["total"] == 2
+        assert lines[-1]["needs_refinement_count"] == 1
+
+    @patch("genai_tag_db_tools.cli.get_default_reader")
+    @patch("genai_tag_db_tools.core_api.recommend_manual_refinement")
+    def test_single_tag_still_emits_item_and_result(
+        self,
+        mock_recommend: MagicMock,
+        mock_reader: MagicMock,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """単一タグでも出力形状は item + result で一定。"""
+        mock_recommend.return_value = RefinementRecommendation(
+            source_tag="flower",
+            normalized_tag="flower",
+            needs_refinement=False,
+            score=0.0,
+        )
+        base_db = tmp_path / "base.db"
+        base_db.touch()
+        args = argparse.Namespace(
+            tag=["flower"],
+            file=None,
+            format_name="unknown",
+            base_db=[str(base_db)],
+            user_db_dir=None,
+        )
+        cmd_recommend_tag(args)
+
+        lines = _parse_jsonl(capsys.readouterr().out)
+        assert [line["kind"] for line in lines] == ["item", "result"]
+        assert lines[-1]["total"] == 1
+        assert lines[-1]["needs_refinement_count"] == 0
+
+    @patch("genai_tag_db_tools.cli.get_default_reader")
+    @patch("genai_tag_db_tools.core_api.recommend_manual_refinement")
+    def test_reads_tags_from_file(
+        self,
+        mock_recommend: MagicMock,
+        mock_reader: MagicMock,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """--file は1行1タグで読み、空行を捨てる。"""
+        mock_recommend.side_effect = lambda tag, repo, *, format_name: RefinementRecommendation(
+            source_tag=tag, normalized_tag=tag, needs_refinement=False, score=0.0
+        )
+        tags_file = tmp_path / "tags.txt"
+        tags_file.write_text("flower\n\n1girl\n", encoding="utf-8")
+        base_db = tmp_path / "base.db"
+        base_db.touch()
+        args = argparse.Namespace(
+            tag=None,
+            file=str(tags_file),
+            format_name="unknown",
+            base_db=[str(base_db)],
+            user_db_dir=None,
+        )
+        cmd_recommend_tag(args)
+
+        lines = _parse_jsonl(capsys.readouterr().out)
+        items = [line for line in lines if line["kind"] == "item"]
+        assert [item["source_tag"] for item in items] == ["flower", "1girl"]
+
+    def test_no_tags_emits_error_and_exit_2(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """タグ未指定(stdin も tty)なら構造化エラー + exit 2。"""
+        monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+        args = argparse.Namespace(
+            tag=None,
+            file=None,
+            format_name="unknown",
+            base_db=None,
+            user_db_dir=None,
+        )
+        with pytest.raises(SystemExit) as exc:
+            cmd_recommend_tag(args)
+        assert exc.value.code == 2
+        lines = _parse_jsonl(capsys.readouterr().out)
+        assert lines[-1]["kind"] == "error"
+        assert lines[-1]["code"] == "INVALID_INPUT"
+
+
+class TestCmdRecommendTranslation:
+    """Test cmd_recommend_translation command (rule-only, no DB)."""
+
+    @patch("genai_tag_db_tools.core_api.recommend_translation_quality")
+    def test_delegates_and_emits_result(
+        self,
+        mock_recommend: MagicMock,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """core_api へ委譲し、recommendation を result 行に展開する。"""
+        mock_recommend.return_value = RefinementRecommendation(
+            source_tag="flower",
+            normalized_tag="flower",
+            needs_refinement=True,
+            score=1.0,
+            reasons=[RefinementReason(code="missing_translation", message="empty")],
+            suggestions=[RefinementSuggestion(kind="review_only")],
+        )
+        args = argparse.Namespace(source_tag="flower", translation="", language="ja")
+        cmd_recommend_translation(args)
+
+        mock_recommend.assert_called_once_with("flower", "", language="ja")
+        lines = _parse_jsonl(capsys.readouterr().out)
+        assert len(lines) == 1
+        assert lines[0]["kind"] == "result"
+        assert lines[0]["source_tag"] == "flower"
+        assert lines[0]["needs_refinement"] is True
+        assert lines[0]["reasons"][0]["code"] == "missing_translation"

--- a/tests/unit/test_cli_introspection.py
+++ b/tests/unit/test_cli_introspection.py
@@ -27,8 +27,10 @@ class TestListCommands:
             "stats",
             "convert",
             "aliases/register",
+            "recommend/tag",
+            "recommend/translation",
         }
-        assert objs[-1] == {"kind": "result", "ok": True, "message": "commands listed", "count": 6}
+        assert objs[-1] == {"kind": "result", "ok": True, "message": "commands listed", "count": 8}
 
     def test_side_effects_and_read_only(self, capsys: pytest.CaptureFixture[str]) -> None:
         tools = {
@@ -41,6 +43,11 @@ class TestListCommands:
         assert tools["register"]["read_only"] is False
         assert tools["register"]["side_effects"] == ["db_write"]
         assert tools["ensure-dbs"]["side_effects"] == ["network_read", "file_write"]
+        # recommend は advisory read-only。tag は DB を引き、translation は純計算。
+        assert tools["recommend/tag"]["read_only"] is True
+        assert tools["recommend/tag"]["side_effects"] == ["db_read"]
+        assert tools["recommend/translation"]["read_only"] is True
+        assert tools["recommend/translation"]["side_effects"] == []
 
 
 class TestDescribeCompact:


### PR DESCRIPTION
## What

`recommend tag` / `recommend translation` を `tag-db` CLI に追加。public API（`recommend_manual_refinement` / `recommend_translation_quality`）に載っていた refinement recommendation を、人間とエージェント双方の入口である CLI へ **薄いアダプタ**として parity させる。ロジックは `core_api` に1か所、CLI は引数パース + JSONL 整形のみ（ヘキサゴナルの入力アダプタ）。

すべて **advisory**: read-only / 非ブロッキング / 自動置換なし / 成功時は常に exit 0。

### コマンド

| コマンド | 委譲先 | 副作用 |
|---|---|---|
| `recommend tag` | `recommend_manual_refinement` | `db_read`（DBヒット無しは rule-only にフォールバック）|
| `recommend translation` | `recommend_translation_quality` | なし（純計算）|

- `recommend tag` は **バッチ**対応：`--tag`（カンマ区切り/複数）/ `--file`（1行1タグ）/ stdin。各タグ `kind=item` + 最後に `kind=result`（`total` / `needs_refinement_count`）。
- `recommend translation` は単一ペア。`RefinementRecommendation` を result 行に展開。`proposals` は MVP では常に空。

### introspection
`recommend/tag`（`db_read`, read_only）/ `recommend/translation`（副作用なし, read_only）を `TOOL_SPECS` に登録。`list-commands` / `describe` で発見・スキーマ取得可。`output_model` は #102 の決定どおり `RefinementRecommendation`。

### models / docs / tests
- `RefinementRecommendRequest` / `TranslationRecommendRequest` 追加
- `docs/cli.md`: 副作用分類表 + 2コマンド節
- CLI テスト（バッチ/単一/ファイル入力/no-input→exit 2/translation 委譲）+ introspection テスト

## 設計判断（#102 に記録）
- 終了コードは **常に exit 0**（判定は `needs_refinement` / `needs_refinement_count` で取得）
- translation の target 引数（proposals 実体化）は **MVP 対象外**
- `--rule-only`・`recommend record` は **follow-up #105** へ
- 出力フィルタは入れず **全件出力**

## Acceptance（#102）
- [x] `recommend tag --tag flower` が JSONL で返す（rule-only / DB-backed）
- [x] 複数タグ（カンマ / `--file` / stdin）で `item`×N + `result`
- [x] `recommend translation --source-tag ... --translation ...`
- [x] `list-commands` / `describe recommend/tag` で登録・スキーマ取得
- [x] `core_api` へ委譲（ロジック再実装なし）
- [x] read-only・非ブロッキング・advisory
- [x] `docs/cli.md` 追従
- [x] CLI / introspection テスト追加、ruff / mypy / pytest green（639 passed）

Closes #102. Refs #2. Follow-up: #105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)