### PR TITLE
fix(db): _create_engine() から StaticPool を削除しマルチスレッド競合を解消

### DIFF
--- a/src/genai_tag_db_tools/db/runtime.py
+++ b/src/genai_tag_db_tools/db/runtime.py
@@ -2,7 +2,7 @@ import logging
 from pathlib import Path
 from typing import Any
 
-from sqlalchemy import Engine, StaticPool, create_engine, event
+from sqlalchemy import Engine, create_engine, event
 from sqlalchemy.orm import Session, sessionmaker
 
 from genai_tag_db_tools.db.schema import Base, UserOverlayBase
@@ -51,7 +51,6 @@ def _create_engine(db_path: Path) -> Engine:
     engine = create_engine(
         f"sqlite:///{db_path.absolute()}",
         connect_args={"check_same_thread": False},
-        poolclass=StaticPool,
         echo=False,
     )
     event.listen(engine, "connect", enable_foreign_keys)

--- a/tests/unit/test_runtime_engine_concurrency.py
+++ b/tests/unit/test_runtime_engine_concurrency.py
@@ -1,0 +1,82 @@
+"""_create_engine() のマルチスレッド同時アクセス回帰テスト (Issue #116)。
+
+`poolclass=StaticPool` を指定していた頃は、全セッションが単一の生 sqlite3
+コネクションを共有し、複数スレッドから同時に SQL を発行すると
+``sqlite3.InterfaceError: bad parameter or other API misuse`` が発生していた。
+
+`_create_engine()` は常に実ファイル `Path` を受け取るため、SQLAlchemy 既定の
+`QueuePool` (スレッドごとに独立したコネクションを払い出す) に任せることで
+この競合を回避する。本テストは実ファイル SQLite DB に対して複数スレッドから
+同時にセッションを発行し、例外なく完了することを検証する。
+"""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import QueuePool
+
+from genai_tag_db_tools.db.runtime import _create_engine
+from genai_tag_db_tools.db.schema import Base, TagFormat
+
+THREAD_COUNT = 8
+ITERATIONS_PER_THREAD = 20
+
+
+def test_create_engine_uses_default_queue_pool(tmp_path: Path) -> None:
+    """_create_engine() が StaticPool を指定せず既定の QueuePool を使うこと。"""
+    db_path = tmp_path / "pool_class.sqlite"
+    engine = _create_engine(db_path)
+    try:
+        assert isinstance(engine.pool, QueuePool)
+    finally:
+        engine.dispose()
+
+
+def test_concurrent_sessions_do_not_raise_interface_error(tmp_path: Path) -> None:
+    """複数スレッドが実ファイルDBへ同時にセッションを発行しても例外が出ないこと。
+
+    修正前 (StaticPool) では、全スレッドが単一の生 sqlite3 コネクションを
+    共有するため、同時アクセス時に
+    ``sqlite3.InterfaceError: bad parameter or other API misuse`` を再現できた。
+    """
+    db_path = tmp_path / "concurrent.sqlite"
+    engine = _create_engine(db_path)
+    Base.metadata.create_all(engine)
+
+    with sessionmaker(bind=engine, autoflush=False, autocommit=False)() as setup_session:
+        setup_session.add(TagFormat(format_id=1, format_name="danbooru"))
+        setup_session.commit()
+
+    session_factory = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+
+    errors: list[BaseException] = []
+    errors_lock = threading.Lock()
+
+    def worker() -> None:
+        try:
+            for _ in range(ITERATIONS_PER_THREAD):
+                with session_factory() as session:
+                    result = session.execute(
+                        select(TagFormat.format_id).where(TagFormat.format_name.in_(["danbooru"]))
+                    ).scalars().all()
+                    assert result == [1]
+        except BaseException as exc:  # スレッド内例外を親スレッドで検知するため意図的に広く捕捉
+            with errors_lock:
+                errors.append(exc)
+
+    threads = [threading.Thread(target=worker) for _ in range(THREAD_COUNT)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=30)
+
+    engine.dispose()
+
+    assert not any(thread.is_alive() for thread in threads), "スレッドがタイムアウトしました"
+    if errors:
+        pytest.fail(f"並行アクセス中に例外が発生しました: {errors!r}")


### PR DESCRIPTION
## 症状

LoRAIro 側 (`RefinementWorker`, LoRAIro #931) がバックグラウンド QThread から `genai_tag_db_tools` 経由でタグ情報（翻訳・type・format）を評価する際、メインスレッドと同時に SQLite へアクセスすると以下の例外が発生していた。

```
ERROR ワーカー実行エラー: (sqlite3.InterfaceError) bad parameter or other API misuse
[SQL: SELECT "TAG_FORMATS".format_id ... WHERE "TAG_FORMATS".format_name IN (?)]
[parameters: ('danbooru',)]
```

例外が飛ばないケースでは古い（直前の変更を含まない）結果が返ることがあり、呼び出し元（LoRAIro 側 GUI）で「編集が消えた」ように見える回帰の一因にもなっていた。

## 原因

`src/genai_tag_db_tools/db/runtime.py` の `_create_engine()` が `poolclass=StaticPool` を指定していた。`StaticPool` は「1本の生 SQLite コネクションを全セッションで使い回す」プールであり、`connect_args={"check_same_thread": False}` は Python 側のスレッドチェックを無効化するだけで、根底の `sqlite3.Connection` への真の同時アクセス（複数スレッドからの同時 SQL 発行）は防げない。これが `bad parameter or other API misuse` の直接原因。

## 修正

`_create_engine()` から `poolclass=StaticPool` を削除し、SQLAlchemy 既定の `QueuePool`（スレッドごとに独立したコネクションを払い出す）に委ねた。`_create_engine()` は常に実ファイル `Path` を受け取る関数であり `:memory:` 分岐は不要なため、単純な削除のみで対応可能。未使用になった `StaticPool` の import も削除した。

```python
def _create_engine(db_path: Path) -> Engine:
    engine = create_engine(
        f"sqlite:///{db_path.absolute()}",
        connect_args={"check_same_thread": False},
        echo=False,
    )
    event.listen(engine, "connect", enable_foreign_keys)
    return engine
```

## テスト

`tests/unit/test_runtime_engine_concurrency.py` を新規追加:

- `test_create_engine_uses_default_queue_pool`: `_create_engine()` が生成する engine の pool が `QueuePool` であることを検証。
- `test_concurrent_sessions_do_not_raise_interface_error`: 実ファイル SQLite DB（tmp_path 上、`:memory:` ではない）に対し、8 スレッドが同時にセッションを発行して SQL を実行しても例外なく完了することを検証。

**回帰テストの有効性を確認済み**: 修正前のコード（`poolclass=StaticPool` を復元）に対して本テストを実行したところ、issue と同一の `sqlite3.InterfaceError: bad parameter or other API misuse` を確認・再現できた。修正後は同テストが安定して pass する。

既存の `:memory:` を使うテスト群（`test_feedback_apply_models.py` 等、および `StaticPool` を直接指定している他の unit test）は本変更の影響を受けないことを確認済み。

CI-equivalent filter (`-m "not slow and not network"`) で全体検証:

```
801 passed, 8 warnings in 265.93s (0:04:25)
```

## 関連

- Closes #116
- LoRAIro 側: NEXTAltair/LoRAIro#1002（同根本原因の LoRAIro 本体側 `db_core.py` 修正を含む。submodule pin 更新は本 PR merge 後に LoRAIro 側で実施）

🤖 Generated with [Claude Code](https://claude.com/claude-code)