### PR TITLE
fix(refinement): 簡体字専用文字集合の取りこぼしを拡充し ja 翻訳の中国語検出を強化

### DIFF
--- a/src/genai_tag_db_tools/core/language_detection.py
+++ b/src/genai_tag_db_tools/core/language_detection.py
@@ -63,10 +63,15 @@ _LATIN_ALPHA_PATTERN = re.compile(r"[A-Za-z]")
 # Japanese writing. Presence of any of these in an otherwise Han-only string is a
 # strong, low-maintenance signal that the text is Chinese rather than Japanese.
 # This is intentionally a *gating/fallback* signal, not an exhaustive dictionary.
+# Precision first (#120): only characters whose simplified form differs from the
+# Japanese shinjitai/joyo form may enter this set (e.g. 连↔連, 兽↔獣, 黑↔黒,
+# 丝↔糸). Never add glyphs shared with Japanese (e.g. 体, 学, 国, 双, 灯).
 CHINESE_SPECIFIC_CHARS = frozenset(
     "们这为么发头见观蓝绿红龙马门风鸟鱼脸长单师网让边过还进车东应电话语说译"
     "图团园课实间问难题颜爱乐习时觉现样资质贝贵费钟银错镜组级纪约纳纸线练经给"
     "绍续维罗妈爸哥姐弟妹钱铁钢银货买卖东应义乡书将专丧丰临举"
+    # #120: lingua が ambiguous を返す短い漢字語の取りこぼし対策で拡充した分
+    "连兽黑丝达汉鸡兰丽两页严亚华变动处备层带岛简谁纯绝继齐"
 )
 
 # Below this top-vs-second confidence margin a non-CJK detection is treated as

--- a/tests/unit/test_language_detection.py
+++ b/tests/unit/test_language_detection.py
@@ -153,5 +153,25 @@ class TestLinguaDetectorWithFakeBackend:
 def test_module_exposes_chinese_specific_chars() -> None:
     assert "蓝" in language_detection.CHINESE_SPECIFIC_CHARS
     # Characters shared with Japanese must not be in the gate set.
-    for shared in "猫黄色青和服国学体":
+    for shared in "猫黄色青和服国学体双灯":
         assert shared not in language_detection.CHINESE_SPECIFIC_CHARS
+
+
+class TestSimplifiedOnlyCharGate120:
+    """#120: lingua が ambiguous を返す簡体字語を決定的に CHINESE 判定する。"""
+
+    def test_issue_samples_are_asserted_chinese(self) -> None:
+        # lingua 実測で JAPANESE (ambiguous) となり素通りしていたサンプル (#120)
+        detector = ScriptHeuristicLanguageDetector()
+        for sample in ("连衣裙", "兽耳", "黑丝"):
+            result = detector.detect(sample)
+            assert result.language is DetectedLanguage.CHINESE, sample
+            assert result.is_ambiguous is False, sample
+
+    def test_shared_glyph_words_stay_ambiguous_japanese(self) -> None:
+        # 日中で字形が同じ語は判別不能のため保守判定のまま (偽陽性防止を優先)
+        detector = ScriptHeuristicLanguageDetector()
+        for sample in ("猫耳", "校服", "泳装", "黄色", "和服"):
+            result = detector.detect(sample)
+            assert result.language is DetectedLanguage.JAPANESE, sample
+            assert result.is_ambiguous is True, sample


### PR DESCRIPTION
## 概要

`recommend_translation_quality(language="ja")` の中国語検出で、lingua が短い漢字語に ambiguous を返すと `wrong_language_translation` が素通りしていた (実測 10 サンプル中 6 件)。

Closes #120

## 真因と対応

Issue 提案の「簡体字専用文字による決定的チェック」の**機構は既存** (`_script_gate` が `CHINESE_SPECIFIC_CHARS` を含む文字列を lingua に依らず決定的に CHINESE 判定する)。素通りの真因は集合に 连/兽/黑/丝 等の高頻度な簡体字専用文字が欠けていたこと。

- 簡体字専用 (日本語の新字体/常用漢字に字形が存在しない) 文字 26 字を追加: `连兽黑丝达汉鸡兰丽两页严亚华变动处备层带岛简谁纯绝继齐`
- precision 優先の追加基準 (簡体字↔新字体で字形が異なるものだけ。体/学/国/双/灯 のような日中共有字形は入れない) をコメントとテストに明文化
- 回帰テスト: Issue の素通りサンプル (`连衣裙` / `兽耳` / `黑丝`) が決定的 CHINESE 判定になること、日中同形語 (`猫耳` / `校服` / `泳装` / `黄色` / `和服`) は従来どおり保守判定 (ambiguous JAPANESE) のままであること

## 検証

- `pytest -m "not slow and not network"` (CI-equivalent filter, QT_QPA_PLATFORM=offscreen) → **829 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)