### PR TITLE
feat(cli): add recommend follow-up adapters

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -3,7 +3,7 @@ type: Contract
 title: tag-db CLI Contract
 status: Accepted
 timestamp: 2026-06-29
-tags: [cli, search, db-read, db-write, tag-conversion]
+tags: [cli, search, db-read, db-write, tag-conversion, recommendation, advisory, introspection]
 depends_on: [pydantic, sqlalchemy, sqlite]
 ---
 
@@ -114,6 +114,7 @@ The classification below is the **steady state** (base DBs already present, no
 | `convert` | `db_read` | conditional (see notes) |
 | `recommend tag` | `db_read` | conditional (see notes) |
 | `recommend translation` | none (pure compute) | yes |
+| `recommend record` | `db_read` | yes |
 | `register` | `db_write` | no |
 | `ensure-dbs` | `network_read`, `file_write` | no |
 
@@ -210,10 +211,13 @@ branching on the exit code.
 Tags come from `--tag` (comma-separated and/or repeated), `--file` (one tag per
 line), or stdin (one tag per line), resolved in that precedence. Reasons are
 rule-based; when a base DB is present, alias / deprecated / preferred-status
-reasons are added. With no DB hit it falls back to rule-only reasons.
+reasons are added. With no DB hit it falls back to rule-only reasons. Pass
+`--rule-only` to bypass DB initialization entirely and force the deterministic
+`repo=None` path even when base DBs are installed.
 
 ```bash
 tag-db recommend tag --tag "flower,1girl" --format-name danbooru
+tag-db recommend tag --tag flower --rule-only
 printf 'flower\n1girl\n' | tag-db recommend tag        # via stdin
 ```
 
@@ -228,15 +232,39 @@ printf 'flower\n1girl\n' | tag-db recommend tag        # via stdin
 Advisory only and **DB-independent** (pure compute, no side effects). Evaluates a
 single `--source-tag` / `--translation` pair and emits the `RefinementRecommendation`
 on the `result` line. Omit / empty `--translation` runs a missing-translation
-check. Exit code is always 0 on success. `proposals` is always empty in the CLI
-(target-scoped proposals are tracked in the follow-up issue #105).
+check. Exit code is always 0 on success.
+
+Pass `--target-scope {base,user}` and `--target-tag-id N` together to emit
+target-scoped `translation_correction` proposals. Providing only one of the pair
+is invalid input.
 
 ```bash
 tag-db recommend translation --source-tag flower --translation "花" --language ja
+tag-db recommend translation --source-tag flower --translation flower --language ja --target-scope user --target-tag-id 1000000001
 ```
 
 ```jsonl
 {"kind": "result", "ok": true, "message": "translation recommendation", "source_tag": "flower", "normalized_tag": "flower", "needs_refinement": false, "score": 0.0, "reasons": [], "suggestions": [], "proposals": []}
+```
+
+### recommend record — advisory refinement recommendation for search records (`db_read`)
+
+Consumes `tag-db search` JSONL from stdin and evaluates each `kind:"item"` row
+with `recommend_tag_record_refinement`. `kind:"result"` and `kind:"event"` lines
+are ignored; `kind:"error"` or invalid JSONL is invalid input. Each input item
+emits one `RefinementRecommendation` `item`, followed by a final count `result`.
+
+The default path uses the data already present in the search row and does not
+initialize DBs again. `--base-db` / `--user-db-dir` may be provided when
+repository metadata is needed.
+
+```bash
+tag-db search --query flower --limit 3 | tag-db recommend record --format-name danbooru
+```
+
+```jsonl
+{"kind": "item", "source_tag": "flower", "normalized_tag": "flower", "needs_refinement": false, "score": 0.0, "reasons": [], "suggestions": [], "proposals": []}
+{"kind": "result", "ok": true, "message": "record recommendations completed", "total": 1, "needs_refinement_count": 0}
 ```
 
 ### ensure-dbs — download base DBs (`network_read`, `file_write`)

--- a/docs/decisions/0011-recommend-cli-followups.md
+++ b/docs/decisions/0011-recommend-cli-followups.md
@@ -1,0 +1,52 @@
+---
+type: ADR
+title: "ADR 0011: Recommendation CLI Follow-up Adapters"
+status: Accepted
+timestamp: 2026-06-29
+deciders: NEXTAltair
+tags: [cli, recommendation, advisory, introspection]
+depends_on: [argparse, pydantic]
+---
+
+# ADR 0011: Recommendation CLI Follow-up Adapters
+
+## Context
+
+Issue #102 exposed `recommend tag` and `recommend translation` as thin CLI
+adapters over the recommendation public API. Issue #105 adds the deferred pieces:
+record-level recommendations from `search` JSONL, target-scoped translation
+proposals, and deterministic rule-only tag checks even when base DBs are present.
+
+These commands are advisory and must remain read-only. The CLI should not
+reimplement recommendation logic that already lives in `core_api`.
+
+## Decision
+
+- `recommend tag --rule-only` bypasses DB initialization and calls
+  `recommend_manual_refinement(..., repo=None)`.
+- `recommend translation` accepts `--target-scope {base,user}` with
+  `--target-tag-id`; the pair is validated together and forwarded to
+  `recommend_translation_quality`.
+- `recommend record` reads JSONL from stdin, processes only `kind:"item"` rows,
+  rejects `kind:"error"` or invalid rows, and emits one `RefinementRecommendation`
+  `item` per input row plus a final count `result`.
+- `recommend/record` is registered in CLI introspection with `db_read` side
+  effects because it may initialize a reader for format metadata.
+
+## Rationale
+
+`--rule-only` is an explicit escape hatch for deterministic checks and CI smoke
+tests; it avoids hidden HF cache/network behavior while preserving the existing
+DB-backed default. Target-scoped translation arguments expose existing core API
+proposal behavior without inventing CLI-side proposal construction. JSONL stdin
+for `recommend record` keeps the command composable with `tag-db search` and
+preserves the one-record-per-line CLI contract.
+
+## Consequences
+
+- `recommend tag --tag flower` can still return no refinement when the DB has a
+  valid exact tag, while `--rule-only` returns rule-based broad-word advisory
+  output.
+- Consumers can pipe `search` into `recommend record` without parsing arrays.
+- Docs, CLI tests, and introspection tests must stay aligned with the three
+  recommendation subcommands.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -25,6 +25,7 @@ frontmatter（`type` / `title` / `status` / `timestamp` / `deciders` / `tags`、
 | [0008](0008-stable-public-api-boundary.md) | ADR 0008: Stable Public API Boundary | 2026-06-29 | Accepted |
 | [0009](0009-recommendation-advisory-and-feedback-routing.md) | ADR 0009: Recommendation Advisory and Feedback Routing | 2026-06-29 | Accepted |
 | [0010](0010-okf-frontmatter-for-docs.md) | ADR 0010: OKF YAML Frontmatter for Documentation | 2026-06-29 | Accepted |
+| [0011](0011-recommend-cli-followups.md) | ADR 0011: Recommendation CLI Follow-up Adapters | 2026-06-29 | Accepted |
 <!-- OKF-TABLE:END -->
 
 > このテーブルは `make adr-index` が frontmatter から生成する。手編集しない。

--- a/docs/decisions/index.md
+++ b/docs/decisions/index.md
@@ -10,3 +10,4 @@
 * [ADR 0008: Stable Public API Boundary](0008-stable-public-api-boundary.md)
 * [ADR 0009: Recommendation Advisory and Feedback Routing](0009-recommendation-advisory-and-feedback-routing.md)
 * [ADR 0010: OKF YAML Frontmatter for Documentation](0010-okf-frontmatter-for-docs.md)
+* [ADR 0011: Recommendation CLI Follow-up Adapters](0011-recommend-cli-followups.md)

--- a/src/genai_tag_db_tools/cli.py
+++ b/src/genai_tag_db_tools/cli.py
@@ -455,14 +455,12 @@ def _validate_recommend_record_row(row: Mapping[str, object], line_number: int) 
         raise ValueError(f"stdin line {line_number} item is missing tag/source_tag")
 
 
-def _collect_recommend_record_rows(lines: Iterable[str]) -> tuple[list[dict[str, object]], bool]:
-    """Collect `kind:item` JSONL payloads from `search` output.
+def _iter_recommend_record_rows(lines: Iterable[str]) -> Iterable[tuple[dict[str, object] | None, bool]]:
+    """Yield parsed record rows and result-line markers from `search` output.
 
     Search result summaries and events are ignored. Structured error lines are treated
     as invalid input because recommendation output would otherwise hide upstream failure.
     """
-    rows: list[dict[str, object]] = []
-    saw_result = False
     for line_number, line in enumerate(lines, start=1):
         stripped = line.strip()
         if not stripped:
@@ -479,31 +477,40 @@ def _collect_recommend_record_rows(lines: Iterable[str]) -> tuple[list[dict[str,
             row = dict(payload)
             row.pop("kind", None)
             _validate_recommend_record_row(row, line_number)
-            rows.append(row)
+            yield row, False
         elif kind == "error":
             raise ValueError(f"stdin line {line_number} is an upstream error line")
-        elif kind in {"event", "result"}:
-            saw_result = saw_result or kind == "result"
+        elif kind == "result":
+            yield None, True
+        elif kind == "event":
             continue
         else:
             raise ValueError(f"stdin line {line_number} has unsupported kind: {kind!r}")
-    return rows, saw_result
 
 
-def _record_rows_need_repo(rows: Iterable[Mapping[str, object]], format_name: str | None) -> bool:
-    """Return True when repo metadata is needed to resolve numeric format_status keys."""
-    for row in rows:
-        requested_format = format_name or row.get("format_name")
-        if not requested_format or str(requested_format) == "unknown":
-            continue
-        format_statuses = row.get("format_statuses") or {}
-        if not isinstance(format_statuses, Mapping):
-            continue
-        if str(requested_format) in format_statuses:
-            continue
-        if any(str(key).isdigit() for key in format_statuses):
-            return True
-    return False
+def _prepare_recommend_record_row(
+    row: dict[str, object],
+    *,
+    format_name: str | None,
+    repo: object | None,
+) -> dict[str, object]:
+    """Avoid false missing-format findings when only numeric status keys are available."""
+    if repo is not None:
+        return row
+    requested_format = format_name or row.get("format_name")
+    if not requested_format or str(requested_format) == "unknown":
+        return row
+    format_statuses = row.get("format_statuses") or {}
+    if not isinstance(format_statuses, Mapping):
+        return row
+    if str(requested_format) in format_statuses:
+        return row
+    if not any(str(key).isdigit() for key in format_statuses):
+        return row
+
+    fallback_row = dict(row)
+    fallback_row.pop("format_statuses", None)
+    return fallback_row
 
 
 def cmd_recommend_record(args: argparse.Namespace) -> None:
@@ -523,17 +530,26 @@ def cmd_recommend_record(args: argparse.Namespace) -> None:
         format_name=args.format_name,
         target_scope=args.target_scope,
     )
-    rows, saw_result = _collect_recommend_record_rows(sys.stdin)
     repo = None
-    if args.base_db or args.user_db_dir or _record_rows_need_repo(rows, request.format_name):
+    if args.base_db or args.user_db_dir:
         _set_db_paths(args.base_db, args.user_db_dir)
         repo = get_default_reader()
 
     total = 0
     needs_refinement_count = 0
-    for row in rows:
-        recommendation = recommend_tag_record_refinement(
+    saw_result = False
+    for row, is_result in _iter_recommend_record_rows(sys.stdin):
+        if is_result:
+            saw_result = True
+            continue
+        assert row is not None
+        prepared_row = _prepare_recommend_record_row(
             row,
+            format_name=request.format_name,
+            repo=repo,
+        )
+        recommendation = recommend_tag_record_refinement(
+            prepared_row,
             format_name=request.format_name,
             target_scope=request.target_scope,
             repo=repo,

--- a/src/genai_tag_db_tools/cli.py
+++ b/src/genai_tag_db_tools/cli.py
@@ -3,7 +3,7 @@ import csv
 import json
 import sys
 import traceback
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 
 from genai_tag_db_tools import errors
@@ -441,12 +441,28 @@ def cmd_recommend_translation(args: argparse.Namespace) -> None:
     emit_result("translation recommendation", **recommendation.model_dump())
 
 
-def _iter_recommend_record_rows(lines: Iterable[str]) -> Iterable[dict[str, object]]:
-    """Yield `kind:item` JSONL payloads from `search` output.
+def _validate_recommend_record_row(row: Mapping[str, object], line_number: int) -> None:
+    if "tag_id" not in row:
+        raise ValueError(f"stdin line {line_number} item is missing tag_id")
+    tag_id = row["tag_id"]
+    if not isinstance(tag_id, int | str):
+        raise ValueError(f"stdin line {line_number} item has invalid tag_id")
+    try:
+        int(tag_id)
+    except ValueError as exc:
+        raise ValueError(f"stdin line {line_number} item has invalid tag_id") from exc
+    if not row.get("tag") and not row.get("source_tag"):
+        raise ValueError(f"stdin line {line_number} item is missing tag/source_tag")
+
+
+def _collect_recommend_record_rows(lines: Iterable[str]) -> tuple[list[dict[str, object]], bool]:
+    """Collect `kind:item` JSONL payloads from `search` output.
 
     Search result summaries and events are ignored. Structured error lines are treated
     as invalid input because recommendation output would otherwise hide upstream failure.
     """
+    rows: list[dict[str, object]] = []
+    saw_result = False
     for line_number, line in enumerate(lines, start=1):
         stripped = line.strip()
         if not stripped:
@@ -462,13 +478,32 @@ def _iter_recommend_record_rows(lines: Iterable[str]) -> Iterable[dict[str, obje
         if kind == "item":
             row = dict(payload)
             row.pop("kind", None)
-            yield row
+            _validate_recommend_record_row(row, line_number)
+            rows.append(row)
         elif kind == "error":
             raise ValueError(f"stdin line {line_number} is an upstream error line")
         elif kind in {"event", "result"}:
+            saw_result = saw_result or kind == "result"
             continue
         else:
             raise ValueError(f"stdin line {line_number} has unsupported kind: {kind!r}")
+    return rows, saw_result
+
+
+def _record_rows_need_repo(rows: Iterable[Mapping[str, object]], format_name: str | None) -> bool:
+    """Return True when repo metadata is needed to resolve numeric format_status keys."""
+    for row in rows:
+        requested_format = format_name or row.get("format_name")
+        if not requested_format or str(requested_format) == "unknown":
+            continue
+        format_statuses = row.get("format_statuses") or {}
+        if not isinstance(format_statuses, Mapping):
+            continue
+        if str(requested_format) in format_statuses:
+            continue
+        if any(str(key).isdigit() for key in format_statuses):
+            return True
+    return False
 
 
 def cmd_recommend_record(args: argparse.Namespace) -> None:
@@ -488,14 +523,15 @@ def cmd_recommend_record(args: argparse.Namespace) -> None:
         format_name=args.format_name,
         target_scope=args.target_scope,
     )
+    rows, saw_result = _collect_recommend_record_rows(sys.stdin)
     repo = None
-    if args.base_db or args.user_db_dir:
+    if args.base_db or args.user_db_dir or _record_rows_need_repo(rows, request.format_name):
         _set_db_paths(args.base_db, args.user_db_dir)
         repo = get_default_reader()
 
     total = 0
     needs_refinement_count = 0
-    for row in _iter_recommend_record_rows(sys.stdin):
+    for row in rows:
         recommendation = recommend_tag_record_refinement(
             row,
             format_name=request.format_name,
@@ -508,6 +544,13 @@ def cmd_recommend_record(args: argparse.Namespace) -> None:
             needs_refinement_count += 1
 
     if total == 0:
+        if saw_result:
+            emit_result(
+                "record recommendations completed",
+                total=0,
+                needs_refinement_count=0,
+            )
+            return
         emit_error(
             errors.INVALID_INPUT,
             "no item records found on stdin",

--- a/src/genai_tag_db_tools/cli.py
+++ b/src/genai_tag_db_tools/cli.py
@@ -29,6 +29,7 @@ from genai_tag_db_tools.models import (
     DbCacheConfig,
     DbSourceRef,
     EnsureDbRequest,
+    RecordRecommendRequest,
     RefinementRecommendRequest,
     TagRegisterRequest,
     TagSearchRequest,
@@ -393,10 +394,16 @@ def cmd_recommend_tag(args: argparse.Namespace) -> None:
         sys.exit(2)
 
     # introspection 契約 (RefinementRecommendRequest) で format_name を検証/正規化。
-    request = RefinementRecommendRequest(tags=",".join(tags), format_name=args.format_name)
+    request = RefinementRecommendRequest(
+        tags=",".join(tags),
+        format_name=args.format_name,
+        rule_only=args.rule_only,
+    )
 
-    _set_db_paths(args.base_db, args.user_db_dir)
-    repo = get_default_reader()
+    repo = None
+    if not request.rule_only:
+        _set_db_paths(args.base_db, args.user_db_dir)
+        repo = get_default_reader()
 
     needs_refinement_count = 0
     for tag in tags:
@@ -421,13 +428,99 @@ def cmd_recommend_translation(args: argparse.Namespace) -> None:
         source_tag=args.source_tag,
         translation=args.translation,
         language=args.language,
+        target_scope=args.target_scope,
+        target_tag_id=args.target_tag_id,
     )
     recommendation = recommend_translation_quality(
         request.source_tag,
         request.translation,
         language=request.language,
+        target_scope=request.target_scope,
+        target_tag_id=request.target_tag_id,
     )
     emit_result("translation recommendation", **recommendation.model_dump())
+
+
+def _iter_recommend_record_rows(lines: Iterable[str]) -> Iterable[dict[str, object]]:
+    """Yield `kind:item` JSONL payloads from `search` output.
+
+    Search result summaries and events are ignored. Structured error lines are treated
+    as invalid input because recommendation output would otherwise hide upstream failure.
+    """
+    for line_number, line in enumerate(lines, start=1):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            payload = json.loads(stripped)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"invalid JSONL on stdin at line {line_number}") from exc
+        if not isinstance(payload, dict):
+            raise ValueError(f"stdin line {line_number} must be a JSON object")
+
+        kind = payload.get("kind")
+        if kind == "item":
+            row = dict(payload)
+            row.pop("kind", None)
+            yield row
+        elif kind == "error":
+            raise ValueError(f"stdin line {line_number} is an upstream error line")
+        elif kind in {"event", "result"}:
+            continue
+        else:
+            raise ValueError(f"stdin line {line_number} has unsupported kind: {kind!r}")
+
+
+def cmd_recommend_record(args: argparse.Namespace) -> None:
+    """`recommend record`: `search` JSONL item rows の refinement を advisory 判定する。"""
+    from genai_tag_db_tools.core_api import recommend_tag_record_refinement
+
+    if sys.stdin.isatty():
+        emit_error(
+            errors.INVALID_INPUT,
+            "no JSONL records provided on stdin (pipe tag-db search output)",
+            retryable=False,
+            user_action_required=True,
+        )
+        sys.exit(2)
+
+    request = RecordRecommendRequest(
+        format_name=args.format_name,
+        target_scope=args.target_scope,
+    )
+    repo = None
+    if args.base_db or args.user_db_dir:
+        _set_db_paths(args.base_db, args.user_db_dir)
+        repo = get_default_reader()
+
+    total = 0
+    needs_refinement_count = 0
+    for row in _iter_recommend_record_rows(sys.stdin):
+        recommendation = recommend_tag_record_refinement(
+            row,
+            format_name=request.format_name,
+            target_scope=request.target_scope,
+            repo=repo,
+        )
+        emit_item(recommendation)
+        total += 1
+        if recommendation.needs_refinement:
+            needs_refinement_count += 1
+
+    if total == 0:
+        emit_error(
+            errors.INVALID_INPUT,
+            "no item records found on stdin",
+            retryable=False,
+            user_action_required=True,
+        )
+        sys.exit(2)
+
+    emit_result(
+        "record recommendations completed",
+        total=total,
+        needs_refinement_count=needs_refinement_count,
+    )
 
 
 def cmd_describe(args: argparse.Namespace) -> None:
@@ -598,6 +691,11 @@ def build_parser(prog: str = "tag-db") -> argparse.ArgumentParser:
         default="unknown",
         help="Target format name for DB-backed reasons (default: unknown).",
     )
+    recommend_tag_parser.add_argument(
+        "--rule-only",
+        action="store_true",
+        help="Bypass DB reads and use deterministic rule-only recommendation logic.",
+    )
     _add_base_db_args(recommend_tag_parser)
     recommend_tag_parser.set_defaults(func=cmd_recommend_tag)
 
@@ -615,7 +713,33 @@ def build_parser(prog: str = "tag-db") -> argparse.ArgumentParser:
         default="ja",
         help="Translation language code (default: ja).",
     )
+    recommend_translation_parser.add_argument(
+        "--target-scope",
+        choices=["base", "user"],
+        help="Patch target scope for proposal output. Must be paired with --target-tag-id.",
+    )
+    recommend_translation_parser.add_argument(
+        "--target-tag-id",
+        type=int,
+        help="Patch target tag id for proposal output. Must be paired with --target-scope.",
+    )
     recommend_translation_parser.set_defaults(func=cmd_recommend_translation)
+
+    recommend_record_parser = recommend_subs.add_parser(
+        "record",
+        help="Recommend refinement for tag search JSONL item records from stdin.",
+    )
+    recommend_record_parser.add_argument(
+        "--format-name",
+        help="Target format name. Defaults to each input row format_name or unknown.",
+    )
+    recommend_record_parser.add_argument(
+        "--target-scope",
+        choices=["base", "user"],
+        help="Override proposal target scope. Defaults to inference from tag_id.",
+    )
+    _add_base_db_args(recommend_record_parser)
+    recommend_record_parser.set_defaults(func=cmd_recommend_record)
 
     list_commands_parser = subparsers.add_parser(
         "list-commands",

--- a/src/genai_tag_db_tools/cli.py
+++ b/src/genai_tag_db_tools/cli.py
@@ -505,7 +505,7 @@ def _prepare_recommend_record_row(
         return row
     if str(requested_format) in format_statuses:
         return row
-    if not any(str(key).isdigit() for key in format_statuses):
+    if not all(str(key).isdigit() for key in format_statuses):
         return row
 
     fallback_row = dict(row)

--- a/src/genai_tag_db_tools/introspection.py
+++ b/src/genai_tag_db_tools/introspection.py
@@ -30,6 +30,7 @@ from genai_tag_db_tools.models import (
     ConvertTagsResult,
     EnsureDbRequest,
     EnsureDbResult,
+    RecordRecommendRequest,
     RefinementRecommendation,
     RefinementRecommendRequest,
     TagRegisterRequest,
@@ -131,10 +132,18 @@ TOOL_SPECS: dict[str, ToolSpec] = {
     ),
     "recommend/translation": ToolSpec(
         name="recommend/translation",
-        description="Advisory translation-quality recommendation (rule-only, no DB).",
+        description="Advisory translation-quality recommendation (rule-only, optional target proposals).",
         side_effects=(),
         read_only=True,
         input_model=TranslationRecommendRequest,
+        output_model=RefinementRecommendation,
+    ),
+    "recommend/record": ToolSpec(
+        name="recommend/record",
+        description="Advisory refinement recommendation for search result records.",
+        side_effects=("db_read",),
+        read_only=True,
+        input_model=RecordRecommendRequest,
         output_model=RefinementRecommendation,
     ),
 }

--- a/src/genai_tag_db_tools/models.py
+++ b/src/genai_tag_db_tools/models.py
@@ -426,6 +426,7 @@ class RefinementRecommendRequest(BaseModel):
 
     tags: str = Field(..., description="Comma-separated input tags")
     format_name: str = Field(default="unknown", description="Target format name for DB-backed reasons")
+    rule_only: bool = Field(default=False, description="Bypass DB reads and use deterministic rule-only checks")
 
 
 class TranslationRecommendRequest(BaseModel):
@@ -437,6 +438,37 @@ class TranslationRecommendRequest(BaseModel):
     source_tag: str = Field(..., description="Original source tag")
     translation: str | None = Field(default=None, description="Observed translation (None/empty = missing)")
     language: str = Field(default="ja", description="Translation language code")
+    target_scope: Literal["base", "user"] | None = Field(
+        default=None,
+        description="Patch target scope; must be paired with target_tag_id",
+    )
+    target_tag_id: int | None = Field(
+        default=None,
+        description="Patch target tag id; must be paired with target_scope",
+    )
+
+    @model_validator(mode="after")
+    def _validate_target_pair(self) -> TranslationRecommendRequest:
+        if (self.target_scope is None) != (self.target_tag_id is None):
+            raise ValueError("target_scope and target_tag_id must be provided together")
+        return self
+
+
+class RecordRecommendRequest(BaseModel):
+    """`recommend record` リクエスト（CLI/introspection 契約用）。
+
+    実レコードは stdin JSONL の `kind:"item"` 行から受け取る。CLI 引数としては、
+    行内の format 情報を解釈するための補助指定だけを持つ。
+    """
+
+    format_name: str | None = Field(
+        default=None,
+        description="Target format name; defaults to each input row format_name or unknown",
+    )
+    target_scope: Literal["base", "user"] | None = Field(
+        default=None,
+        description="Override target scope; otherwise inferred from tag_id",
+    )
 
 
 class ApprovedDbFeedback(BaseModel):

--- a/tests/unit/test_cli_integration.py
+++ b/tests/unit/test_cli_integration.py
@@ -765,3 +765,80 @@ class TestCmdRecommendRecord:
 
         with pytest.raises(ValueError, match="upstream error"):
             cmd_recommend_record(args)
+
+    def test_empty_search_result_stream_is_success(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        stdin = io.StringIO(json.dumps({"kind": "result", "ok": True, "message": "search completed"}))
+        monkeypatch.setattr("sys.stdin", stdin)
+        args = argparse.Namespace(format_name=None, target_scope=None, base_db=None, user_db_dir=None)
+
+        cmd_recommend_record(args)
+
+        lines = _parse_jsonl(capsys.readouterr().out)
+        assert lines == [
+            {
+                "kind": "result",
+                "ok": True,
+                "message": "record recommendations completed",
+                "total": 0,
+                "needs_refinement_count": 0,
+            }
+        ]
+
+    def test_malformed_item_missing_tag_id_is_invalid_input(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        stdin = io.StringIO(json.dumps({"kind": "item", "tag": "flower"}))
+        monkeypatch.setattr("sys.stdin", stdin)
+        args = argparse.Namespace(format_name=None, target_scope=None, base_db=None, user_db_dir=None)
+
+        with pytest.raises(ValueError, match="missing tag_id"):
+            cmd_recommend_record(args)
+
+    @patch("genai_tag_db_tools.cli.get_default_reader")
+    @patch("genai_tag_db_tools.cli._set_db_paths")
+    @patch("genai_tag_db_tools.core_api.recommend_tag_record_refinement")
+    def test_numeric_format_status_keys_initialize_repo_metadata(
+        self,
+        mock_recommend: MagicMock,
+        mock_set_db_paths: MagicMock,
+        mock_reader: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        mock_recommend.return_value = RefinementRecommendation(
+            source_tag="custom tag",
+            normalized_tag="custom tag",
+            needs_refinement=False,
+            score=0.0,
+        )
+        stdin = io.StringIO(
+            json.dumps(
+                {
+                    "kind": "item",
+                    "tag": "custom tag",
+                    "tag_id": 1_000_000_001,
+                    "format_name": "Lorairo",
+                    "format_statuses": {
+                        "1000": {
+                            "alias": False,
+                            "deprecated": False,
+                            "type_id": 0,
+                            "type_name": "unknown",
+                            "preferred_tag_id": 1_000_000_001,
+                        }
+                    },
+                }
+            )
+        )
+        monkeypatch.setattr("sys.stdin", stdin)
+        args = argparse.Namespace(format_name=None, target_scope=None, base_db=None, user_db_dir=None)
+
+        cmd_recommend_record(args)
+
+        mock_set_db_paths.assert_called_once_with(None, None)
+        mock_reader.assert_called_once()
+        assert mock_recommend.call_args.kwargs["repo"] is mock_reader.return_value

--- a/tests/unit/test_cli_integration.py
+++ b/tests/unit/test_cli_integration.py
@@ -838,3 +838,51 @@ class TestCmdRecommendRecord:
         passed_row = mock_recommend.call_args.args[0]
         assert "format_statuses" not in passed_row
         assert mock_recommend.call_args.kwargs["repo"] is None
+
+    @patch("genai_tag_db_tools.core_api.recommend_tag_record_refinement")
+    def test_mixed_format_status_keys_are_preserved_without_repo(
+        self,
+        mock_recommend: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        mock_recommend.return_value = RefinementRecommendation(
+            source_tag="custom tag",
+            normalized_tag="custom tag",
+            needs_refinement=True,
+            score=0.5,
+        )
+        format_statuses = {
+            "e621": {
+                "alias": False,
+                "deprecated": False,
+                "type_id": 0,
+                "type_name": "general",
+                "preferred_tag_id": 1_000_000_001,
+            },
+            "1000": {
+                "alias": False,
+                "deprecated": False,
+                "type_id": 0,
+                "type_name": "unknown",
+                "preferred_tag_id": 1_000_000_001,
+            },
+        }
+        stdin = io.StringIO(
+            json.dumps(
+                {
+                    "kind": "item",
+                    "tag": "custom tag",
+                    "tag_id": 1_000_000_001,
+                    "format_name": "Lorairo",
+                    "format_statuses": format_statuses,
+                }
+            )
+        )
+        monkeypatch.setattr("sys.stdin", stdin)
+        args = argparse.Namespace(format_name="danbooru", target_scope=None, base_db=None, user_db_dir=None)
+
+        cmd_recommend_record(args)
+
+        passed_row = mock_recommend.call_args.args[0]
+        assert passed_row["format_statuses"] == format_statuses
+        assert mock_recommend.call_args.kwargs["repo"] is None

--- a/tests/unit/test_cli_integration.py
+++ b/tests/unit/test_cli_integration.py
@@ -14,6 +14,7 @@ Note: cmd_ensure_dbsはHF cache自動管理により実質的に不要になっ�
 from __future__ import annotations
 
 import argparse
+import io
 import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -22,6 +23,7 @@ import pytest
 
 from genai_tag_db_tools.cli import (
     cmd_convert,
+    cmd_recommend_record,
     cmd_recommend_tag,
     cmd_recommend_translation,
     cmd_register,
@@ -481,6 +483,7 @@ class TestCmdRecommendTag:
             tag=["flower,1girl"],
             file=None,
             format_name="danbooru",
+            rule_only=False,
             base_db=[str(base_db)],
             user_db_dir=None,
         )
@@ -520,6 +523,7 @@ class TestCmdRecommendTag:
             tag=["flower"],
             file=None,
             format_name="unknown",
+            rule_only=False,
             base_db=[str(base_db)],
             user_db_dir=None,
         )
@@ -551,6 +555,7 @@ class TestCmdRecommendTag:
             tag=None,
             file=str(tags_file),
             format_name="unknown",
+            rule_only=False,
             base_db=[str(base_db)],
             user_db_dir=None,
         )
@@ -571,6 +576,7 @@ class TestCmdRecommendTag:
             tag=None,
             file=None,
             format_name="unknown",
+            rule_only=False,
             base_db=None,
             user_db_dir=None,
         )
@@ -580,6 +586,40 @@ class TestCmdRecommendTag:
         lines = _parse_jsonl(capsys.readouterr().out)
         assert lines[-1]["kind"] == "error"
         assert lines[-1]["code"] == "INVALID_INPUT"
+
+    @patch("genai_tag_db_tools.cli.get_default_reader")
+    @patch("genai_tag_db_tools.core_api.recommend_manual_refinement")
+    def test_rule_only_bypasses_db_reader(
+        self,
+        mock_recommend: MagicMock,
+        mock_reader: MagicMock,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """--rule-only は DB 初期化/readers を使わず repo=None 経路へ委譲する。"""
+        mock_recommend.return_value = RefinementRecommendation(
+            source_tag="flower",
+            normalized_tag="flower",
+            needs_refinement=True,
+            score=0.6,
+            reasons=[RefinementReason(code="broad_single_word", message="broad")],
+            suggestions=[RefinementSuggestion(kind="review_only")],
+        )
+        args = argparse.Namespace(
+            tag=["flower"],
+            file=None,
+            format_name="unknown",
+            rule_only=True,
+            base_db=None,
+            user_db_dir=None,
+        )
+
+        cmd_recommend_tag(args)
+
+        mock_reader.assert_not_called()
+        mock_recommend.assert_called_once()
+        assert mock_recommend.call_args.args[1] is None
+        lines = _parse_jsonl(capsys.readouterr().out)
+        assert lines[0]["reasons"][0]["code"] == "broad_single_word"
 
 
 class TestCmdRecommendTranslation:
@@ -600,13 +640,128 @@ class TestCmdRecommendTranslation:
             reasons=[RefinementReason(code="missing_translation", message="empty")],
             suggestions=[RefinementSuggestion(kind="review_only")],
         )
-        args = argparse.Namespace(source_tag="flower", translation="", language="ja")
+        args = argparse.Namespace(
+            source_tag="flower",
+            translation="",
+            language="ja",
+            target_scope=None,
+            target_tag_id=None,
+        )
         cmd_recommend_translation(args)
 
-        mock_recommend.assert_called_once_with("flower", "", language="ja")
+        mock_recommend.assert_called_once_with(
+            "flower",
+            "",
+            language="ja",
+            target_scope=None,
+            target_tag_id=None,
+        )
         lines = _parse_jsonl(capsys.readouterr().out)
         assert len(lines) == 1
         assert lines[0]["kind"] == "result"
         assert lines[0]["source_tag"] == "flower"
         assert lines[0]["needs_refinement"] is True
         assert lines[0]["reasons"][0]["code"] == "missing_translation"
+
+    @patch("genai_tag_db_tools.core_api.recommend_translation_quality")
+    def test_target_args_are_forwarded_for_proposals(
+        self,
+        mock_recommend: MagicMock,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """target scope/id を core_api へ渡し、proposal 付き recommendation を出力する。"""
+        mock_recommend.return_value = RefinementRecommendation(
+            source_tag="flower",
+            normalized_tag="flower",
+            needs_refinement=True,
+            score=0.9,
+            reasons=[RefinementReason(code="wrong_language_translation", message="wrong")],
+            suggestions=[RefinementSuggestion(kind="review_only")],
+        )
+        args = argparse.Namespace(
+            source_tag="flower",
+            translation="flower",
+            language="ja",
+            target_scope="user",
+            target_tag_id=1_000_000_001,
+        )
+
+        cmd_recommend_translation(args)
+
+        mock_recommend.assert_called_once_with(
+            "flower",
+            "flower",
+            language="ja",
+            target_scope="user",
+            target_tag_id=1_000_000_001,
+        )
+        lines = _parse_jsonl(capsys.readouterr().out)
+        assert lines[0]["kind"] == "result"
+
+
+class TestCmdRecommendRecord:
+    """Test cmd_recommend_record command (search JSONL stdin adapter)."""
+
+    @patch("genai_tag_db_tools.core_api.recommend_tag_record_refinement")
+    def test_reads_search_items_from_stdin(
+        self,
+        mock_recommend: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        mock_recommend.side_effect = lambda row, **_kwargs: RefinementRecommendation(
+            source_tag=row["tag"],
+            normalized_tag=row["tag"],
+            needs_refinement=row["tag"] == "flower",
+            score=0.6 if row["tag"] == "flower" else 0.0,
+            reasons=[RefinementReason(code="broad_single_word", message="broad")]
+            if row["tag"] == "flower"
+            else [],
+            suggestions=[RefinementSuggestion(kind="review_only")] if row["tag"] == "flower" else [],
+        )
+        stdin = io.StringIO(
+            "\n".join(
+                [
+                    json.dumps({"kind": "item", "tag": "flower", "tag_id": 1, "format_name": "danbooru"}),
+                    json.dumps({"kind": "result", "ok": True, "message": "search completed"}),
+                    json.dumps({"kind": "item", "tag": "1girl", "tag_id": 2, "format_name": "danbooru"}),
+                ]
+            )
+        )
+        monkeypatch.setattr("sys.stdin", stdin)
+        args = argparse.Namespace(
+            format_name="danbooru",
+            target_scope="base",
+            base_db=None,
+            user_db_dir=None,
+        )
+
+        cmd_recommend_record(args)
+
+        assert mock_recommend.call_count == 2
+        assert mock_recommend.call_args_list[0].kwargs == {
+            "format_name": "danbooru",
+            "target_scope": "base",
+            "repo": None,
+        }
+        lines = _parse_jsonl(capsys.readouterr().out)
+        assert [line["kind"] for line in lines] == ["item", "item", "result"]
+        assert lines[-1]["total"] == 2
+        assert lines[-1]["needs_refinement_count"] == 1
+
+    def test_upstream_error_line_is_invalid_input(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        stdin = io.StringIO(
+            json.dumps(
+                {
+                    "kind": "error",
+                    "ok": False,
+                    "code": "DB_ERROR",
+                    "message": "upstream failed",
+                }
+            )
+        )
+        monkeypatch.setattr("sys.stdin", stdin)
+        args = argparse.Namespace(format_name=None, target_scope=None, base_db=None, user_db_dir=None)
+
+        with pytest.raises(ValueError, match="upstream error"):
+            cmd_recommend_record(args)

--- a/tests/unit/test_cli_integration.py
+++ b/tests/unit/test_cli_integration.py
@@ -799,14 +799,10 @@ class TestCmdRecommendRecord:
         with pytest.raises(ValueError, match="missing tag_id"):
             cmd_recommend_record(args)
 
-    @patch("genai_tag_db_tools.cli.get_default_reader")
-    @patch("genai_tag_db_tools.cli._set_db_paths")
     @patch("genai_tag_db_tools.core_api.recommend_tag_record_refinement")
-    def test_numeric_format_status_keys_initialize_repo_metadata(
+    def test_numeric_format_status_keys_fall_back_to_row_level_without_repo(
         self,
         mock_recommend: MagicMock,
-        mock_set_db_paths: MagicMock,
-        mock_reader: MagicMock,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         mock_recommend.return_value = RefinementRecommendation(
@@ -839,6 +835,6 @@ class TestCmdRecommendRecord:
 
         cmd_recommend_record(args)
 
-        mock_set_db_paths.assert_called_once_with(None, None)
-        mock_reader.assert_called_once()
-        assert mock_recommend.call_args.kwargs["repo"] is mock_reader.return_value
+        passed_row = mock_recommend.call_args.args[0]
+        assert "format_statuses" not in passed_row
+        assert mock_recommend.call_args.kwargs["repo"] is None

--- a/tests/unit/test_cli_introspection.py
+++ b/tests/unit/test_cli_introspection.py
@@ -29,8 +29,9 @@ class TestListCommands:
             "aliases/register",
             "recommend/tag",
             "recommend/translation",
+            "recommend/record",
         }
-        assert objs[-1] == {"kind": "result", "ok": True, "message": "commands listed", "count": 8}
+        assert objs[-1] == {"kind": "result", "ok": True, "message": "commands listed", "count": 9}
 
     def test_side_effects_and_read_only(self, capsys: pytest.CaptureFixture[str]) -> None:
         tools = {
@@ -48,6 +49,16 @@ class TestListCommands:
         assert tools["recommend/tag"]["side_effects"] == ["db_read"]
         assert tools["recommend/translation"]["read_only"] is True
         assert tools["recommend/translation"]["side_effects"] == []
+        assert tools["recommend/record"]["read_only"] is True
+        assert tools["recommend/record"]["side_effects"] == ["db_read"]
+
+    def test_describe_recommend_record(self, capsys: pytest.CaptureFixture[str]) -> None:
+        objs = [json.loads(line) for line in _run(["describe", "recommend/record"], capsys)]
+        assert objs[0]["kind"] == "tool"
+        assert objs[0]["name"] == "recommend/record"
+        models = {o["role"]: o for o in objs if o["kind"] == "model"}
+        assert models["input"]["name"] == "RecordRecommendRequest"
+        assert models["output"]["name"] == "RefinementRecommendation"
 
 
 class TestDescribeCompact:


### PR DESCRIPTION
Fixes #105.

Branch: issue-105-recommend-followup
ADR: docs/decisions/0011-recommend-cli-followups.md

## Summary
- add `recommend tag --rule-only` to bypass DB initialization and force repo=None rule-only recommendations
- add translation target args (`--target-scope` / `--target-tag-id`) and forward them to core proposal generation
- add `recommend record` for `tag-db search` JSONL stdin item rows, plus introspection and docs

## Verification
- `QT_QPA_PLATFORM=offscreen UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run pytest tests/unit/test_cli_integration.py tests/unit/test_cli_introspection.py tests/unit/test_translation_quality_recommendation.py tests/unit/test_tag_record_recommendation.py -q`
- `QT_QPA_PLATFORM=offscreen UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run pytest tests/unit -q`
- `UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run mypy src/genai_tag_db_tools`
- `UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run ruff check .`
- `git diff --check`
- `make docs-okf`
- `UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run tag-db recommend tag --tag flower --rule-only`
- `UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run tag-db recommend translation --source-tag flower --translation flower --language ja --target-scope user --target-tag-id 1000000001`
- `UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run tag-db search --query flower --limit 1 | UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run tag-db recommend record`
