### PR TITLE
docs: OKF frontmatter の検証・索引生成ツールを導入 (adr-okf / adr-index / docs-okf) (#108)

### DIFF
--- a/.agents/skills/okf-bundle/SKILL.md
+++ b/.agents/skills/okf-bundle/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: okf-bundle
+version: "1.0.0"
+description: "Maintain a directory of markdown docs as an Open Knowledge Format (OKF) bundle in any project: ensure each concept file has valid OKF frontmatter (required `type`, plus optional title/description/tags/timestamp), keep frontmatter the single source of truth, and regenerate the derived index.md (and an optional human-readable table) from it. Use when adding/editing concept docs (ADRs, knowledge bases, glossaries) or when a bundle's index looks stale. Project-specific drift detection stays in the project."
+metadata:
+  short-description: 任意プロジェクトの md 群を OKF バンドルとして保守（frontmatter=SSoT → index/表を生成・検証）。
+---
+
+# OKF Bundle Maintenance
+
+Markdown ファイルのディレクトリを [Open Knowledge Format (OKF)](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
+バンドルとして保守する汎用スキル。**frontmatter を唯一の正準ソース (SSoT)** とし、
+`index.md` や人間向けテーブルは frontmatter から生成する派生物として扱う。
+
+プロジェクト非依存・stdlib only。`--bundle-root` で対象ディレクトリを受け取るので、
+ADR・知識ベース・用語集など任意の OKF バンドルに使える。
+
+## OKF の必須ルール (SPEC v0.1)
+
+- frontmatter の必須キーは **`type` のみ**。`title` / `description` / `tags` / `timestamp` は任意。
+- スカラー値メタデータ (status / timestamp 等) は **frontmatter に置く**。本文の散文に書かない。
+- `index.md` / `log.md` は予約ファイル名。概念ドキュメントには使わない。`log.md` の日付は ISO 8601。
+- `index.md` / 生成テーブルは**生成物**。手編集しない。
+
+## スクリプト (scripts/)
+
+すべて `python3` 単体 (依存なし) で動く。
+
+| スクリプト | 役割 |
+|---|---|
+| `okf_validate.py --bundle-root DIR` | frontmatter 検証 (必須 `type` / ISO `timestamp` / `--require`・`--exclude`・`--skip-missing` 可) |
+| `okf_index.py --bundle-root DIR --index` | OKF `index.md` (箇条書き) を生成 |
+| `okf_index.py --bundle-root DIR --table --columns ... --link-column ...` | 列を frontmatter キーで指定する Markdown テーブルを生成 |
+
+`okf_index.py` の `--check` は書き込まず「生成物が最新か」だけ検証する (drift 検出)。
+`--table-output` 先に `<!-- OKF-TABLE:START -->` / `<!-- OKF-TABLE:END -->` マーカーがあれば、
+その間だけ置換するのでテーブル前後の散文を保持できる。
+
+`okf_validate.py --skip-missing` は frontmatter が無いファイルを違反にせず除外する
+(段階的移行 / lazy migration 用)。frontmatter 未付与の既存ドキュメントを許容しつつ、
+付与済みのものだけ `type` 必須 / ISO `timestamp` を強制したいバンドルで使う。
+全件 frontmatter 必須のバンドル (例: ADR) には付けない。
+
+## Workflow (Agent が判断で起動)
+
+概念ドキュメントを追加・編集・改番したら:
+
+1. **検証**: `python3 <skill>/scripts/okf_validate.py --bundle-root <DIR> [--exclude README.md]`
+   — frontmatter 欠落や必須キー漏れを補う。
+2. **再生成**: `python3 <skill>/scripts/okf_index.py --bundle-root <DIR> --index ...`
+   (必要なら `--table ...` も) で派生ビューを更新する。
+3. **コミット**: 生成物を含めてコミットする (docs chore は main 直 push 可なプロジェクトもある)。
+
+CI 自走に頼らず Agent の判断で回す。許容するのは「実行漏れ (索引が一時的に古い)」だけで、
+生成は決定論なので内容ドリフトは発生しない。**索引やテーブルを手で書き起こさない**
+(書式ブレ・転記ミスの温床)。
+
+## プロジェクト固有の責務 (スキル外)
+
+「その概念を参照しているコードが概念より新しい」式の drift 検出 (REFERENCE-DRIFT) は
+各プロジェクトの enactment surface に依存するため、本スキルには含めない。プロジェクト側の
+ツール (例: LoRAIro `scripts/check_adr_drift.py`) が担う。
+
+## LoRAIro での使用例
+
+```bash
+# ADR バンドル検証 (全件 frontmatter 必須)
+python3 .claude/skills/okf-bundle/scripts/okf_validate.py --bundle-root docs/decisions --exclude README.md
+# index.md + README テーブルを再生成
+make adr-index   # 内部で okf_index.py を呼ぶ
+
+# 通常ドキュメント検証 (lazy migration: 未付与は skip、付与済みのみ検証。ADR 0082)
+make docs-okf    # docs / iam-lib docs / genai-tag docs を --skip-missing で検証
+```

--- a/.agents/skills/okf-bundle/scripts/_okf.py
+++ b/.agents/skills/okf-bundle/scripts/_okf.py
@@ -1,0 +1,137 @@
+"""OKF (Open Knowledge Format) バンドル操作の共有ユーティリティ。
+
+stdlib のみで動作する。frontmatter のパースとバンドル走査を提供し、
+``okf_validate.py`` / ``okf_index.py`` から import される。
+
+OKF SPEC: https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md
+
+frontmatter パーサは YAML 全体ではなく、OKF が想定する素直な部分集合だけを扱う:
+
+- ``key: value`` のスカラー (前後の引用符は除去)
+- ``key: [a, b, c]`` のインラインリスト
+- 次行以降に ``  - item`` が並ぶブロックリスト
+
+ネストした map やフロースタイル map は対象外 (OKF concept frontmatter には不要)。
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+# 任意の階層に置けて、概念ドキュメントには使えない予約ファイル名 (OKF SPEC §3.1)。
+RESERVED_FILENAMES = frozenset({"index.md", "log.md"})
+
+
+def split_frontmatter(text: str) -> tuple[str, str]:
+    """先頭の ``---`` で囲まれた frontmatter ブロックと本文を分離して返す。
+
+    Args:
+        text: Markdown ファイル全体の文字列。
+
+    Returns:
+        ``(frontmatter_block, body)`` のタプル。frontmatter が無ければ
+        ``("", text)`` を返す。frontmatter_block は ``---`` 区切り行を含まない。
+    """
+    if not text.startswith("---"):
+        return "", text
+    # 開始 --- 行の直後から、次の --- 行までを frontmatter とする。
+    # rstrip() で CRLF (``---\r``) や末尾空白も区切りとして認識する。
+    lines = text.splitlines(keepends=True)
+    if not lines or lines[0].rstrip() != "---":
+        return "", text
+    for i in range(1, len(lines)):
+        if lines[i].rstrip() == "---":
+            block = "".join(lines[1:i])
+            body = "".join(lines[i + 1 :])
+            return block, body
+    return "", text
+
+
+def _strip_scalar(value: str) -> str:
+    """スカラー値の前後空白と一重/二重引用符を除去する。"""
+    value = value.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
+        return value[1:-1]
+    return value
+
+
+def _parse_inline_list(value: str) -> list[str]:
+    """``[a, b, c]`` 形式のインラインリストを要素リストへ変換する。"""
+    inner = value.strip()[1:-1].strip()
+    if not inner:
+        return []
+    return [_strip_scalar(item) for item in inner.split(",") if item.strip()]
+
+
+def parse_frontmatter(text: str) -> dict[str, str | list[str]]:
+    """Markdown の frontmatter をパースして key/value の dict を返す。
+
+    OKF が想定する素直な部分集合のみ対応 (モジュール docstring 参照)。
+
+    Args:
+        text: Markdown ファイル全体の文字列。
+
+    Returns:
+        frontmatter の key/value。値はスカラー (str) かリスト (list[str])。
+        frontmatter が無ければ空 dict。
+    """
+    block, _ = split_frontmatter(text)
+    if not block:
+        return {}
+    result: dict[str, str | list[str]] = {}
+    lines = block.splitlines()
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        i += 1
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        if ":" not in line:
+            continue
+        key, _, raw = line.partition(":")
+        key = key.strip()
+        raw = raw.strip()
+        if raw.startswith("[") and raw.endswith("]"):
+            result[key] = _parse_inline_list(raw)
+        elif raw == "":
+            # ブロックリストの可能性: 次行以降の "  - item" を集める。
+            items: list[str] = []
+            while i < len(lines) and lines[i].lstrip().startswith("- "):
+                items.append(_strip_scalar(lines[i].lstrip()[2:]))
+                i += 1
+            result[key] = items
+        else:
+            result[key] = _strip_scalar(raw)
+    return result
+
+
+def iter_concept_files(
+    bundle_root: Path, *, extra_excludes: frozenset[str] = frozenset()
+) -> Iterator[Path]:
+    """バンドル配下の概念ドキュメント (*.md) を名前順に列挙する。
+
+    予約ファイル名 (``index.md`` / ``log.md``) と ``extra_excludes`` の
+    ファイル名は除外する。
+
+    Args:
+        bundle_root: バンドルのルートディレクトリ。
+        extra_excludes: 追加で除外するファイル名の集合 (例: ``{"README.md"}``)。
+
+    Yields:
+        概念ドキュメントの Path。
+    """
+    excludes = RESERVED_FILENAMES | extra_excludes
+    for path in sorted(bundle_root.rglob("*.md")):
+        if path.name in excludes:
+            continue
+        yield path
+
+
+def as_scalar(value: str | list[str] | None) -> str:
+    """frontmatter 値を表示用スカラー文字列へ正規化する。"""
+    if value is None:
+        return ""
+    if isinstance(value, list):
+        return ", ".join(value)
+    return value

--- a/.agents/skills/okf-bundle/scripts/okf_index.py
+++ b/.agents/skills/okf-bundle/scripts/okf_index.py
@@ -1,0 +1,192 @@
+"""OKF バンドルの索引を frontmatter から生成する汎用ツール (stdlib only)。
+
+frontmatter を唯一の正準ソース (SSoT) とみなし、そこから派生ビューを生成する:
+
+- ``--index``  : OKF SPEC §6 の ``index.md`` (箇条書き、progressive disclosure) を生成。
+- ``--table``  : 人間向け Markdown テーブルを生成。列は frontmatter キーで指定するため
+  プロジェクト非依存 (``--columns id,title,timestamp,status`` 等)。
+
+いずれも ``--check`` で「生成結果が既存ファイルと一致するか」だけを検証できる
+(CI/skill が drift を検出する用途)。``--table-output`` 先に
+``<!-- OKF-TABLE:START -->`` / ``<!-- OKF-TABLE:END -->`` マーカーがあれば、その間だけを
+置換するため、テーブル前後の人手の散文 (説明・テンプレ) を保持できる。
+
+特殊列:
+- ``id``   : ファイル名先頭の連番 (例 ``0001-foo.md`` -> ``0001``)。無ければ stem。
+- ``file`` : ファイル名。
+
+使い方:
+    python3 okf_index.py --bundle-root docs/decisions --index --exclude README.md
+    python3 okf_index.py --bundle-root docs/decisions --table \\
+        --columns id,title,timestamp,status --headers "ADR,タイトル,日付,ステータス" \\
+        --link-column id --table-output docs/decisions/README.md
+    python3 okf_index.py --bundle-root docs/decisions --table ... --check
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+from _okf import as_scalar, iter_concept_files, parse_frontmatter
+
+TABLE_START = "<!-- OKF-TABLE:START -->"
+TABLE_END = "<!-- OKF-TABLE:END -->"
+_LEADING_NUM = re.compile(r"^(\d+)")
+
+
+def _id_of(path: Path) -> str:
+    m = _LEADING_NUM.match(path.stem)
+    return m.group(1) if m else path.stem
+
+
+def _cell(path: Path, fm: dict[str, str | list[str]], col: str) -> str:
+    if col == "id":
+        return _id_of(path)
+    if col == "file":
+        return path.name
+    if col == "title":
+        return as_scalar(fm.get("title")) or path.stem
+    return as_scalar(fm.get(col))
+
+
+def _md_escape(text: str) -> str:
+    """テーブルセル内のパイプをエスケープする。"""
+    return text.replace("|", "\\|")
+
+
+def _collect(
+    bundle_root: Path, excludes: frozenset[str], sort_by: str
+) -> list[tuple[Path, dict[str, str | list[str]]]]:
+    rows = [
+        (p, parse_frontmatter(p.read_text(encoding="utf-8")))
+        for p in iter_concept_files(bundle_root, extra_excludes=excludes)
+    ]
+    if sort_by == "file":
+        rows.sort(key=lambda r: r[0].name)
+    else:
+        rows.sort(key=lambda r: _cell(r[0], r[1], sort_by))
+    return rows
+
+
+def build_index(
+    rows: list[tuple[Path, dict[str, str | list[str]]]], bundle_root: Path, title: str, title_key: str
+) -> str:
+    """OKF SPEC §6 形式の index.md 本文を生成する。"""
+    lines = [f"# {title}", ""]
+    for path, fm in rows:
+        rel = path.relative_to(bundle_root).as_posix()
+        label = as_scalar(fm.get(title_key)) or path.stem
+        desc = as_scalar(fm.get("description"))
+        entry = f"* [{label}]({rel})"
+        if desc:
+            entry += f" — {desc}"
+        lines.append(entry)
+    lines.append("")
+    return "\n".join(lines)
+
+
+def build_table(
+    rows: list[tuple[Path, dict[str, str | list[str]]]],
+    bundle_root: Path,
+    columns: list[str],
+    headers: list[str],
+    link_column: str | None,
+) -> str:
+    """Markdown テーブル本文を生成する。"""
+    out = ["| " + " | ".join(headers) + " |", "|" + "|".join(["---"] * len(columns)) + "|"]
+    for path, fm in rows:
+        cells: list[str] = []
+        rel = path.relative_to(bundle_root).as_posix()
+        for col in columns:
+            value = _md_escape(_cell(path, fm, col))
+            if col == link_column:
+                value = f"[{value}]({rel})"
+            cells.append(value)
+        out.append("| " + " | ".join(cells) + " |")
+    return "\n".join(out)
+
+
+def _inject(existing: str, table: str) -> str:
+    """マーカー間にテーブルを差し込む。無ければテーブルのみを返す。"""
+    if TABLE_START in existing and TABLE_END in existing:
+        pre = existing[: existing.index(TABLE_START) + len(TABLE_START)]
+        post = existing[existing.index(TABLE_END) :]
+        return f"{pre}\n{table}\n{post}"
+    return table + "\n"
+
+
+def _emit(content: str, output: Path | None, check: bool, label: str) -> int:
+    """書き込み or --check 検証。差分があれば 1 を返す。"""
+    if output is None:
+        print(content)
+        return 0
+    current = output.read_text(encoding="utf-8") if output.exists() else ""
+    if check:
+        if current != content:
+            print(f"DRIFT: {output} が最新でない ({label} を再生成してください)", file=sys.stderr)
+            return 1
+        print(f"OK: {output} は最新 ({label})")
+        return 0
+    output.write_text(content, encoding="utf-8")
+    print(f"生成: {output} ({label})")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="OKF バンドルの索引を frontmatter から生成する。")
+    parser.add_argument("--bundle-root", type=Path, required=True)
+    parser.add_argument("--exclude", default="", help="除外ファイル名のカンマ区切り。")
+    parser.add_argument("--sort-by", default="file", help="並び替えに使う列 (既定: file)。")
+    parser.add_argument("--check", action="store_true", help="書き込まず最新かどうか検証する。")
+    # index
+    parser.add_argument("--index", action="store_true", help="index.md を生成する。")
+    parser.add_argument(
+        "--index-output", type=Path, default=None, help="index.md の出力先 (既定: <root>/index.md)。"
+    )
+    parser.add_argument("--index-title", default="Index")
+    parser.add_argument("--title-key", default="title")
+    # table
+    parser.add_argument("--table", action="store_true", help="Markdown テーブルを生成する。")
+    parser.add_argument("--columns", default="id,title,timestamp,status")
+    parser.add_argument("--headers", default="", help="表示ヘッダのカンマ区切り (既定: columns と同じ)。")
+    parser.add_argument("--link-column", default=None, help="リンク化する列名。")
+    parser.add_argument("--table-output", type=Path, default=None)
+    args = parser.parse_args()
+
+    bundle_root: Path = args.bundle_root
+    if not bundle_root.is_dir():
+        print(f"エラー: バンドルが見つからない: {bundle_root}", file=sys.stderr)
+        return 2
+    if not (args.index or args.table):
+        print("エラー: --index か --table のいずれかを指定してください。", file=sys.stderr)
+        return 2
+
+    excludes = frozenset(k.strip() for k in args.exclude.split(",") if k.strip())
+    rows = _collect(bundle_root, excludes, args.sort_by)
+
+    rc = 0
+    if args.index:
+        content = build_index(rows, bundle_root, args.index_title, args.title_key)
+        output = args.index_output or (bundle_root / "index.md")
+        rc |= _emit(content, output, args.check, "index.md")
+    if args.table:
+        columns = [c.strip() for c in args.columns.split(",") if c.strip()]
+        headers = [h.strip() for h in args.headers.split(",")] if args.headers else columns
+        if len(headers) != len(columns):
+            print("エラー: --headers の数が --columns と一致しません。", file=sys.stderr)
+            return 2
+        table = build_table(rows, bundle_root, columns, headers, args.link_column)
+        if args.table_output is not None:
+            existing = args.table_output.read_text(encoding="utf-8") if args.table_output.exists() else ""
+            content = _inject(existing, table)
+        else:
+            content = table
+        rc |= _emit(content, args.table_output, args.check, "table")
+    return rc
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/okf-bundle/scripts/okf_validate.py
+++ b/.agents/skills/okf-bundle/scripts/okf_validate.py
@@ -1,0 +1,124 @@
+"""OKF バンドルの frontmatter を検証する汎用ツール (stdlib only)。
+
+OKF SPEC v0.1 が要求する最小の構造規約を機械チェックする:
+
+- 各概念ドキュメントに frontmatter があり、必須キー ``type`` を持つこと。
+- ``timestamp`` があれば ISO 8601 (``YYYY-MM-DD`` または日時) であること。
+- 予約ファイル名 (``index.md`` / ``log.md``) を概念ドキュメントに使っていないこと
+  (本ツールは予約名を概念として走査しないため、混在は ``--require`` の対象外)。
+
+プロジェクト非依存。``--bundle-root`` で対象ディレクトリを受け取り、
+``--require`` で必須キーを追加できる。違反があれば終了コード 1。
+
+段階的移行 (lazy migration) のため ``--skip-missing`` を用意する。frontmatter が
+無いファイルを違反にせず走査から除外するので、既存ドキュメントへ frontmatter を
+徐々に付与しつつ、付与済みのものだけ規約を強制できる。
+
+使い方:
+    python3 okf_validate.py --bundle-root docs/decisions
+    python3 okf_validate.py --bundle-root docs/decisions --require type,title --exclude README.md
+    python3 okf_validate.py --bundle-root docs --skip-missing --exclude README.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from datetime import date, datetime
+from pathlib import Path
+
+from _okf import iter_concept_files, parse_frontmatter
+
+# OKF SPEC §4.1: frontmatter の必須キーは type のみ。
+DEFAULT_REQUIRED = ("type",)
+
+
+def _is_iso8601(value: str) -> bool:
+    """値が ISO 8601 の日付または日時として解釈できるか判定する。"""
+    for parser in (date.fromisoformat, datetime.fromisoformat):
+        try:
+            parser(value.replace("Z", "+00:00") if parser is datetime.fromisoformat else value)
+            return True
+        except ValueError:
+            continue
+    return False
+
+
+def validate(
+    bundle_root: Path,
+    required: tuple[str, ...],
+    excludes: frozenset[str],
+    *,
+    skip_missing: bool = False,
+) -> list[str]:
+    """バンドルを検証し、違反メッセージのリストを返す (空なら合格)。
+
+    Args:
+        bundle_root: バンドルのルートディレクトリ。
+        required: 各概念ドキュメントに必須とするキーのタプル。
+        excludes: 走査から除外するファイル名の集合。
+        skip_missing: True なら frontmatter が無いファイルを違反にせず除外する
+            (lazy migration 用)。
+    """
+    problems: list[str] = []
+    count = 0
+    for path in iter_concept_files(bundle_root, extra_excludes=excludes):
+        count += 1
+        rel = path.relative_to(bundle_root).as_posix()
+        text = path.read_text(encoding="utf-8")
+        fm = parse_frontmatter(text)
+        if not fm:
+            if not skip_missing:
+                problems.append(f"{rel}: frontmatter が無い")
+            continue
+        for key in required:
+            if not fm.get(key):
+                problems.append(f"{rel}: 必須キー '{key}' が無い")
+        timestamp = fm.get("timestamp")
+        if isinstance(timestamp, str) and timestamp and not _is_iso8601(timestamp):
+            problems.append(f"{rel}: timestamp '{timestamp}' が ISO 8601 でない")
+    if count == 0:
+        problems.append(f"{bundle_root}: 概念ドキュメント (*.md) が見つからない")
+    return problems
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="OKF バンドルの frontmatter を検証する。")
+    parser.add_argument("--bundle-root", type=Path, required=True, help="バンドルのルートディレクトリ。")
+    parser.add_argument(
+        "--require",
+        default="type",
+        help="必須キーのカンマ区切り (既定: type)。",
+    )
+    parser.add_argument(
+        "--exclude",
+        default="",
+        help="走査から除外するファイル名のカンマ区切り (例: README.md)。",
+    )
+    parser.add_argument(
+        "--skip-missing",
+        action="store_true",
+        help="frontmatter が無いファイルを違反にせず除外する (lazy migration 用)。",
+    )
+    args = parser.parse_args()
+
+    bundle_root: Path = args.bundle_root
+    if not bundle_root.is_dir():
+        print(f"エラー: バンドルが見つからない: {bundle_root}", file=sys.stderr)
+        return 2
+
+    required = tuple(k.strip() for k in args.require.split(",") if k.strip()) or DEFAULT_REQUIRED
+    excludes = frozenset(k.strip() for k in args.exclude.split(",") if k.strip())
+
+    problems = validate(bundle_root, required, excludes, skip_missing=args.skip_missing)
+    if problems:
+        print(f"OKF 検証 NG: {len(problems)} 件の違反")
+        for p in problems:
+            print(f"  - {p}")
+        return 1
+    print(f"OKF 検証 OK: {bundle_root}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,44 @@
+# genai-tag-db-tools Makefile
+# OKF ドキュメント検証・索引生成タスク (ADR 0010 / Issue #108)
+
+.PHONY: help adr-okf adr-index docs-okf
+
+OKF := .agents/skills/okf-bundle/scripts
+
+# DOCS_OKF_EXCLUDE: frontmatter 規約の対象外 (README/メタ系 + 外部ツールが固有形式を要求する SKILL.md)。
+DOCS_OKF_EXCLUDE := README.md,CHANGELOG.md,AGENTS.md,GEMINI.md,CLAUDE.md,SKILL.md
+
+help:
+	@echo "genai-tag-db-tools - OKF documentation targets:"
+	@echo "  adr-okf      Validate ADR frontmatter (全件必須) + check index is up to date"
+	@echo "  adr-index    Regenerate ADR index.md + README table from frontmatter"
+	@echo "  docs-okf     Validate docs OKF frontmatter (lazy: --skip-missing)"
+
+# ADR (OKF バンドル) の README テーブル + index.md を frontmatter から再生成する (ADR 0010)。
+adr-index:
+	@echo "Regenerating ADR index from frontmatter..."
+	python3 $(OKF)/okf_index.py --bundle-root docs/decisions \
+		--table --columns id,title,timestamp,status --headers "ADR,タイトル,日付,ステータス" \
+		--link-column id --exclude README.md --table-output docs/decisions/README.md
+	python3 $(OKF)/okf_index.py --bundle-root docs/decisions \
+		--index --index-output docs/decisions/index.md \
+		--index-title "Architecture Decision Records" --exclude README.md
+
+# ADR の frontmatter を OKF 規約に照らして検証する (全件 frontmatter 必須、ADR 0010)。
+adr-okf:
+	@echo "Validating ADR frontmatter (OKF)..."
+	python3 $(OKF)/okf_validate.py --bundle-root docs/decisions \
+		--require type,title,status,timestamp --exclude README.md
+	python3 $(OKF)/okf_index.py --bundle-root docs/decisions \
+		--table --columns id,title,timestamp,status --headers "ADR,タイトル,日付,ステータス" \
+		--link-column id --exclude README.md --table-output docs/decisions/README.md --check
+	python3 $(OKF)/okf_index.py --bundle-root docs/decisions \
+		--index --index-output docs/decisions/index.md \
+		--index-title "Architecture Decision Records" --exclude README.md --check
+
+# 通常ドキュメント (docs) の OKF frontmatter を検証する (ADR 0010)。
+# lazy migration: --skip-missing で frontmatter 未付与ファイルは pass、付与済みのみ type/timestamp を検証。
+docs-okf:
+	@echo "Validating documentation OKF frontmatter (lazy migration, ADR 0010)..."
+	python3 $(OKF)/okf_validate.py --bundle-root docs \
+		--skip-missing --exclude $(DOCS_OKF_EXCLUDE)

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -12,18 +12,22 @@ genai-tag-db-tools の重要な設計判断を記録するドキュメント群�
 frontmatter（`type` / `title` / `status` / `timestamp` / `deciders` / `tags`、必要に応じ
 `depends_on`）を持つ。docs 全体の frontmatter 規約は [ADR 0010](0010-okf-frontmatter-for-docs.md) を参照。
 
+<!-- OKF-TABLE:START -->
 | ADR | タイトル | 日付 | ステータス |
-|-----|---------|------|-----------|
-| [0010](0010-okf-frontmatter-for-docs.md) | OKF YAML Frontmatter for Documentation | 2026-06-29 | Accepted |
-| [0009](0009-recommendation-advisory-and-feedback-routing.md) | Recommendation Advisory and Feedback Routing | 2026-06-29 | Accepted |
-| [0008](0008-stable-public-api-boundary.md) | Stable Public API Boundary | 2026-06-29 | Accepted |
-| [0007](0007-user-overlay-patch-db.md) | User Overlay Patch DB | 2026-06-29 | Accepted |
-| [0006](0006-search-filter-pushdown-and-merged-pagination.md) | Search Filter Pushdown and Merged Pagination | 2026-06-03 | Accepted |
-| [0005](0005-cli-command-introspection.md) | CLI Command Introspection Contract | 2026-06-02 | Accepted |
-| [0004](0004-search-bounded-and-correct-pagination.md) | Bounded and Correct Search Pagination | 2026-06-02 | Accepted |
-| [0003](0003-cli-jsonl-output-and-error-contract.md) | CLI JSONL Output and Structured Error Contract | 2026-06-02 | Accepted |
-| [0002](0002-cli-gui-entrypoint-policy.md) | CLI and GUI Entrypoint Policy | 2026-06-02 | Accepted |
-| [0001](0001-cli-default-database-source-policy.md) | CLI Default Database Source Policy | 2026-06-02 | Accepted |
+|---|---|---|---|
+| [0001](0001-cli-default-database-source-policy.md) | ADR 0001: CLI Default Database Source Policy | 2026-06-02 | Accepted |
+| [0002](0002-cli-gui-entrypoint-policy.md) | ADR 0002: CLI and GUI Entrypoint Policy | 2026-06-02 | Accepted |
+| [0003](0003-cli-jsonl-output-and-error-contract.md) | ADR 0003: CLI JSONL Output and Structured Error Contract | 2026-06-02 | Accepted |
+| [0004](0004-search-bounded-and-correct-pagination.md) | ADR 0004: Bounded and Correct Search Pagination | 2026-06-02 | Accepted |
+| [0005](0005-cli-command-introspection.md) | ADR 0005: CLI Command Introspection Contract | 2026-06-02 | Accepted |
+| [0006](0006-search-filter-pushdown-and-merged-pagination.md) | ADR 0006: Search Filter Pushdown and Merged Pagination | 2026-06-03 | Accepted |
+| [0007](0007-user-overlay-patch-db.md) | ADR 0007: User Overlay Patch DB | 2026-06-29 | Accepted |
+| [0008](0008-stable-public-api-boundary.md) | ADR 0008: Stable Public API Boundary | 2026-06-29 | Accepted |
+| [0009](0009-recommendation-advisory-and-feedback-routing.md) | ADR 0009: Recommendation Advisory and Feedback Routing | 2026-06-29 | Accepted |
+| [0010](0010-okf-frontmatter-for-docs.md) | ADR 0010: OKF YAML Frontmatter for Documentation | 2026-06-29 | Accepted |
+<!-- OKF-TABLE:END -->
+
+> このテーブルは `make adr-index` が frontmatter から生成する。手編集しない。
 
 ## ADR テンプレート
 

--- a/docs/decisions/index.md
+++ b/docs/decisions/index.md
@@ -1,0 +1,12 @@
+# Architecture Decision Records
+
+* [ADR 0001: CLI Default Database Source Policy](0001-cli-default-database-source-policy.md)
+* [ADR 0002: CLI and GUI Entrypoint Policy](0002-cli-gui-entrypoint-policy.md)
+* [ADR 0003: CLI JSONL Output and Structured Error Contract](0003-cli-jsonl-output-and-error-contract.md)
+* [ADR 0004: Bounded and Correct Search Pagination](0004-search-bounded-and-correct-pagination.md)
+* [ADR 0005: CLI Command Introspection Contract](0005-cli-command-introspection.md)
+* [ADR 0006: Search Filter Pushdown and Merged Pagination](0006-search-filter-pushdown-and-merged-pagination.md)
+* [ADR 0007: User Overlay Patch DB](0007-user-overlay-patch-db.md)
+* [ADR 0008: Stable Public API Boundary](0008-stable-public-api-boundary.md)
+* [ADR 0009: Recommendation Advisory and Feedback Routing](0009-recommendation-advisory-and-feedback-routing.md)
+* [ADR 0010: OKF YAML Frontmatter for Documentation](0010-okf-frontmatter-for-docs.md)


### PR DESCRIPTION
## 概要

Issue #108。frontmatter 規約とその適用は ADR 0010 / #103 / PR #106 で完了済み。本 PR は **検証・索引生成ツール**（OKF 対応の残り「途中まで」部分）を追加する。

LoRAIro ADR 0082（LoRAIro#971）/ ADR 0069 と同じ運用に揃える。

## 変更内容

- **okf-bundle スクリプト**（stdlib only）を `.agents/skills/okf-bundle/` へ vendor
  - LoRAIro の汎用スキル `okf-bundle` と同一（`okf_validate.py` / `okf_index.py` / `_okf.py`）
- **Makefile 新規追加**:
  - `adr-okf`: `docs/decisions` を全件 frontmatter 必須で検証 + index 最新チェック
  - `adr-index`: frontmatter から README テーブル + `index.md` を生成
  - `docs-okf`: `docs` を `--skip-missing` で検証（lazy migration）
- `docs/decisions/README.md` のテーブルを **OKF-TABLE マーカー方式の生成物**へ切替（手編集をやめる）
- `docs/decisions/index.md` を frontmatter から生成

## 検証

```
make adr-okf    # OKF 検証 OK + README/index は最新
make docs-okf   # docs OK（--skip-missing）
```

いずれも pass。CI（`src/genai_tag_db_tools` のみ lint/mypy/pytest）はスクリプト vendor の影響を受けない。

## 完了条件 (#108)

- [x] `make adr-okf` が pass
- [x] `make docs-okf` が pass
- [x] `docs/decisions/README.md` が frontmatter からの生成物

Refs #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)