### PR TITLE
docs: introspection registry の feedback 群非登録を確定方針として明文化 (#103)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -314,8 +314,12 @@ tag-db feedback apply-base-patches --file patches.jsonl --base-db build/cc0.sqli
 ```
 
 > Note: `aliases/register` は introspection registry (`TOOL_SPECS`) に登録済みで
-> `list-commands` / `describe` に現れるが、**`feedback` 群は未登録**のため introspection
-> には出ない。registry 同期は issue #103 で追跡中。
+> `list-commands` / `describe` に現れるが、**`feedback` 群は意図的に未登録**のため
+> introspection には出ない。これは確定方針: introspection registry は **エージェントが
+> 実行時に呼ぶ runtime コマンド面**（user DB への read/write・recommend）を公開する契約で、
+> `feedback` 群は **base DB ビルド時の保守者/builder パイプライン**（JSONL patch ファイルの
+> validate/export/apply、人間承認＋検証が前提）であり runtime のエージェント呼び出し対象では
+> ないため除外する。詳細は ADR 0009（feedback routing）/ ADR 0005（introspection contract）。
 
 ## Introspection
 

--- a/docs/decisions/0009-recommendation-advisory-and-feedback-routing.md
+++ b/docs/decisions/0009-recommendation-advisory-and-feedback-routing.md
@@ -45,3 +45,10 @@ epic #2「タグ手動変更リコメンド」は、`needs_manual_refinement(tag
 - リコメンド自体は DB を書き換えない。書き込みは feedback apply（user-local）／builder apply（base）に限定。
 - 下流（LoRAIro）はレビュー UI で本 API を public API 経由で消費する（ADR 0008）。
 - CLI からの recommend 露出は別途 issue #102 で対応（public API との parity）。
+- **introspection registry（`TOOL_SPECS`, ADR 0005）への登録は runtime のエージェント呼び出し
+  対象に限る。** `recommend/*` と `aliases/register`（runtime・user DB 操作）は登録して
+  `list-commands` / `describe` に露出するが、**CLI `feedback` 群（base DB ビルド時の保守者/builder
+  パイプライン）は意図的に未登録**とする。base patch の validate/export/apply は人間承認＋検証を
+  前提とするビルド工程であり、エージェントが実行時に発見・自動実行する runtime コマンド面では
+  ないため。この非対称は `tests/unit/test_cli_feedback.py::test_list_commands_unchanged_by_feedback_group`
+  で固定する（issue #103）。

--- a/tests/unit/test_cli_feedback.py
+++ b/tests/unit/test_cli_feedback.py
@@ -90,8 +90,11 @@ def test_export_then_apply_cli(tmp_path: Path, capsys: pytest.CaptureFixture[str
 
 
 def test_list_commands_unchanged_by_feedback_group(capsys: pytest.CaptureFixture[str]) -> None:
-    # feedback subcommands are intentionally not registered as tool specs,
-    # so the introspection command set stays stable.
+    # feedback subcommands are intentionally not registered as tool specs
+    # (settled policy: ADR 0009 / ADR 0005 / docs/cli.md, issue #103). The
+    # introspection registry exposes runtime agent-callable commands only;
+    # the feedback group is a base-DB build-time maintainer pipeline, so it
+    # stays out of the introspection command set.
     objs = _run(["list-commands"], capsys)
     names = {o["name"] for o in objs if o["kind"] == "tool"}
     assert "feedback" not in names


### PR DESCRIPTION
## 概要

issue #103 の最後の残タスク **「introspection registry のコード同期（feedback 群を `TOOL_SPECS` に登録するか方針確定）」** を解決する。docs では現状を明文化済みだったが、cli.md の Note が「registry 同期は issue #103 で追跡中」のままで決着していなかった。

## 決定

introspection registry は **runtime のエージェント呼び出し対象**（user DB の read/write・recommend）を公開する契約とし、**`feedback` 群は意図的に未登録**で確定する。

- 登録: `recommend/*`, `aliases/register`（runtime・user DB 操作 → discoverable）
- 非登録: CLI `feedback` 群（base DB ビルド時の保守者/builder パイプライン。JSONL patch の validate/export/apply で人間承認＋検証が前提であり、エージェントが実行時に発見・自動実行する runtime コマンド面ではない）

## 変更

- `docs/cli.md`: feedback 節の Note を「#103 で追跡中」から確定方針へ書き換え（ADR 0009 / ADR 0005 参照）
- `docs/decisions/0009-recommendation-advisory-and-feedback-routing.md`: Consequences に introspection 登録スコープの決定を追記
- `tests/unit/test_cli_feedback.py`: 非登録テストの docstring に確定方針/ADR 参照を追記

## 検証

- `make adr-okf` / `make docs-okf`: OK
- CI-equivalent filter `pytest -m "not slow and not network"` (`QT_QPA_PLATFORM=offscreen`): **768 passed, 1 skipped**

これで issue #103 の Acceptance / 残チェックボックスは全て充足。コード挙動の変更なし。

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)