### PR TITLE
fix(okf): malformed frontmatter を validate で reject (3 repo 同期)

### DIFF
--- a/.agents/skills/okf-bundle/scripts/_okf.py
+++ b/.agents/skills/okf-bundle/scripts/_okf.py
@@ -32,6 +32,11 @@ def split_frontmatter(text: str) -> tuple[str, str]:
     Returns:
         ``(frontmatter_block, body)`` のタプル。frontmatter が無ければ
         ``("", text)`` を返す。frontmatter_block は ``---`` 区切り行を含まない。
+
+    Raises:
+        ValueError: 開始 ``---`` 区切りがあるのに閉じ ``---`` が無い
+            (unterminated frontmatter) 場合。``--skip-missing`` で malformed を
+            「未付与」と取り違えないための guardrail。
     """
     if not text.startswith("---"):
         return "", text
@@ -45,14 +50,22 @@ def split_frontmatter(text: str) -> tuple[str, str]:
             block = "".join(lines[1:i])
             body = "".join(lines[i + 1 :])
             return block, body
-    return "", text
+    raise ValueError("frontmatter の閉じ '---' が無い (unterminated)")
 
 
 def _strip_scalar(value: str) -> str:
-    """スカラー値の前後空白と一重/二重引用符を除去する。"""
+    """スカラー値の前後空白と一重/二重引用符を除去する。
+
+    クォートで始まるのに同じクォートで閉じていない値 (例: ``"Broken``) は
+    不正な YAML スカラーとして ``ValueError`` を送出する。frontmatter を契約とする
+    OKF バンドル (ADR 0010 / LoRAIro ADR 0082) で、検証が malformed scalar を
+    silently 通さないための guardrail。
+    """
     value = value.strip()
-    if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
-        return value[1:-1]
+    if value and value[0] in "\"'":
+        if len(value) >= 2 and value[-1] == value[0]:
+            return value[1:-1]
+        raise ValueError(f"不正な quoted scalar (クォート未終端): {value!r}")
     return value
 
 
@@ -92,7 +105,12 @@ def parse_frontmatter(text: str) -> dict[str, str | list[str]]:
         key, _, raw = line.partition(":")
         key = key.strip()
         raw = raw.strip()
-        if raw.startswith("[") and raw.endswith("]"):
+        if raw.startswith("["):
+            # inline list は ']' で閉じる必要がある。未終端 (例: ``[webapi``) は
+            # plain scalar に fall through させず reject する (tags/depends_on は
+            # 機械可読な list である契約。ADR 0010)。
+            if not raw.endswith("]"):
+                raise ValueError(f"不正な inline list (']' 未終端): {raw!r}")
             result[key] = _parse_inline_list(raw)
         elif raw == "":
             # ブロックリストの可能性: 次行以降の "  - item" を集める。

--- a/.agents/skills/okf-bundle/scripts/okf_validate.py
+++ b/.agents/skills/okf-bundle/scripts/okf_validate.py
@@ -66,7 +66,12 @@ def validate(
         count += 1
         rel = path.relative_to(bundle_root).as_posix()
         text = path.read_text(encoding="utf-8")
-        fm = parse_frontmatter(text)
+        try:
+            fm = parse_frontmatter(text)
+        except ValueError as e:
+            # 不正な YAML スカラー (クォート未終端等) は frontmatter があっても違反扱い。
+            problems.append(f"{rel}: frontmatter が不正: {e}")
+            continue
         if not fm:
             if not skip_missing:
                 problems.append(f"{rel}: frontmatter が無い")
@@ -75,7 +80,10 @@ def validate(
             if not fm.get(key):
                 problems.append(f"{rel}: 必須キー '{key}' が無い")
         timestamp = fm.get("timestamp")
-        if isinstance(timestamp, str) and timestamp and not _is_iso8601(timestamp):
+        if isinstance(timestamp, list):
+            # timestamp は scalar (日付文字列) でなければならない。list は不正。
+            problems.append(f"{rel}: timestamp が scalar でない: {timestamp!r}")
+        elif isinstance(timestamp, str) and timestamp and not _is_iso8601(timestamp):
             problems.append(f"{rel}: timestamp '{timestamp}' が ISO 8601 でない")
     if count == 0:
         problems.append(f"{bundle_root}: 概念ドキュメント (*.md) が見つからない")


### PR DESCRIPTION
## 概要

okf-bundle スクリプト（`.agents/skills/okf-bundle/scripts/`）は LoRAIro / image-annotator-lib と共有する vendor copy。image-annotator-lib #159 で Codex が検出した malformed-input guardrail 4 件を本リポジトリにも追従させ、3 repo で `_okf.py` / `okf_validate.py` を一致させる。

## 変更内容（malformed YAML を validate で reject）

- 未終端 quoted scalar（例: `title: "Broken`）→ `ValueError`
- 未終端 frontmatter（閉じ `---` 無し）→ `ValueError`（`--skip-missing` で「未付与」と誤判定するのを防ぐ）
- 未終端 inline list（例: `tags: [webapi`）→ `ValueError`
- 非 scalar timestamp（list）→ 違反報告

## 検証

`make adr-okf` / `make docs-okf` 既存 docs pass、各 malformed パターンで NG を確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)