### PR TITLE
fix(db): create_tag の reader 読み戻し依存を廃し挿入 id を直接返す

### DIFF
--- a/src/genai_tag_db_tools/db/repository.py
+++ b/src/genai_tag_db_tools/db/repository.py
@@ -604,16 +604,28 @@ class TagRepository:
         if existing_id is not None:
             return existing_id
 
-        new_tag_data = {"source_tag": source_tag, "tag": tag}
-        df = pl.DataFrame(new_tag_data)
-        self.bulk_insert_tags(df)
-
-        tag_id = self._reader.get_tag_id_by_name(tag, partial=False)
-        if tag_id is None:
-            msg = ErrorMessages.TAG_ID_NOT_FOUND_AFTER_INSERT
-            self.logger.error(msg)
-            raise ValueError(msg)
-        return tag_id
+        # #124: bulk_insert → reader 読み戻しの 2 段構えは、writer と reader の間に
+        # 正規化・可視性のドリフトがあると「挿入は成功したのに id を返せない」
+        # (TAG_ID_NOT_FOUND_AFTER_INSERT) 失敗を作る。挿入と id 取得を同一 session で
+        # 完結させ、読み戻しに依存しない。
+        with self.session_factory() as session:
+            existing = session.query(Tag).filter(Tag.tag == tag).one_or_none()
+            if existing is not None:
+                return existing.tag_id
+            new_tag = Tag(source_tag=source_tag, tag=tag)
+            session.add(new_tag)
+            try:
+                session.commit()
+            except IntegrityError as e:
+                session.rollback()
+                # 並行登録に負けた場合は勝者の id を返す
+                winner = session.query(Tag).filter(Tag.tag == tag).one_or_none()
+                if winner is not None:
+                    return winner.tag_id
+                msg = ErrorMessages.DB_OPERATION_FAILED.format(error_msg=str(e))
+                self.logger.error(msg)
+                raise ValueError(msg) from e
+            return new_tag.tag_id
 
     def update_tag(self, tag_id: int, *, source_tag: str | None = None, tag: str | None = None) -> None:
         with self.session_factory() as session:

--- a/src/genai_tag_db_tools/utils/messages.py
+++ b/src/genai_tag_db_tools/utils/messages.py
@@ -22,7 +22,6 @@ class ErrorMessages:
 
     # --- データベース関連のエラーメッセージ ---
     DB_OPERATION_FAILED = "データベース操作に失敗しました: {error_msg}"
-    TAG_ID_NOT_FOUND_AFTER_INSERT = "挿入後にタグ ID が見つかりませんでした。"
     INVALID_TAG_ID_DELETION_ATTEMPT = "存在しないタグID {tag_id} の削除を試みました。"
     MISSING_REQUIRED_FIELDS = "登録時に必要なデータが欠けています: {fields}"
     MISSING_TAG_FORMAT = "指定されたタグフォーマットが見つかりません。: {format_name}"

--- a/tests/unit/test_tag_repository.py
+++ b/tests/unit/test_tag_repository.py
@@ -42,6 +42,48 @@ def test_create_tag_returns_existing_id(session_factory: Callable[[], Session]) 
     assert first_id == second_id
 
 
+def test_create_tag_returns_inserted_id_without_reader_readback(
+    session_factory: Callable[[], Session],
+) -> None:
+    """#124: reader 読み戻しに依存せず、挿入した行の id を直接返す。
+
+    実運用では writer と reader の間に正規化・可視性のドリフトが起こり得る。
+    「reader が常に None を返す」最悪ケースでも create_tag は挿入 id を返し、
+    TAG_ID_NOT_FOUND_AFTER_INSERT 相当の失敗を起こしてはならない。
+    """
+
+    class _BlindReader:
+        """挿入済みタグを見つけられない (ドリフトした) reader のスタブ。"""
+
+        def get_tag_id_by_name(self, keyword: str, partial: bool = False) -> int | None:
+            return None
+
+    repo = TagRepository(session_factory, reader=_BlindReader())
+
+    tag_id = repo.create_tag("__lock_test__", "lock test")
+
+    assert isinstance(tag_id, int)
+    with session_factory() as session:
+        row = session.query(Tag).filter(Tag.tag == "lock test").one()
+        assert row.tag_id == tag_id
+        assert row.source_tag == "__lock_test__"
+
+
+def test_create_tag_returns_existing_id_when_reader_is_blind(
+    session_factory: Callable[[], Session],
+) -> None:
+    """#124: reader が既存タグを見落としても、同一 session の存在確認で既存 id を返す。"""
+
+    class _BlindReader:
+        def get_tag_id_by_name(self, keyword: str, partial: bool = False) -> int | None:
+            return None
+
+    repo = TagRepository(session_factory, reader=_BlindReader())
+    first_id = repo.create_tag("witch", "witch")
+    second_id = repo.create_tag("witch", "witch")
+    assert first_id == second_id
+
+
 def test_bulk_insert_tags_deduplicates_by_tag(session_factory: Callable[[], Session]) -> None:
     reader = TagReader(session_factory)
     repo = TagRepository(session_factory, reader=MergedTagReader(base_repo=reader))


### PR DESCRIPTION
## 概要

`TagRepository.create_tag` は `bulk_insert_tags` 実行後に `reader.get_tag_id_by_name(tag)` で読み戻す 2 段構えで、writer と reader の間に正規化・可視性のドリフトがあると「挿入は成功したのに id を返せない」(`TAG_ID_NOT_FOUND_AFTER_INSERT` で ValueError) 失敗を作る。LoRAIro 側で `tag='__lock_test__'` 登録時に実機ログで確認された (Issue の再現)。呼び出し側は fallback で `tag_id=None` 保存 → tag_db と未リンクの孤立タグになる。

Closes #124

## 変更内容 (Issue の修正候補 2 を採用)

- 挿入と id 取得を**同一 session で完結**させ、reader 読み戻しに依存しない (`session.add` + `commit` → `new_tag.tag_id`)
- 挿入前の存在確認も同一 session で行い、reader が既存タグを見落としても既存 id を返す
- 並行登録に負けた場合 (IntegrityError) は rollback 後に勝者の id を返す。それでも見つからない場合のみ `DB_OPERATION_FAILED` で raise
- 到達不能になった `TAG_ID_NOT_FOUND_AFTER_INSERT` メッセージを削除
- 回帰テスト 2 件: 「reader が常に None を返す (ドリフトした)」最悪ケースでも挿入 id / 既存 id を返すこと

なお in-memory DB での単純再現 (`create_tag('__lock_test__', ...)`) は成功するため、実機の失敗はスコープ/DB 可視性のドリフトが濃厚。本修正はドリフトの種類に依らず読み戻し失敗モードを構造的に排除する。

## 検証

- `pytest -m "not slow and not network"` (CI-equivalent filter, QT_QPA_PLATFORM=offscreen) → **829 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)