### PR TITLE
feat(api): write_user_translation 公開 API を追加 (LoRAIro #989)

### DIFF
--- a/src/genai_tag_db_tools/__init__.py
+++ b/src/genai_tag_db_tools/__init__.py
@@ -38,6 +38,7 @@ from .core_api import (
     register_tag,
     search_tags,
     update_tags_type_batch,
+    write_user_translation,
 )
 from .models import (
     ApprovedDbFeedback,
@@ -103,6 +104,7 @@ __all__ = [
     "register_tag",
     "search_tags",
     "update_tags_type_batch",
+    "write_user_translation",
 ]
 
 

--- a/src/genai_tag_db_tools/api.py
+++ b/src/genai_tag_db_tools/api.py
@@ -101,6 +101,7 @@ class TagWriterProtocol(Protocol):
     """
 
     def update_tags_type_batch(self, *args: Any, **kwargs: Any) -> Any: ...
+    def write_user_translation(self, *args: Any, **kwargs: Any) -> Any: ...
 
 
 def get_tag_reader() -> TagReaderProtocol:

--- a/src/genai_tag_db_tools/core_api.py
+++ b/src/genai_tag_db_tools/core_api.py
@@ -1559,3 +1559,29 @@ def update_tags_type_batch(repo_writer, tag_updates: list, format_id: int) -> No
         >>> update_tags_type_batch(repo, updates, format_id=1000)
     """
     repo_writer.update_tags_type_batch(tag_updates, format_id)
+
+
+def write_user_translation(repo_writer, tag_id: int, language: str, translation: str) -> None:
+    """タグに言語別翻訳を user DB overlay として追加します。
+
+    翻訳行は user DB の ``USER_TAG_TRANSLATION_PATCH`` にのみ書き込まれます（base DB は
+    書き換えません）。``target_scope`` は ``tag_id`` から自動導出されます
+    （``USER_TAG_ID_OFFSET`` 以上なら "user"、それ未満なら "base"）。同一
+    (scope, tag_id, language, translation) の重複は無視されます。
+
+    Args:
+        repo_writer: TagRepository インスタンス（``get_user_repository()`` で取得、書き込み権限が必要）
+        tag_id: 翻訳を付与する対象タグの tag_id（base / user どちらでも可）
+        language: 言語コード（例: ``ja``）
+        translation: 翻訳文字列
+
+    Raises:
+        Exception: 書き込みに失敗した場合
+
+    Example:
+        >>> from genai_tag_db_tools import write_user_translation
+        >>> from genai_tag_db_tools.db.runtime import get_default_repository
+        >>> repo = get_default_repository()
+        >>> write_user_translation(repo, 123, "ja", "青い目")
+    """
+    repo_writer.write_user_translation(tag_id, language, translation)

--- a/src/genai_tag_db_tools/db/repository.py
+++ b/src/genai_tag_db_tools/db/repository.py
@@ -1212,17 +1212,26 @@ class TagRepository:
         """Add a translation overlay for ``tag_id`` to the user database.
 
         Writes a row into the user DB ``USER_TAG_TRANSLATION_PATCH`` table (never the
-        base DB). ``target_scope`` is derived from ``tag_id``: ids at or above
-        ``USER_TAG_ID_OFFSET`` belong to the user scope, everything below to the base
-        scope. The base-scope case still writes only to the user DB overlay; the scope
-        merely records which tag the overlay points at so the merged reader can surface
-        it on the corresponding base tag. Duplicate (scope, tag_id, language, translation)
-        rows are ignored.
+        base DB). ``target_scope`` records which tag the overlay points at so the merged
+        reader can surface it on the corresponding base/user tag; the row itself always
+        lives only in the user DB. Duplicate (scope, tag_id, language, translation) rows
+        are ignored.
+
+        Scope is resolved through the injected reader (``get_tag_scope``) when available,
+        which checks actual repository membership rather than the numeric offset. This
+        avoids mis-tagging a low-id user tag (legacy TAGS path) as base scope. If the
+        reader cannot find ``tag_id`` in any scope the write is rejected with
+        ``ValueError`` so callers never create an orphan FK-less patch for a stale or
+        mistyped id. When no reader is injected the method falls back to the
+        ``USER_TAG_ID_OFFSET`` heuristic (no existence validation).
 
         Args:
-            tag_id: Target tag id (base or user scope; scope is derived automatically).
+            tag_id: Target tag id (base or user scope; scope is resolved automatically).
             language: Language code (e.g. ``ja``).
             translation: Translation string to register.
+
+        Raises:
+            ValueError: If a reader is available and ``tag_id`` exists in no scope.
 
         Example:
             >>> repo = get_default_repository()
@@ -1230,7 +1239,14 @@ class TagRepository:
         """
         from genai_tag_db_tools.db.user_tag_repository import UserTagRepository
 
-        target_scope = "user" if tag_id >= USER_TAG_ID_OFFSET else "base"
+        if self._reader is not None:
+            target_scope = self._reader.get_tag_scope(tag_id)
+            if target_scope is None:
+                # 対象タグがどの scope にも存在しない → orphan patch を書かず拒否する。
+                raise ValueError(f"write_user_translation: tag_id={tag_id} not found in any scope")
+        else:
+            # reader 未注入 (直接生成等) は offset ヒューリスティックへ縮退する。
+            target_scope = "user" if tag_id >= USER_TAG_ID_OFFSET else "base"
         user_repo = UserTagRepository(self.session_factory)
         user_repo.write_translation_patch(
             target_scope=target_scope,

--- a/src/genai_tag_db_tools/db/repository.py
+++ b/src/genai_tag_db_tools/db/repository.py
@@ -18,6 +18,7 @@ from genai_tag_db_tools.db.query_utils import (
     normalize_search_keyword,
 )
 from genai_tag_db_tools.db.schema import (
+    USER_TAG_ID_OFFSET,
     DatabaseMetadata,
     Tag,
     TagFormat,
@@ -1206,6 +1207,37 @@ class TagRepository:
                 session.rollback()
                 self.logger.error(f"Failed to update tag types in batch: {e}", exc_info=True)
                 raise
+
+    def write_user_translation(self, tag_id: int, language: str, translation: str) -> None:
+        """Add a translation overlay for ``tag_id`` to the user database.
+
+        Writes a row into the user DB ``USER_TAG_TRANSLATION_PATCH`` table (never the
+        base DB). ``target_scope`` is derived from ``tag_id``: ids at or above
+        ``USER_TAG_ID_OFFSET`` belong to the user scope, everything below to the base
+        scope. The base-scope case still writes only to the user DB overlay; the scope
+        merely records which tag the overlay points at so the merged reader can surface
+        it on the corresponding base tag. Duplicate (scope, tag_id, language, translation)
+        rows are ignored.
+
+        Args:
+            tag_id: Target tag id (base or user scope; scope is derived automatically).
+            language: Language code (e.g. ``ja``).
+            translation: Translation string to register.
+
+        Example:
+            >>> repo = get_default_repository()
+            >>> repo.write_user_translation(123, "ja", "青い目")
+        """
+        from genai_tag_db_tools.db.user_tag_repository import UserTagRepository
+
+        target_scope = "user" if tag_id >= USER_TAG_ID_OFFSET else "base"
+        user_repo = UserTagRepository(self.session_factory)
+        user_repo.write_translation_patch(
+            target_scope=target_scope,
+            target_tag_id=tag_id,
+            language=language,
+            translation=translation,
+        )
 
 
 class MergedTagReader:

--- a/tests/unit/test_user_tag_repository.py
+++ b/tests/unit/test_user_tag_repository.py
@@ -633,3 +633,32 @@ class TestWriteUserTranslation:
         rows = self._rows(user_session_factory)
         assert len(rows) == 1
         assert rows[0].translation == "金髪"
+
+    def test_reader_scope_overrides_offset_heuristic(self, user_session_factory):
+        """reader 注入時は get_tag_scope の実スコープ判定を offset より優先する。
+
+        低 ID でも reader が "user" と判定すれば user scope で書く (legacy TAGS path、
+        Codex #113 P2)。
+        """
+
+        class _FakeReader:
+            def get_tag_scope(self, tag_id: int) -> str | None:
+                return "user"  # 低 ID でも user 判定
+
+        repo = TagRepository(session_factory=user_session_factory, reader=_FakeReader())
+        repo.write_user_translation(123, "ja", "猫耳")  # 低 ID だが reader は user
+        rows = self._rows(user_session_factory)
+        assert len(rows) == 1
+        assert rows[0].target_scope == "user"
+
+    def test_rejects_missing_tag_when_reader_present(self, user_session_factory):
+        """reader が tag_id をどの scope にも見つけなければ orphan patch を拒否する。"""
+
+        class _FakeReader:
+            def get_tag_scope(self, tag_id: int) -> str | None:
+                return None  # 存在しない
+
+        repo = TagRepository(session_factory=user_session_factory, reader=_FakeReader())
+        with pytest.raises(ValueError, match="not found in any scope"):
+            repo.write_user_translation(999, "ja", "幽霊")
+        assert self._rows(user_session_factory) == []

--- a/tests/unit/test_user_tag_repository.py
+++ b/tests/unit/test_user_tag_repository.py
@@ -11,6 +11,8 @@ from sqlalchemy import text
 from sqlalchemy.orm import sessionmaker
 
 from genai_tag_db_tools.db.runtime import _create_engine
+from genai_tag_db_tools.core_api import write_user_translation
+from genai_tag_db_tools.db.repository import TagRepository
 from genai_tag_db_tools.db.schema import (
     USER_TAG_ID_OFFSET,
     Base,
@@ -20,6 +22,7 @@ from genai_tag_db_tools.db.schema import (
     TagTypeName,
     UserOverlayBase,
     UserTagStatusPatch,
+    UserTagTranslationPatch,
 )
 from genai_tag_db_tools.db.user_tag_repository import UserTagRepository
 from genai_tag_db_tools.models import TagRegisterRequest
@@ -586,3 +589,47 @@ class TestTagRegisterServiceBaseScope:
 
         mock_user_repo.create_user_tag.assert_not_called()
         mock_user_repo.write_patch.assert_not_called()
+
+
+class TestWriteUserTranslation:
+    """TagRepository.write_user_translation と公開ラッパーの overlay 書き込み検証 (#989)。"""
+
+    @pytest.fixture()
+    def repo(self, user_session_factory) -> TagRepository:
+        # write_user_translation は session_factory のみ使用 (reader 不要)。
+        return TagRepository(session_factory=user_session_factory)
+
+    def _rows(self, user_session_factory) -> list[UserTagTranslationPatch]:
+        with user_session_factory() as session:
+            return session.query(UserTagTranslationPatch).all()
+
+    def test_user_scope_derived_from_offset(self, repo, user_session_factory):
+        """tag_id >= USER_TAG_ID_OFFSET なら target_scope='user' で書かれる。"""
+        repo.write_user_translation(USER_TAG_ID_OFFSET + 5, "ja", "青い目")
+        rows = self._rows(user_session_factory)
+        assert len(rows) == 1
+        assert rows[0].target_scope == "user"
+        assert rows[0].target_tag_id == USER_TAG_ID_OFFSET + 5
+        assert rows[0].language == "ja"
+        assert rows[0].translation == "青い目"
+
+    def test_base_scope_derived_for_low_tag_id(self, repo, user_session_factory):
+        """tag_id < USER_TAG_ID_OFFSET なら base タグを指す overlay を user DB に書く。"""
+        repo.write_user_translation(123, "ja", "猫耳")
+        rows = self._rows(user_session_factory)
+        assert len(rows) == 1
+        assert rows[0].target_scope == "base"
+        assert rows[0].target_tag_id == 123
+
+    def test_duplicate_is_ignored(self, repo, user_session_factory):
+        """同一 (scope, tag_id, language, translation) の重複は無視される。"""
+        repo.write_user_translation(123, "ja", "猫耳")
+        repo.write_user_translation(123, "ja", "猫耳")
+        assert len(self._rows(user_session_factory)) == 1
+
+    def test_public_wrapper_delegates(self, repo, user_session_factory):
+        """公開ラッパー write_user_translation が repo_writer へ委譲する。"""
+        write_user_translation(repo, USER_TAG_ID_OFFSET + 1, "ja", "金髪")
+        rows = self._rows(user_session_factory)
+        assert len(rows) == 1
+        assert rows[0].translation == "金髪"


### PR DESCRIPTION
## 目的

LoRAIro #989 (TagPanelWidget の翻訳追加 / ADR 0083 Phase 2) で、user DB へ翻訳 overlay を
書き込む公開 API を提供する。現状 `write_translation_patch` は `UserTagRepository` の内部
メソッドで公開 API に未露出のため、LoRAIro が内部 import せずに済むよう `update_tags_type_batch`
と対称な公開ラッパーを足す。

## 変更

- `TagRepository.write_user_translation(tag_id, language, translation)` を追加。
  `tag_id` から `target_scope` を導出 (`>= USER_TAG_ID_OFFSET` → `"user"` / 未満 → `"base"`) し
  `UserTagRepository.write_translation_patch` へ委譲。**書き込みは user DB の
  `USER_TAG_TRANSLATION_PATCH` のみ、base DB は書き換えない**(`target_scope` は対象タグの
  所属を記録するだけ)。
- `core_api.write_user_translation(repo_writer, ...)` 公開ラッパー。
- `TagWriterProtocol` / `__init__.__all__` に公開シンボル追加。
- tests: user/base scope 導出・重複無視・公開ラッパー委譲。

## テスト

`make test-genai-tag` (CI-equivalent `-m "not slow and not network"`) → **773 passed** (新規4件含む)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)