### PR TITLE
feat(overlay): 翻訳 overlay の削除・base 翻訳の抑制 (tombstone) API を追加

### DIFF
--- a/src/genai_tag_db_tools/__init__.py
+++ b/src/genai_tag_db_tools/__init__.py
@@ -25,6 +25,7 @@ from .core_api import (
     build_downloaded_at_utc,
     clear_preferred_translation,
     convert_tags,
+    delete_user_translation,
     ensure_databases,
     get_all_type_names,
     get_format_type_names,
@@ -42,6 +43,8 @@ from .core_api import (
     search_tags_batch,
     set_preferred_translation,
     update_tags_type_batch,
+    suppress_translation,
+    unsuppress_translation,
     write_user_translation,
 )
 from .models import (
@@ -87,6 +90,7 @@ __all__ = [
     "build_downloaded_at_utc",
     "clear_preferred_translation",
     "convert_tags",
+    "delete_user_translation",
     "create_tag_register_service",
     "ensure_databases",
     "get_all_type_names",
@@ -112,6 +116,8 @@ __all__ = [
     "search_tags_batch",
     "set_preferred_translation",
     "update_tags_type_batch",
+    "suppress_translation",
+    "unsuppress_translation",
     "write_user_translation",
 ]
 

--- a/src/genai_tag_db_tools/core_api.py
+++ b/src/genai_tag_db_tools/core_api.py
@@ -1744,3 +1744,69 @@ def write_user_translation(repo_writer, tag_id: int, language: str, translation:
         >>> write_user_translation(repo, 123, "ja", "青い目")
     """
     repo_writer.write_user_translation(tag_id, language, translation)
+
+
+def delete_user_translation(repo_writer, tag_id: int, language: str, translation: str) -> bool:
+    """user DB overlay の翻訳 patch 行を削除します (#121)。
+
+    :func:`write_user_translation` で追加した user 由来の翻訳の取り消しに使います。
+    base DB 由来の翻訳行は削除できません (隠すには :func:`suppress_translation`)。
+
+    Args:
+        repo_writer: TagRepository インスタンス (``get_user_repository()`` で取得)
+        tag_id: 対象タグの tag_id (base / user どちらでも可)
+        language: 言語コード (例: ``ja``)
+        translation: 削除する翻訳文字列
+
+    Returns:
+        patch 行を削除したら True、元々無ければ False
+
+    Raises:
+        ValueError: tag_id がどの scope にも存在しない場合
+
+    Example:
+        >>> from genai_tag_db_tools import delete_user_translation
+        >>> delete_user_translation(repo, 123, "ja", "誤った訳")
+    """
+    return repo_writer.delete_user_translation(tag_id, language, translation)
+
+
+def suppress_translation(repo_writer, tag_id: int, language: str, translation: str) -> None:
+    """(tag_id, language, translation) を merged 表示から隠す tombstone を書きます (#121)。
+
+    base DB は書き換えずに、base 由来の誤訳をマージ結果 (``get_translations*`` /
+    ``search_tags*`` / 主訳) から除外します。言語の付け替えは「旧言語行の suppress +
+    新言語での :func:`write_user_translation`」で表現します。重複は無視されます。
+
+    Args:
+        repo_writer: TagRepository インスタンス (``get_user_repository()`` で取得)
+        tag_id: 対象タグの tag_id (base / user どちらでも可)
+        language: 隠す翻訳の言語コード
+        translation: 隠す翻訳文字列
+
+    Raises:
+        ValueError: tag_id がどの scope にも存在しない場合
+
+    Example:
+        >>> from genai_tag_db_tools import suppress_translation
+        >>> suppress_translation(repo, 123, "ja", "中文の誤訳")
+    """
+    repo_writer.suppress_translation(tag_id, language, translation)
+
+
+def unsuppress_translation(repo_writer, tag_id: int, language: str, translation: str) -> bool:
+    """:func:`suppress_translation` の tombstone を取り消します (#121)。
+
+    Args:
+        repo_writer: TagRepository インスタンス (``get_user_repository()`` で取得)
+        tag_id: 対象タグの tag_id
+        language: 言語コード
+        translation: 抑制を解除する翻訳文字列
+
+    Returns:
+        tombstone を削除したら True、元々無ければ False
+
+    Raises:
+        ValueError: tag_id がどの scope にも存在しない場合
+    """
+    return repo_writer.unsuppress_translation(tag_id, language, translation)

--- a/src/genai_tag_db_tools/db/overlay_reader.py
+++ b/src/genai_tag_db_tools/db/overlay_reader.py
@@ -160,9 +160,15 @@ class OverlayTagReader:
                 for row in sorted(rows, key=lambda r: r.target_scope == "user"):
                     hidden = tombstoned.get(row.target_tag_id, set())
                     if (row.target_scope, row.language, row.translation) in hidden:
+                        # 後勝ち側 (user) の行が tombstone された場合、先に積んだ
+                        # 影 (base) 値を残すと shadow の主訳が漏れるため language ごと
+                        # 取り下げる (Codex P2)
+                        if row.target_scope == "user":
+                            result.get(row.target_tag_id, {}).pop(row.language, None)
                         continue
                     result.setdefault(row.target_tag_id, {})[row.language] = row.translation
-        return result
+        # 取り下げで空になった tag_id は「設定なし」として返さない
+        return {tag_id: prefs for tag_id, prefs in result.items() if prefs}
 
     def get_all_tag_ids(self) -> list[int]:
         """USER_TAGS の全 tag_id を返す。"""
@@ -658,8 +664,12 @@ class OverlayTagReader:
             ]
 
     def list_translations(self) -> list[TagTranslation]:
+        """USER_TAG_TRANSLATION_PATCH 全件を返す (tombstone 済み行は除外、#121)。"""
         with self.session_factory() as session:
             rows = session.query(UserTagTranslationPatch).all()
+            tombstoned = self._load_translation_tombstones(
+                session, {r.target_tag_id for r in rows}
+            )
             return [
                 TagTranslation(
                     translation_id=r.patch_id,
@@ -668,6 +678,8 @@ class OverlayTagReader:
                     translation=r.translation,
                 )
                 for r in rows
+                if (r.target_scope, r.language, r.translation)
+                not in tombstoned.get(r.target_tag_id, set())
             ]
 
     def get_translations_batch(self, tag_ids: list[int]) -> dict[int, list[TagTranslation]]:

--- a/src/genai_tag_db_tools/db/overlay_reader.py
+++ b/src/genai_tag_db_tools/db/overlay_reader.py
@@ -143,6 +143,10 @@ class OverlayTagReader:
             return {}
         result: dict[int, dict[str, str]] = {}
         with self.session_factory() as session:
+            # tombstone (#121) された翻訳を指す preference は行自身の target_scope で
+            # 照合して除外する (scope を落とすと base 宛 tombstone が同 id の
+            # user-scope preference まで隠す。Codex P2)
+            tombstoned = self._load_translation_tombstones(session, set(tag_ids))
             for start in range(0, len(tag_ids), TAG_ID_IN_CHUNK):
                 chunk = list(tag_ids[start : start + TAG_ID_IN_CHUNK])
                 rows = (
@@ -154,6 +158,9 @@ class OverlayTagReader:
                 # 併存しうる (Codex P2)。呼び出し側はマージ視点 (user が base を shadow)
                 # の tag_id で引くため、base を先に処理し user 行で決定的に上書きする。
                 for row in sorted(rows, key=lambda r: r.target_scope == "user"):
+                    hidden = tombstoned.get(row.target_tag_id, set())
+                    if (row.target_scope, row.language, row.translation) in hidden:
+                        continue
                     result.setdefault(row.target_tag_id, {})[row.language] = row.translation
         return result
 

--- a/src/genai_tag_db_tools/db/overlay_reader.py
+++ b/src/genai_tag_db_tools/db/overlay_reader.py
@@ -430,14 +430,23 @@ class OverlayTagReader:
         """
         if not tag_ids:
             return {}
+        ordered_ids = list(tag_ids)
+        rows: list[UserTagTranslationTombstone] = []
         try:
-            rows = (
-                session.query(UserTagTranslationTombstone)
-                .filter(UserTagTranslationTombstone.target_tag_id.in_(tag_ids))
-                .all()
-            )
-        except OperationalError:
-            return {}
+            # SQLite の bind 変数上限を超えないよう他の batch lookup と同じく chunk する (Codex P2)
+            for start in range(0, len(ordered_ids), TAG_ID_IN_CHUNK):
+                chunk = ordered_ids[start : start + TAG_ID_IN_CHUNK]
+                rows.extend(
+                    session.query(UserTagTranslationTombstone)
+                    .filter(UserTagTranslationTombstone.target_tag_id.in_(chunk))
+                    .all()
+                )
+        except OperationalError as exc:
+            # 旧 user DB (init_user_db 前) にはテーブルが無い。それ以外の
+            # OperationalError まで握りつぶすと抑制漏れが silent になるため再送出する
+            if "no such table" in str(exc).lower():
+                return {}
+            raise
         result: dict[int, set[tuple[str, str]]] = {}
         for r in rows:
             result.setdefault(r.target_tag_id, set()).add((r.language, r.translation))

--- a/src/genai_tag_db_tools/db/overlay_reader.py
+++ b/src/genai_tag_db_tools/db/overlay_reader.py
@@ -26,6 +26,7 @@ from genai_tag_db_tools.db.schema import (
     UserTagStatusPatch,
     UserTagTranslationPatch,
     UserTagTranslationPreference,
+    UserTagTranslationTombstone,
     UserTagUsagePatch,
 )
 from genai_tag_db_tools.models import TagSearchRow
@@ -410,10 +411,47 @@ class OverlayTagReader:
             .filter(UserTagTranslationPatch.target_tag_id.in_(tag_ids))
             .all()
         )
+        # tombstone (#121) された (tag_id, language, translation) は patch 由来でも表示しない
+        tombstoned = self._load_translation_tombstones(session, tag_ids)
         result: dict[int, list[UserTagTranslationPatch]] = {}
         for r in rows:
+            if (r.language, r.translation) in tombstoned.get(r.target_tag_id, set()):
+                continue
             result.setdefault(r.target_tag_id, []).append(r)
         return result
+
+    def _load_translation_tombstones(
+        self, session: Session, tag_ids: set[int]
+    ) -> dict[int, set[tuple[str, str]]]:
+        """tag_id ごとの tombstone 済み (language, translation) 集合を返す (#121)。
+
+        USER_TAG_TRANSLATION_TOMBSTONE テーブルは旧 user DB に無いことがある
+        (init_user_db 前の接続等) ため、欠損は空として扱う。
+        """
+        if not tag_ids:
+            return {}
+        try:
+            rows = (
+                session.query(UserTagTranslationTombstone)
+                .filter(UserTagTranslationTombstone.target_tag_id.in_(tag_ids))
+                .all()
+            )
+        except OperationalError:
+            return {}
+        result: dict[int, set[tuple[str, str]]] = {}
+        for r in rows:
+            result.setdefault(r.target_tag_id, set()).add((r.language, r.translation))
+        return result
+
+    def get_translation_tombstones_batch(self, tag_ids: list[int]) -> dict[int, set[tuple[str, str]]]:
+        """複数 tag_id の tombstone 済み (language, translation) 集合を返す (#121)。
+
+        MergedTagReader が base 由来の翻訳をマージ時に除外するために参照する。
+        """
+        if not tag_ids:
+            return {}
+        with self.session_factory() as session:
+            return self._load_translation_tombstones(session, set(tag_ids))
 
     def _load_type_name_map(self, session: Session) -> dict[tuple[int, int], tuple[int, str]]:
         """(format_id, type_id) → (type_name_id, type_name) のマップを返す。"""
@@ -575,7 +613,10 @@ class OverlayTagReader:
     # ------------------------------------------------------------------
 
     def get_translations(self, tag_id: int) -> list[TagTranslation]:
-        """USER_TAG_TRANSLATION_PATCH から翻訳を取得し TagTranslation オブジェクトに変換する。"""
+        """USER_TAG_TRANSLATION_PATCH から翻訳を取得し TagTranslation オブジェクトに変換する。
+
+        tombstone (#121) 済みの (language, translation) は patch 行があっても返さない。
+        """
         with self.session_factory() as session:
             rows = (
                 session.query(UserTagTranslationPatch)
@@ -584,6 +625,7 @@ class OverlayTagReader:
                 )
                 .all()
             )
+            tombstoned = self._load_translation_tombstones(session, {tag_id}).get(tag_id, set())
             return [
                 TagTranslation(
                     translation_id=r.patch_id,
@@ -592,6 +634,7 @@ class OverlayTagReader:
                     translation=r.translation,
                 )
                 for r in rows
+                if (r.language, r.translation) not in tombstoned
             ]
 
     def list_translations(self) -> list[TagTranslation]:
@@ -608,7 +651,10 @@ class OverlayTagReader:
             ]
 
     def get_translations_batch(self, tag_ids: list[int]) -> dict[int, list[TagTranslation]]:
-        """複数 tag_id の翻訳をバッチ取得する。"""
+        """複数 tag_id の翻訳をバッチ取得する。
+
+        tombstone (#121) 済みの (language, translation) は patch 行があっても返さない。
+        """
         if not tag_ids:
             return {}
         with self.session_factory() as session:
@@ -619,8 +665,11 @@ class OverlayTagReader:
                 )
                 .all()
             )
+            tombstoned = self._load_translation_tombstones(session, set(tag_ids))
         result: dict[int, list[TagTranslation]] = {}
         for r in rows:
+            if (r.language, r.translation) in tombstoned.get(r.target_tag_id, set()):
+                continue
             result.setdefault(r.target_tag_id, []).append(
                 TagTranslation(
                     translation_id=r.patch_id,

--- a/src/genai_tag_db_tools/db/overlay_reader.py
+++ b/src/genai_tag_db_tools/db/overlay_reader.py
@@ -411,20 +411,22 @@ class OverlayTagReader:
             .filter(UserTagTranslationPatch.target_tag_id.in_(tag_ids))
             .all()
         )
-        # tombstone (#121) された (tag_id, language, translation) は patch 由来でも表示しない
+        # tombstone (#121) された (scope, language, translation) は patch 由来でも表示しない
         tombstoned = self._load_translation_tombstones(session, tag_ids)
         result: dict[int, list[UserTagTranslationPatch]] = {}
         for r in rows:
-            if (r.language, r.translation) in tombstoned.get(r.target_tag_id, set()):
+            if (r.target_scope, r.language, r.translation) in tombstoned.get(r.target_tag_id, set()):
                 continue
             result.setdefault(r.target_tag_id, []).append(r)
         return result
 
     def _load_translation_tombstones(
         self, session: Session, tag_ids: set[int]
-    ) -> dict[int, set[tuple[str, str]]]:
-        """tag_id ごとの tombstone 済み (language, translation) 集合を返す (#121)。
+    ) -> dict[int, set[tuple[str, str, str]]]:
+        """tag_id ごとの tombstone 済み (target_scope, language, translation) 集合を返す (#121)。
 
+        legacy 低 id の user タグは base タグと数値 id を共有し得るため、scope を落とすと
+        base 宛 tombstone が無関係な user-scope 翻訳まで隠してしまう (Codex P2)。
         USER_TAG_TRANSLATION_TOMBSTONE テーブルは旧 user DB に無いことがある
         (init_user_db 前の接続等) ため、欠損は空として扱う。
         """
@@ -447,13 +449,15 @@ class OverlayTagReader:
             if "no such table" in str(exc).lower():
                 return {}
             raise
-        result: dict[int, set[tuple[str, str]]] = {}
+        result: dict[int, set[tuple[str, str, str]]] = {}
         for r in rows:
-            result.setdefault(r.target_tag_id, set()).add((r.language, r.translation))
+            result.setdefault(r.target_tag_id, set()).add((r.target_scope, r.language, r.translation))
         return result
 
-    def get_translation_tombstones_batch(self, tag_ids: list[int]) -> dict[int, set[tuple[str, str]]]:
-        """複数 tag_id の tombstone 済み (language, translation) 集合を返す (#121)。
+    def get_translation_tombstones_batch(
+        self, tag_ids: list[int]
+    ) -> dict[int, set[tuple[str, str, str]]]:
+        """複数 tag_id の tombstone 済み (target_scope, language, translation) 集合を返す (#121)。
 
         MergedTagReader が base 由来の翻訳をマージ時に除外するために参照する。
         """
@@ -643,7 +647,7 @@ class OverlayTagReader:
                     translation=r.translation,
                 )
                 for r in rows
-                if (r.language, r.translation) not in tombstoned
+                if (r.target_scope, r.language, r.translation) not in tombstoned
             ]
 
     def list_translations(self) -> list[TagTranslation]:
@@ -677,7 +681,7 @@ class OverlayTagReader:
             tombstoned = self._load_translation_tombstones(session, set(tag_ids))
         result: dict[int, list[TagTranslation]] = {}
         for r in rows:
-            if (r.language, r.translation) in tombstoned.get(r.target_tag_id, set()):
+            if (r.target_scope, r.language, r.translation) in tombstoned.get(r.target_tag_id, set()):
                 continue
             result.setdefault(r.target_tag_id, []).append(
                 TagTranslation(

--- a/src/genai_tag_db_tools/db/repository.py
+++ b/src/genai_tag_db_tools/db/repository.py
@@ -2134,20 +2134,10 @@ class MergedTagReader:
                 continue
             for tag_id, translations in getter(tag_ids).items():
                 result.setdefault(tag_id, {}).update(translations)
-        # tombstone (#121) された翻訳を指す preference は表示しない。
-        # preference のマージ出力は scope 帰属を持たない (user が base を後勝ちで
-        # 上書きした結果のみ残る) ため、ここでは全 scope の tombstone を適用する
-        tombstoned = self._translation_tombstones_batch(tag_ids)
-        for tag_id, translations in list(result.items()):
-            hidden = {
-                (language, text) for _scope, language, text in tombstoned.get(tag_id, set())
-            }
-            if not hidden:
-                continue
-            for language in [lang for lang, text in translations.items() if (lang, text) in hidden]:
-                del translations[language]
-            if not translations:
-                del result[tag_id]
+        # tombstone (#121) された翻訳を指す preference の除外は、行の target_scope が
+        # 分かる OverlayTagReader.get_preferred_translations_batch 側で scope-aware に
+        # 行う (マージ出力は scope 帰属を失うため、ここで適用すると base 宛 tombstone が
+        # 同 id の user-scope preference まで隠す。Codex P2)
         return result
 
     def list_tag_statuses(self, tag_id: int | None = None) -> list[TagStatus]:

--- a/src/genai_tag_db_tools/db/repository.py
+++ b/src/genai_tag_db_tools/db/repository.py
@@ -1462,6 +1462,80 @@ class TagRepository:
             language=language,
         )
 
+    def delete_user_translation(self, tag_id: int, language: str, translation: str) -> bool:
+        """user DB overlay の翻訳 patch 行を削除する (#121)。
+
+        user 由来の誤登録の取り消しに使う。base DB 由来の翻訳行は削除できない
+        (隠すには :meth:`suppress_translation`)。
+
+        Args:
+            tag_id: 対象タグの tag_id (base / user どちらでも可)。
+            language: 言語コード (例: ``ja``)。
+            translation: 削除する翻訳文字列。
+
+        Returns:
+            patch 行を削除したら True、元々無ければ False。
+
+        Raises:
+            ValueError: reader 注入時に tag_id がどの scope にも存在しない場合。
+        """
+        from genai_tag_db_tools.db.user_tag_repository import UserTagRepository
+
+        target_scope = self._resolve_patch_scope(tag_id, operation="delete_user_translation")
+        user_repo = UserTagRepository(self.session_factory)
+        return user_repo.delete_translation_patch(
+            target_scope=target_scope,
+            target_tag_id=tag_id,
+            language=language,
+            translation=translation,
+        )
+
+    def suppress_translation(self, tag_id: int, language: str, translation: str) -> None:
+        """(tag_id, language, translation) を merged 表示から隠す tombstone を書く (#121)。
+
+        base DB は書き換えない。base 由来の誤訳の抑制と、言語付け替え
+        (旧言語行の suppress + 新言語での write_user_translation) に使う。
+        重複は無視される。
+
+        Args:
+            tag_id: 対象タグの tag_id (base / user どちらでも可)。
+            language: 隠す翻訳の言語コード。
+            translation: 隠す翻訳文字列。
+
+        Raises:
+            ValueError: reader 注入時に tag_id がどの scope にも存在しない場合。
+        """
+        from genai_tag_db_tools.db.user_tag_repository import UserTagRepository
+
+        target_scope = self._resolve_patch_scope(tag_id, operation="suppress_translation")
+        user_repo = UserTagRepository(self.session_factory)
+        user_repo.write_translation_tombstone(
+            target_scope=target_scope,
+            target_tag_id=tag_id,
+            language=language,
+            translation=translation,
+        )
+
+    def unsuppress_translation(self, tag_id: int, language: str, translation: str) -> bool:
+        """suppress_translation の tombstone を取り消す (#121)。
+
+        Returns:
+            tombstone を削除したら True、元々無ければ False。
+
+        Raises:
+            ValueError: reader 注入時に tag_id がどの scope にも存在しない場合。
+        """
+        from genai_tag_db_tools.db.user_tag_repository import UserTagRepository
+
+        target_scope = self._resolve_patch_scope(tag_id, operation="unsuppress_translation")
+        user_repo = UserTagRepository(self.session_factory)
+        return user_repo.delete_translation_tombstone(
+            target_scope=target_scope,
+            target_tag_id=tag_id,
+            language=language,
+            translation=translation,
+        )
+
 
 class MergedTagReader:
     """Read-only view merging base/user repositories."""
@@ -1682,6 +1756,8 @@ class MergedTagReader:
         patched_by_tag: dict[int, list[Any]] = {}
         usage_by_tag: dict[int, list[TagUsageCounts]] = {}
         translations_by_tag = self.user_repo.get_translations_batch(list(tag_ids))
+        # tombstone (#121): base 検索行に載ってきた翻訳もマージ時に除外する
+        tombstones_by_tag = self._translation_tombstones_batch(list(tag_ids))
         for tag_id in tag_ids:
             patched_by_tag[tag_id] = self.user_repo.list_tag_statuses(tag_id)
             usage_by_tag[tag_id] = self.user_repo.list_usage_counts(tag_id=tag_id)
@@ -1690,6 +1766,16 @@ class MergedTagReader:
         for row in rows:
             updated = dict(row)
             format_statuses = dict(row.get("format_statuses") or {})
+
+            hidden = tombstones_by_tag.get(row["tag_id"], set())
+            translations_obj = updated.get("translations")
+            if hidden and isinstance(translations_obj, dict):
+                filtered: dict[str, list[str]] = {}
+                for language, values in cast("dict[str, list[str]]", translations_obj).items():
+                    kept = [value for value in values or [] if (language, value) not in hidden]
+                    if kept:
+                        filtered[language] = kept
+                updated["translations"] = filtered
 
             for usage in usage_by_tag.get(row["tag_id"], []):
                 fmt_name = self._format_name_for_id(usage.format_id)
@@ -2025,6 +2111,16 @@ class MergedTagReader:
                 continue
             for tag_id, translations in getter(tag_ids).items():
                 result.setdefault(tag_id, {}).update(translations)
+        # tombstone (#121) された翻訳を指す preference は表示しない
+        tombstoned = self._translation_tombstones_batch(tag_ids)
+        for tag_id, translations in list(result.items()):
+            hidden = tombstoned.get(tag_id)
+            if not hidden:
+                continue
+            for language in [lang for lang, text in translations.items() if (lang, text) in hidden]:
+                del translations[language]
+            if not translations:
+                del result[tag_id]
         return result
 
     def list_tag_statuses(self, tag_id: int | None = None) -> list[TagStatus]:
@@ -2298,11 +2394,33 @@ class MergedTagReader:
     # ------------------------------------------------------------------
 
     def get_translations(self, tag_id: int) -> list[TagTranslation]:
-        return self._accumulate_unique(
+        # batch 版へ委譲すると get_translations しか持たない duck-typed reader を壊すため、
+        # 従来の accumulate に tombstone (#121) フィルタを重ねる
+        merged = self._accumulate_unique(
             "get_translations",
             lambda tr: (tr.language, tr.translation),
             tag_id,
         )
+        hidden = self._translation_tombstones_batch([tag_id]).get(tag_id, set())
+        if not hidden:
+            return merged
+        return [tr for tr in merged if (tr.language, tr.translation) not in hidden]
+
+    def _translation_tombstones_batch(self, tag_ids: list[int]) -> dict[int, set[tuple[str, str]]]:
+        """user overlay の翻訳 tombstone (#121) を取得する。
+
+        user_repo 未設定、または tombstone を提供しない reader (legacy TagReader 等)
+        の場合は空 dict を返す。
+
+        Returns:
+            ``{tag_id: {(language, translation), ...}}``。
+        """
+        if not self._has_user():
+            return {}
+        getter = getattr(self.user_repo, "get_translation_tombstones_batch", None)
+        if getter is None:
+            return {}
+        return cast("dict[int, set[tuple[str, str]]]", getter(tag_ids))
 
     def get_translations_batch(self, tag_ids: list[int]) -> dict[int, list[TagTranslation]]:
         """複数タグIDの翻訳を全リポジトリからバッチ取得してマージする。
@@ -2310,6 +2428,7 @@ class MergedTagReader:
         全リポジトリから一括取得し、(tag_id, language, translation) タプルで重複排除する。
         重複時は先着順（低優先度→高優先度→user_repo）で保持する。
         get_translations と同一のセマンティクスを保つ。
+        tombstone (#121) 済みの (language, translation) は base 由来でも除外する。
 
         Args:
             tag_ids: 翻訳を取得するタグIDのリスト。空リストの場合は空辞書を返す。
@@ -2319,11 +2438,14 @@ class MergedTagReader:
         """
         if not tag_ids:
             return {}
+        tombstoned = self._translation_tombstones_batch(tag_ids)
         seen: set[tuple[int, str | None, str | None]] = set()
         result: dict[int, list[TagTranslation]] = {}
         for repo in self._iter_base_repos_low_to_high():
             for tag_id, trs in repo.get_translations_batch(tag_ids).items():
                 for tr in trs:
+                    if (tr.language, tr.translation) in tombstoned.get(tag_id, set()):
+                        continue
                     key = (tr.tag_id, tr.language, tr.translation)
                     if key not in seen:
                         seen.add(key)
@@ -2332,6 +2454,8 @@ class MergedTagReader:
             assert self.user_repo is not None
             for tag_id, trs in self.user_repo.get_translations_batch(tag_ids).items():
                 for tr in trs:
+                    if (tr.language, tr.translation) in tombstoned.get(tag_id, set()):
+                        continue
                     key = (tr.tag_id, tr.language, tr.translation)
                     if key not in seen:
                         seen.add(key)

--- a/src/genai_tag_db_tools/db/repository.py
+++ b/src/genai_tag_db_tools/db/repository.py
@@ -2568,10 +2568,34 @@ class MergedTagReader:
         return result
 
     def list_translations(self) -> list[TagTranslation]:
-        return self._accumulate_unique(
-            "list_translations",
-            lambda tr: (tr.tag_id, tr.language, tr.translation),
-        )
+        # 列挙経路にも get_translations* と同じ tombstone 除外規則を適用する (#121 Codex P2)。
+        # 自前で scope-aware に除外する reader (OverlayTagReader) は素通しし、素の base
+        # reader の行だけ base 宛 tombstone で除外する。
+        repo_entries: list[tuple[Any, str]] = [
+            (repo, "base") for repo in self._iter_base_repos_low_to_high()
+        ]
+        if self._has_user():
+            assert self.user_repo is not None
+            repo_entries.append((self.user_repo, "user"))
+        seen: set[tuple[int | None, str | None, str | None]] = set()
+        result: list[TagTranslation] = []
+        for repo, scope in repo_entries:
+            rows = repo.list_translations()
+            self_filtering = getattr(repo, "get_translation_tombstones_batch", None) is not None
+            hidden_map: dict[int, set[tuple[str, str, str]]] = {}
+            if not self_filtering and rows:
+                tag_ids = sorted({tr.tag_id for tr in rows if tr.tag_id is not None})
+                hidden_map = self._translation_tombstones_batch(tag_ids)
+            for tr in rows:
+                if not self_filtering:
+                    hidden = self._hidden_pairs_for_scope(hidden_map.get(tr.tag_id, set()), scope)
+                    if (tr.language, tr.translation) in hidden:
+                        continue
+                key = (tr.tag_id, tr.language, tr.translation)
+                if key not in seen:
+                    seen.add(key)
+                    result.append(tr)
+        return result
 
     # ------------------------------------------------------------------
     # Pattern D: Union/aggregate (固有ロジックのため明示的に実装)

--- a/src/genai_tag_db_tools/db/repository.py
+++ b/src/genai_tag_db_tools/db/repository.py
@@ -2323,12 +2323,22 @@ class MergedTagReader:
             )
             patched_by_tag_id = {row["tag_id"]: row for row in patched}
             merged = {keyword: patched_by_tag_id.get(row["tag_id"], row) for keyword, row in merged.items()}
-            # tombstone で唯一の一致訳が消えた keyword は bulk 結果から落とす (#121 Codex P2)
-            merged = {
-                keyword: row
+            # tombstone で選ばれた行の一致訳が消えた keyword は、次候補を per-keyword
+            # search で引き直す (別 tag が同じ訳で一致し得るため、単に落とすと
+            # search_tags / search_tags_bulk_all と結果が食い違う。#121 Codex P2)
+            dropped = [
+                keyword
                 for keyword, row in merged.items()
-                if self._row_still_matches_keyword(row, keyword)
-            }
+                if not self._row_still_matches_keyword(row, keyword)
+            ]
+            for keyword in dropped:
+                fallback_rows = self.search_tags(
+                    keyword, partial=False, format_name=format_name, resolve_preferred=False
+                )
+                if fallback_rows:
+                    merged[keyword] = fallback_rows[0]
+                else:
+                    del merged[keyword]
         if not resolve_preferred:
             return merged
         merged = {keyword: self._resolve_cross_scope_preferred([row])[0] for keyword, row in merged.items()}

--- a/src/genai_tag_db_tools/db/repository.py
+++ b/src/genai_tag_db_tools/db/repository.py
@@ -1767,7 +1767,10 @@ class MergedTagReader:
             updated = dict(row)
             format_statuses = dict(row.get("format_statuses") or {})
 
-            hidden = tombstones_by_tag.get(row["tag_id"], set())
+            # 検索行の translations は base 由来値が主 (user patch は overlay 側で
+            # scope-aware に除外済みの値が後段でマージされる) ため、base 宛 tombstone
+            # のみ適用する (Codex P2: scope 保持)
+            hidden = self._hidden_pairs_for_scope(tombstones_by_tag.get(row["tag_id"], set()), "base")
             translations_obj = updated.get("translations")
             if hidden and isinstance(translations_obj, dict):
                 filtered: dict[str, list[str]] = {}
@@ -2131,10 +2134,14 @@ class MergedTagReader:
                 continue
             for tag_id, translations in getter(tag_ids).items():
                 result.setdefault(tag_id, {}).update(translations)
-        # tombstone (#121) された翻訳を指す preference は表示しない
+        # tombstone (#121) された翻訳を指す preference は表示しない。
+        # preference のマージ出力は scope 帰属を持たない (user が base を後勝ちで
+        # 上書きした結果のみ残る) ため、ここでは全 scope の tombstone を適用する
         tombstoned = self._translation_tombstones_batch(tag_ids)
         for tag_id, translations in list(result.items()):
-            hidden = tombstoned.get(tag_id)
+            hidden = {
+                (language, text) for _scope, language, text in tombstoned.get(tag_id, set())
+            }
             if not hidden:
                 continue
             for language in [lang for lang, text in translations.items() if (lang, text) in hidden]:
@@ -2436,32 +2443,51 @@ class MergedTagReader:
     # ------------------------------------------------------------------
 
     def get_translations(self, tag_id: int) -> list[TagTranslation]:
-        # batch 版へ委譲すると get_translations しか持たない duck-typed reader を壊すため、
-        # 従来の accumulate に tombstone (#121) フィルタを重ねる
-        merged = self._accumulate_unique(
-            "get_translations",
-            lambda tr: (tr.language, tr.translation),
-            tag_id,
-        )
+        # get_translations_batch と同じ収集順・除外規則で 1 tag ぶんを返す。
+        # (batch 版へ委譲すると get_translations しか持たない duck-typed reader を壊す)
         hidden = self._translation_tombstones_batch([tag_id]).get(tag_id, set())
-        if not hidden:
-            return merged
-        return [tr for tr in merged if (tr.language, tr.translation) not in hidden]
+        base_hidden = self._hidden_pairs_for_scope(hidden, "base")
+        user_hidden = self._hidden_pairs_for_scope(hidden, "user")
+        seen: set[tuple[str | None, str | None]] = set()
+        result: list[TagTranslation] = []
+        for repo in self._iter_base_repos_low_to_high():
+            self_filtering = getattr(repo, "get_translation_tombstones_batch", None) is not None
+            for tr in repo.get_translations(tag_id):
+                if not self_filtering and (tr.language, tr.translation) in base_hidden:
+                    continue
+                key = (tr.language, tr.translation)
+                if key not in seen:
+                    seen.add(key)
+                    result.append(tr)
+        if self._has_user():
+            assert self.user_repo is not None
+            self_filtering = getattr(self.user_repo, "get_translation_tombstones_batch", None) is not None
+            for tr in self.user_repo.get_translations(tag_id):
+                if not self_filtering and (tr.language, tr.translation) in user_hidden:
+                    continue
+                key = (tr.language, tr.translation)
+                if key not in seen:
+                    seen.add(key)
+                    result.append(tr)
+        return result
 
-    def _translation_tombstones_batch(self, tag_ids: list[int]) -> dict[int, set[tuple[str, str]]]:
+    def _translation_tombstones_batch(
+        self, tag_ids: list[int]
+    ) -> dict[int, set[tuple[str, str, str]]]:
         """user overlay の翻訳 tombstone (#121) を取得する。
 
         tombstone を提供できる repo (base repos + user_repo) から集めて union する。
         どの repo も提供しない (legacy TagReader のみ等) 場合は空 dict を返す。
 
         Returns:
-            ``{tag_id: {(language, translation), ...}}``。
+            ``{tag_id: {(target_scope, language, translation), ...}}``。scope を保持するのは
+            legacy 低 id の user タグが base タグと数値 id を共有し得るため (Codex P2)。
         """
         # get_user_tag_reader() は OverlayTagReader を base_repo として単独ラップする
         # (user_repo=None) ため、user_repo だけを見ると user-only 読みで tombstone が
         # 空になる (Codex P2)。preference (#122) と同じく、tombstone を提供できる repo を
         # 優先度 低→高 の順に集めて union する。
-        result: dict[int, set[tuple[str, str]]] = {}
+        result: dict[int, set[tuple[str, str, str]]] = {}
         providers = [*self._iter_base_repos_low_to_high()]
         if self.user_repo is not None:
             providers.append(self.user_repo)
@@ -2472,6 +2498,13 @@ class MergedTagReader:
             for tag_id, hidden in getter(tag_ids).items():
                 result.setdefault(tag_id, set()).update(hidden)
         return result
+
+    @staticmethod
+    def _hidden_pairs_for_scope(
+        hidden: set[tuple[str, str, str]], scope: str
+    ) -> set[tuple[str, str]]:
+        """指定 scope 宛の tombstone を (language, translation) 集合に射影する。"""
+        return {(language, translation) for s, language, translation in hidden if s == scope}
 
     def get_translations_batch(self, tag_ids: list[int]) -> dict[int, list[TagTranslation]]:
         """複数タグIDの翻訳を全リポジトリからバッチ取得してマージする。
@@ -2493,9 +2526,13 @@ class MergedTagReader:
         seen: set[tuple[int, str | None, str | None]] = set()
         result: dict[int, list[TagTranslation]] = {}
         for repo in self._iter_base_repos_low_to_high():
+            # 自前で scope-aware に除外する reader (OverlayTagReader) は素通しし、
+            # 素の base reader の行だけ base 宛 tombstone で除外する (Codex P2: scope 保持)
+            self_filtering = getattr(repo, "get_translation_tombstones_batch", None) is not None
             for tag_id, trs in repo.get_translations_batch(tag_ids).items():
+                base_hidden = self._hidden_pairs_for_scope(tombstoned.get(tag_id, set()), "base")
                 for tr in trs:
-                    if (tr.language, tr.translation) in tombstoned.get(tag_id, set()):
+                    if not self_filtering and (tr.language, tr.translation) in base_hidden:
                         continue
                     key = (tr.tag_id, tr.language, tr.translation)
                     if key not in seen:
@@ -2503,9 +2540,11 @@ class MergedTagReader:
                         result.setdefault(tag_id, []).append(tr)
         if self._has_user():
             assert self.user_repo is not None
+            self_filtering = getattr(self.user_repo, "get_translation_tombstones_batch", None) is not None
             for tag_id, trs in self.user_repo.get_translations_batch(tag_ids).items():
+                user_hidden = self._hidden_pairs_for_scope(tombstoned.get(tag_id, set()), "user")
                 for tr in trs:
-                    if (tr.language, tr.translation) in tombstoned.get(tag_id, set()):
+                    if not self_filtering and (tr.language, tr.translation) in user_hidden:
                         continue
                     key = (tr.tag_id, tr.language, tr.translation)
                     if key not in seen:

--- a/src/genai_tag_db_tools/db/repository.py
+++ b/src/genai_tag_db_tools/db/repository.py
@@ -1882,6 +1882,26 @@ class MergedTagReader:
             return False
         return True
 
+    def _row_still_matches_keyword(self, row: TagSearchRow, keyword: str) -> bool:
+        """tombstone (#121) フィルタ後も keyword に一致しているかを再判定する。
+
+        bulk 経路は base 検索が翻訳一致で keyword→row を対応付けた後に
+        `_apply_user_patches_to_search_rows` の tombstone 除外が走るため、
+        唯一の一致訳が消えた row を結果から落とす必要がある (Codex P2)。
+        """
+        return self._search_row_matches_filters(
+            row,
+            keyword,
+            partial=False,
+            type_name=None,
+            type_names=None,
+            language=None,
+            min_usage=None,
+            max_usage=None,
+            alias=None,
+            deprecated=None,
+        )
+
     def _base_rows_for_user_translation_matches(
         self,
         keyword: str,
@@ -2303,6 +2323,12 @@ class MergedTagReader:
             )
             patched_by_tag_id = {row["tag_id"]: row for row in patched}
             merged = {keyword: patched_by_tag_id.get(row["tag_id"], row) for keyword, row in merged.items()}
+            # tombstone で唯一の一致訳が消えた keyword は bulk 結果から落とす (#121 Codex P2)
+            merged = {
+                keyword: row
+                for keyword, row in merged.items()
+                if self._row_still_matches_keyword(row, keyword)
+            }
         if not resolve_preferred:
             return merged
         merged = {keyword: self._resolve_cross_scope_preferred([row])[0] for keyword, row in merged.items()}
@@ -2375,6 +2401,12 @@ class MergedTagReader:
                 keyword: [patched_by_tag_id.get(row["tag_id"], row) for row in rows]
                 for keyword, rows in merged.items()
             }
+            # tombstone で唯一の一致訳が消えた row を落とし、空になった keyword は除く (#121 Codex P2)
+            merged = {
+                keyword: kept
+                for keyword, rows in merged.items()
+                if (kept := [row for row in rows if self._row_still_matches_keyword(row, keyword)])
+            }
 
         if resolve_preferred:
             merged = {
@@ -2409,18 +2441,27 @@ class MergedTagReader:
     def _translation_tombstones_batch(self, tag_ids: list[int]) -> dict[int, set[tuple[str, str]]]:
         """user overlay の翻訳 tombstone (#121) を取得する。
 
-        user_repo 未設定、または tombstone を提供しない reader (legacy TagReader 等)
-        の場合は空 dict を返す。
+        tombstone を提供できる repo (base repos + user_repo) から集めて union する。
+        どの repo も提供しない (legacy TagReader のみ等) 場合は空 dict を返す。
 
         Returns:
             ``{tag_id: {(language, translation), ...}}``。
         """
-        if not self._has_user():
-            return {}
-        getter = getattr(self.user_repo, "get_translation_tombstones_batch", None)
-        if getter is None:
-            return {}
-        return cast("dict[int, set[tuple[str, str]]]", getter(tag_ids))
+        # get_user_tag_reader() は OverlayTagReader を base_repo として単独ラップする
+        # (user_repo=None) ため、user_repo だけを見ると user-only 読みで tombstone が
+        # 空になる (Codex P2)。preference (#122) と同じく、tombstone を提供できる repo を
+        # 優先度 低→高 の順に集めて union する。
+        result: dict[int, set[tuple[str, str]]] = {}
+        providers = [*self._iter_base_repos_low_to_high()]
+        if self.user_repo is not None:
+            providers.append(self.user_repo)
+        for repo in providers:
+            getter = getattr(repo, "get_translation_tombstones_batch", None)
+            if getter is None:
+                continue
+            for tag_id, hidden in getter(tag_ids).items():
+                result.setdefault(tag_id, set()).update(hidden)
+        return result
 
     def get_translations_batch(self, tag_ids: list[int]) -> dict[int, list[TagTranslation]]:
         """複数タグIDの翻訳を全リポジトリからバッチ取得してマージする。

--- a/src/genai_tag_db_tools/db/schema.py
+++ b/src/genai_tag_db_tools/db/schema.py
@@ -300,6 +300,34 @@ class UserTagTranslationPatch(UserOverlayBase):
     )
 
 
+class UserTagTranslationTombstone(UserOverlayBase):
+    """merged 表示から特定の翻訳を隠す tombstone (#121)。
+
+    base DB は書き換えない方針のまま「この (tag_id, language, translation) は
+    表示しない」を user overlay に記録する。base 由来の誤訳の抑制と、言語付け替え
+    (旧言語行の tombstone + 新言語での追加) に使う。専用テーブルにしているのは
+    既存 user DB への列追加 migration を避けるため (init_user_db の create_all で
+    自動作成される)。
+    """
+
+    __tablename__ = "USER_TAG_TRANSLATION_TOMBSTONE"
+
+    tombstone_id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    target_scope: Mapped[str] = mapped_column()
+    target_tag_id: Mapped[int] = mapped_column()
+    language: Mapped[str] = mapped_column()
+    translation: Mapped[str] = mapped_column()
+    created_at: Mapped[datetime | None] = mapped_column(DateTime, server_default=func.now(), nullable=True)
+
+    __table_args__ = (
+        UniqueConstraint(
+            "target_scope", "target_tag_id", "language", "translation", name="uix_trans_tombstone"
+        ),
+        CheckConstraint("target_scope IN ('base', 'user')", name="ck_trans_tombstone_scope"),
+        Index("ix_trans_tombstone_target", "target_scope", "target_tag_id"),
+    )
+
+
 class UserTagTranslationPreference(UserOverlayBase):
     """タグ x 言語ごとの優先翻訳 (主訳) (#122)。
 

--- a/src/genai_tag_db_tools/db/user_tag_repository.py
+++ b/src/genai_tag_db_tools/db/user_tag_repository.py
@@ -16,6 +16,7 @@ from genai_tag_db_tools.db.schema import (
     UserTagStatusPatch,
     UserTagTranslationPatch,
     UserTagTranslationPreference,
+    UserTagTranslationTombstone,
     UserTagUsagePatch,
 )
 
@@ -215,6 +216,96 @@ class UserTagRepository:
                 )
             )
             session.commit()
+
+    def delete_translation_patch(
+        self, target_scope: str, target_tag_id: int, language: str, translation: str
+    ) -> bool:
+        """USER_TAG_TRANSLATION_PATCH から翻訳行を削除する (#121)。
+
+        user 由来の誤登録の取り消しに使う。base DB の行は対象外
+        (base 由来の翻訳を隠すには :meth:`write_translation_tombstone`)。
+
+        Args:
+            target_scope: パッチ対象スコープ ("base" or "user")。
+            target_tag_id: パッチ対象タグID。
+            language: 言語コード（例: ja）。
+            translation: 削除する翻訳文字列。
+
+        Returns:
+            行を削除した場合 True、該当行が無かった場合 False。
+        """
+        with self._session_factory() as session:
+            deleted = (
+                session.query(UserTagTranslationPatch)
+                .filter(
+                    UserTagTranslationPatch.target_scope == target_scope,
+                    UserTagTranslationPatch.target_tag_id == target_tag_id,
+                    UserTagTranslationPatch.language == language,
+                    UserTagTranslationPatch.translation == translation,
+                )
+                .delete()
+            )
+            session.commit()
+        return deleted > 0
+
+    def write_translation_tombstone(
+        self, target_scope: str, target_tag_id: int, language: str, translation: str
+    ) -> None:
+        """USER_TAG_TRANSLATION_TOMBSTONE に「表示しない」記録を追加する (#121、重複は無視)。
+
+        base DB は書き換えずに、merged 表示から該当の (tag_id, language, translation)
+        を隠す。言語付け替えは「旧言語行の tombstone + 新言語での patch 追加」で表現する。
+
+        Args:
+            target_scope: 対象スコープ ("base" or "user")。
+            target_tag_id: 対象タグID。
+            language: 隠す翻訳の言語コード。
+            translation: 隠す翻訳文字列。
+        """
+        with self._session_factory() as session:
+            existing = (
+                session.query(UserTagTranslationTombstone)
+                .filter(
+                    UserTagTranslationTombstone.target_scope == target_scope,
+                    UserTagTranslationTombstone.target_tag_id == target_tag_id,
+                    UserTagTranslationTombstone.language == language,
+                    UserTagTranslationTombstone.translation == translation,
+                )
+                .one_or_none()
+            )
+            if existing is not None:
+                return
+            session.add(
+                UserTagTranslationTombstone(
+                    target_scope=target_scope,
+                    target_tag_id=target_tag_id,
+                    language=language,
+                    translation=translation,
+                )
+            )
+            session.commit()
+
+    def delete_translation_tombstone(
+        self, target_scope: str, target_tag_id: int, language: str, translation: str
+    ) -> bool:
+        """USER_TAG_TRANSLATION_TOMBSTONE から抑制記録を取り消す (#121)。
+
+        Returns:
+            行を削除した場合 True、該当行が無かった場合 False。
+        """
+        with self._session_factory() as session:
+            deleted = (
+                session.query(UserTagTranslationTombstone)
+                .filter(
+                    UserTagTranslationTombstone.target_scope == target_scope,
+                    UserTagTranslationTombstone.target_tag_id == target_tag_id,
+                    UserTagTranslationTombstone.language == language,
+                    UserTagTranslationTombstone.translation == translation,
+                )
+                .delete()
+            )
+            session.commit()
+        return deleted > 0
 
     def write_usage_patch(self, target_scope: str, target_tag_id: int, format_id: int, count: int) -> None:
         """USER_TAG_USAGE_PATCH に usage count を INSERT or UPDATE する。

--- a/tests/unit/test_translation_tombstone.py
+++ b/tests/unit/test_translation_tombstone.py
@@ -1,0 +1,233 @@
+"""翻訳 overlay の削除・tombstone (base 翻訳の抑制) の単体テスト (#121)。
+
+- UserTagRepository: patch 行削除 / tombstone の書き込み・取り消し
+- OverlayTagReader: tombstone 済み patch 行の除外
+- MergedTagReader: base 由来翻訳の抑制 (get_translations* / 主訳 / search 行マージ)
+- TagRepository: scope 解決つき公開経路 (delete_user_translation / suppress_translation)
+- 言語付け替え (旧言語 tombstone + 新言語 patch) の end-to-end
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from sqlalchemy import StaticPool, create_engine
+from sqlalchemy.orm import sessionmaker
+
+from genai_tag_db_tools.db.overlay_reader import OverlayTagReader
+from genai_tag_db_tools.db.repository import MergedTagReader, TagReader, TagRepository
+from genai_tag_db_tools.db.schema import (
+    USER_TAG_ID_OFFSET,
+    Base,
+    Tag,
+    TagTranslation,
+    UserOverlayBase,
+    UserTagTranslationPatch,
+    UserTagTranslationTombstone,
+)
+from genai_tag_db_tools.db.user_tag_repository import UserTagRepository
+
+pytestmark = pytest.mark.db_tools
+
+# --- fixtures ---
+
+
+@pytest.fixture()
+def user_engine(tmp_path: Path):
+    """tmp_path に Base + UserOverlayBase 両スキーマを持つ SQLite エンジン。"""
+    db_path = tmp_path / "test_tombstone.sqlite"
+    engine = create_engine(
+        f"sqlite:///{db_path}",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    UserOverlayBase.metadata.create_all(engine)
+    yield engine
+    engine.dispose()
+
+
+@pytest.fixture()
+def user_session_factory(user_engine):
+    return sessionmaker(bind=user_engine, autoflush=False, autocommit=False)
+
+
+@pytest.fixture()
+def user_repo(user_session_factory):
+    return UserTagRepository(user_session_factory)
+
+
+@pytest.fixture()
+def overlay_reader(user_session_factory):
+    return OverlayTagReader(session_factory=user_session_factory)
+
+
+@pytest.fixture()
+def merged(user_session_factory, overlay_reader):
+    """base (TAGS/TAG_TRANSLATIONS) + user overlay を合成した MergedTagReader。"""
+    return MergedTagReader(
+        base_repo=TagReader(session_factory=user_session_factory),
+        user_repo=overlay_reader,
+    )
+
+
+def _add_base_translation(session_factory, tag_id: int, language: str, translation: str) -> None:
+    """base 側 (TAG_TRANSLATIONS) に翻訳行を作る。"""
+    with session_factory() as session:
+        if session.get(Tag, tag_id) is None:
+            session.add(Tag(tag_id=tag_id, source_tag=f"tag{tag_id}", tag=f"tag{tag_id}"))
+        session.add(TagTranslation(tag_id=tag_id, language=language, translation=translation))
+        session.commit()
+
+
+# --- UserTagRepository ---
+
+
+class TestDeleteTranslationPatch:
+    def test_delete_returns_true_then_false(self, user_repo, user_session_factory):
+        user_repo.write_translation_patch("base", 10, "ja", "誤った訳")
+
+        assert user_repo.delete_translation_patch("base", 10, "ja", "誤った訳") is True
+        assert user_repo.delete_translation_patch("base", 10, "ja", "誤った訳") is False
+        with user_session_factory() as session:
+            assert session.query(UserTagTranslationPatch).count() == 0
+
+    def test_delete_leaves_other_rows(self, user_repo, user_session_factory):
+        user_repo.write_translation_patch("base", 10, "ja", "訳A")
+        user_repo.write_translation_patch("base", 10, "ja", "訳B")
+
+        assert user_repo.delete_translation_patch("base", 10, "ja", "訳A") is True
+        with user_session_factory() as session:
+            rows = session.query(UserTagTranslationPatch).all()
+        assert [(r.language, r.translation) for r in rows] == [("ja", "訳B")]
+
+
+class TestTranslationTombstoneWrites:
+    def test_write_is_idempotent(self, user_repo, user_session_factory):
+        user_repo.write_translation_tombstone("base", 10, "ja", "隠す訳")
+        user_repo.write_translation_tombstone("base", 10, "ja", "隠す訳")
+
+        with user_session_factory() as session:
+            assert session.query(UserTagTranslationTombstone).count() == 1
+
+    def test_delete_returns_true_then_false(self, user_repo):
+        user_repo.write_translation_tombstone("base", 10, "ja", "隠す訳")
+
+        assert user_repo.delete_translation_tombstone("base", 10, "ja", "隠す訳") is True
+        assert user_repo.delete_translation_tombstone("base", 10, "ja", "隠す訳") is False
+
+
+# --- OverlayTagReader ---
+
+
+class TestOverlayReaderTombstoneExclusion:
+    def test_tombstoned_patch_row_is_hidden(self, user_repo, overlay_reader):
+        user_repo.write_translation_patch("base", 10, "ja", "誤った訳")
+        user_repo.write_translation_patch("base", 10, "ja", "正しい訳")
+        user_repo.write_translation_tombstone("base", 10, "ja", "誤った訳")
+
+        single = [(t.language, t.translation) for t in overlay_reader.get_translations(10)]
+        batch = overlay_reader.get_translations_batch([10])
+
+        assert single == [("ja", "正しい訳")]
+        assert [(t.language, t.translation) for t in batch[10]] == [("ja", "正しい訳")]
+
+    def test_get_translation_tombstones_batch(self, user_repo, overlay_reader):
+        user_repo.write_translation_tombstone("base", 10, "ja", "隠す訳")
+        user_repo.write_translation_tombstone("base", 20, "en", "hidden")
+
+        result = overlay_reader.get_translation_tombstones_batch([10, 20, 30])
+
+        assert result == {10: {("ja", "隠す訳")}, 20: {("en", "hidden")}}
+        assert overlay_reader.get_translation_tombstones_batch([]) == {}
+
+
+# --- MergedTagReader ---
+
+
+class TestMergedReaderSuppression:
+    def test_base_translation_is_suppressed(self, user_repo, user_session_factory, merged):
+        _add_base_translation(user_session_factory, 10, "ja", "誤った訳")
+        _add_base_translation(user_session_factory, 10, "en", "correct")
+        user_repo.write_translation_tombstone("base", 10, "ja", "誤った訳")
+
+        batch = merged.get_translations_batch([10])
+        single = merged.get_translations(10)
+
+        assert [(t.language, t.translation) for t in batch[10]] == [("en", "correct")]
+        assert [(t.language, t.translation) for t in single] == [("en", "correct")]
+
+    def test_without_user_repo_nothing_is_suppressed(self, user_session_factory):
+        _add_base_translation(user_session_factory, 10, "ja", "訳")
+        merged = MergedTagReader(base_repo=TagReader(session_factory=user_session_factory))
+
+        batch = merged.get_translations_batch([10])
+
+        assert [(t.language, t.translation) for t in batch[10]] == [("ja", "訳")]
+
+    def test_preferred_translation_is_suppressed(self, user_repo, overlay_reader, merged):
+        user_repo.write_translation_preference("base", 10, "ja", "隠す主訳")
+        user_repo.write_translation_tombstone("base", 10, "ja", "隠す主訳")
+
+        assert merged.get_preferred_translations_batch([10]) == {}
+
+    def test_search_row_translations_are_suppressed(self, user_repo, merged):
+        # base 検索行に載ってきた翻訳が _apply_user_patches_to_search_rows の
+        # マージ時に除外されること (#121。search_tags 本体の行構築は既存テストが担う)
+        user_repo.write_translation_tombstone("base", 10, "ja", "誤った訳")
+        row = {
+            "tag_id": 10,
+            "tag": "tag10",
+            "translations": {"ja": ["誤った訳", "正しい訳"], "en": ["ok"]},
+            "format_statuses": {},
+        }
+
+        patched = merged._apply_user_patches_to_search_rows([row])
+
+        assert patched[0]["translations"] == {"ja": ["正しい訳"], "en": ["ok"]}
+
+
+# --- TagRepository 公開経路 (scope 解決) ---
+
+
+class TestTagRepositoryPublicPath:
+    def test_delete_user_translation_via_heuristic_scope(self, user_session_factory, overlay_reader):
+        repo = TagRepository(user_session_factory)
+        user_tag_id = USER_TAG_ID_OFFSET + 5
+        repo.write_user_translation(user_tag_id, "ja", "訳")
+        assert [(t.language, t.translation) for t in overlay_reader.get_translations(user_tag_id)] == [
+            ("ja", "訳")
+        ]
+
+        assert repo.delete_user_translation(user_tag_id, "ja", "訳") is True
+        assert overlay_reader.get_translations(user_tag_id) == []
+        assert repo.delete_user_translation(user_tag_id, "ja", "訳") is False
+
+    def test_suppress_and_unsuppress_translation(self, user_session_factory, merged):
+        repo = TagRepository(user_session_factory)
+        _add_base_translation(user_session_factory, 10, "ja", "誤った訳")
+
+        repo.suppress_translation(10, "ja", "誤った訳")
+        assert merged.get_translations_batch([10]) == {}
+
+        assert repo.unsuppress_translation(10, "ja", "誤った訳") is True
+        batch = merged.get_translations_batch([10])
+        assert [(t.language, t.translation) for t in batch[10]] == [("ja", "誤った訳")]
+        assert repo.unsuppress_translation(10, "ja", "誤った訳") is False
+
+
+# --- 言語付け替え (issue の期待 API 3) ---
+
+
+class TestLanguageReassignment:
+    def test_tombstone_plus_new_language_patch(self, user_session_factory, user_repo, merged):
+        """ja に混入した中国語を zh へ付け替える: 旧行 tombstone + 新言語 patch。"""
+        repo = TagRepository(user_session_factory)
+        _add_base_translation(user_session_factory, 10, "ja", "错误")
+
+        repo.suppress_translation(10, "ja", "错误")
+        repo.write_user_translation(10, "zh", "错误")
+
+        batch = merged.get_translations_batch([10])
+        assert [(t.language, t.translation) for t in batch[10]] == [("zh", "错误")]

--- a/tests/unit/test_translation_tombstone.py
+++ b/tests/unit/test_translation_tombstone.py
@@ -139,7 +139,7 @@ class TestOverlayReaderTombstoneExclusion:
 
         result = overlay_reader.get_translation_tombstones_batch([10, 20, 30])
 
-        assert result == {10: {("ja", "隠す訳")}, 20: {("en", "hidden")}}
+        assert result == {10: {("base", "ja", "隠す訳")}, 20: {("base", "en", "hidden")}}
         assert overlay_reader.get_translation_tombstones_batch([]) == {}
 
 
@@ -339,7 +339,7 @@ class TestBulkFallbackAndChunking:
 
         result = overlay_reader.get_translation_tombstones_batch(tag_ids)
 
-        assert result == {10: {("ja", "隠す訳")}}
+        assert result == {10: {("base", "ja", "隠す訳")}}
 
     def test_tombstone_lookup_reraises_non_missing_table_errors(
         self, overlay_reader, monkeypatch
@@ -365,3 +365,37 @@ class TestBulkFallbackAndChunking:
 
         with pytest.raises(OperationalError):
             overlay_reader.get_translation_tombstones_batch([1, 2, 3])
+
+
+class TestTombstoneScopeIsolation:
+    """legacy 低 id 衝突: base 宛 tombstone が同 id の user-scope 翻訳を隠さない (Codex P2)。"""
+
+    def test_base_tombstone_does_not_hide_user_scope_patch(self, user_repo, overlay_reader) -> None:
+        user_repo.write_translation_patch("user", 10, "ja", "同名の訳")
+        user_repo.write_translation_tombstone("base", 10, "ja", "同名の訳")
+
+        batch = overlay_reader.get_translations_batch([10])
+        single = overlay_reader.get_translations(10)
+
+        assert [(t.language, t.translation) for t in batch[10]] == [("ja", "同名の訳")]
+        assert [(t.language, t.translation) for t in single] == [("ja", "同名の訳")]
+
+    def test_user_tombstone_hides_user_scope_patch(self, user_repo, overlay_reader) -> None:
+        user_repo.write_translation_patch("user", 10, "ja", "同名の訳")
+        user_repo.write_translation_tombstone("user", 10, "ja", "同名の訳")
+
+        assert overlay_reader.get_translations_batch([10]) == {}
+
+    def test_merged_base_tombstone_keeps_user_patch_visible(
+        self, user_session_factory, user_repo, merged
+    ) -> None:
+        """base 行は隠しつつ、同 id の user-scope patch はマージ結果に残る。"""
+        _add_base_translation(user_session_factory, 10, "ja", "同名の訳")
+        user_repo.write_translation_patch("user", 10, "en", "user only")
+        user_repo.write_translation_tombstone("base", 10, "ja", "同名の訳")
+
+        batch = merged.get_translations_batch([10])
+        single = merged.get_translations(10)
+
+        assert [(t.language, t.translation) for t in batch[10]] == [("en", "user only")]
+        assert [(t.language, t.translation) for t in single] == [("en", "user only")]

--- a/tests/unit/test_translation_tombstone.py
+++ b/tests/unit/test_translation_tombstone.py
@@ -429,3 +429,44 @@ class TestPreferenceTombstoneScope:
         user_repo.write_translation_tombstone("base", 10, "ja", "base主訳")
 
         assert overlay_reader.get_preferred_translations_batch([10]) == {10: {"ja": "user主訳"}}
+
+
+class TestListTranslationsAndShadowedPreference:
+    """列挙経路 + shadow 主訳の tombstone 適用 (Codex P2 round5)。"""
+
+    def test_overlay_list_translations_excludes_tombstoned(self, user_repo, overlay_reader) -> None:
+        user_repo.write_translation_patch("base", 10, "ja", "隠す訳")
+        user_repo.write_translation_patch("base", 10, "en", "keep")
+        user_repo.write_translation_tombstone("base", 10, "ja", "隠す訳")
+
+        rows = overlay_reader.list_translations()
+
+        assert [(t.tag_id, t.language, t.translation) for t in rows] == [(10, "en", "keep")]
+
+    def test_merged_list_translations_excludes_base_tombstoned(
+        self, user_session_factory, user_repo, merged
+    ) -> None:
+        _add_base_translation(user_session_factory, 10, "ja", "隠す訳")
+        _add_base_translation(user_session_factory, 10, "en", "keep")
+        user_repo.write_translation_tombstone("base", 10, "ja", "隠す訳")
+
+        rows = merged.list_translations()
+
+        assert [(t.tag_id, t.language, t.translation) for t in rows] == [(10, "en", "keep")]
+
+    def test_merged_list_translations_keeps_user_scope_rows(self, user_repo, merged) -> None:
+        """base 宛 tombstone は同 id の user-scope patch を列挙からも隠さない。"""
+        user_repo.write_translation_patch("user", 10, "ja", "同名の訳")
+        user_repo.write_translation_tombstone("base", 10, "ja", "同名の訳")
+
+        rows = merged.list_translations()
+
+        assert [(t.tag_id, t.language, t.translation) for t in rows] == [(10, "ja", "同名の訳")]
+
+    def test_user_tombstone_clears_shadowed_base_preference(self, user_repo, overlay_reader) -> None:
+        """user 主訳を suppress したとき、影の base 主訳が漏れて返らない (Codex P2)。"""
+        user_repo.write_translation_preference("base", 10, "ja", "base主訳")
+        user_repo.write_translation_preference("user", 10, "ja", "user主訳")
+        user_repo.write_translation_tombstone("user", 10, "ja", "user主訳")
+
+        assert overlay_reader.get_preferred_translations_batch([10]) == {}

--- a/tests/unit/test_translation_tombstone.py
+++ b/tests/unit/test_translation_tombstone.py
@@ -304,3 +304,64 @@ class TestBulkSearchSuppression:
 
         assert "tag ten" in result
         assert result["tag ten"]["tag_id"] == 10
+
+
+class TestBulkFallbackAndChunking:
+    def test_bulk_returns_next_candidate_when_chosen_row_is_tombstoned(
+        self, user_session_factory, user_repo, merged
+    ) -> None:
+        """同じ訳で複数タグが一致する場合、先頭行の suppress 後は次候補を返す (Codex P2)。"""
+        from genai_tag_db_tools.db.schema import TagFormat, TagStatus, TagTypeFormatMapping, TagTypeName
+
+        with user_session_factory() as session:
+            session.add(TagFormat(format_id=1, format_name="danbooru"))
+            session.add(TagTypeName(type_name_id=1, type_name="general"))
+            session.add(TagTypeFormatMapping(format_id=1, type_id=0, type_name_id=1))
+            for tag_id in (10, 20):
+                session.add(Tag(tag_id=tag_id, source_tag=f"tag {tag_id}", tag=f"tag {tag_id}"))
+                session.add(
+                    TagStatus(tag_id=tag_id, format_id=1, type_id=0, alias=False, preferred_tag_id=tag_id)
+                )
+                session.add(TagTranslation(tag_id=tag_id, language="ja", translation="bad"))
+            session.commit()
+
+        user_repo.write_translation_tombstone("base", 10, "ja", "bad")
+
+        result = merged.search_tags_bulk(["bad"])
+
+        assert "bad" in result
+        assert result["bad"]["tag_id"] == 20
+
+    def test_tombstone_lookup_chunks_large_tag_id_sets(self, user_repo, overlay_reader) -> None:
+        """SQLite bind 変数上限超の tag_ids でも tombstone lookup が落ちない (Codex P2)。"""
+        user_repo.write_translation_tombstone("base", 10, "ja", "隠す訳")
+        tag_ids = list(range(1, 1202))  # TAG_ID_IN_CHUNK (900) を跨ぐ
+
+        result = overlay_reader.get_translation_tombstones_batch(tag_ids)
+
+        assert result == {10: {("ja", "隠す訳")}}
+
+    def test_tombstone_lookup_reraises_non_missing_table_errors(
+        self, overlay_reader, monkeypatch
+    ) -> None:
+        """missing-table 以外の OperationalError は握りつぶさず再送出する (Codex P2)。"""
+        from sqlalchemy.exc import OperationalError
+
+        class _BrokenQuery:
+            def filter(self, *args, **kwargs):
+                raise OperationalError("SELECT ...", {}, Exception("too many SQL variables"))
+
+        class _BrokenSession:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+            def query(self, *args, **kwargs):
+                return _BrokenQuery()
+
+        monkeypatch.setattr(overlay_reader, "session_factory", lambda: _BrokenSession())
+
+        with pytest.raises(OperationalError):
+            overlay_reader.get_translation_tombstones_batch([1, 2, 3])

--- a/tests/unit/test_translation_tombstone.py
+++ b/tests/unit/test_translation_tombstone.py
@@ -231,3 +231,76 @@ class TestLanguageReassignment:
 
         batch = merged.get_translations_batch([10])
         assert [(t.language, t.translation) for t in batch[10]] == [("zh", "错误")]
+
+
+# --- Codex P2 回帰: user-only reader / bulk 検索 ---
+
+
+class TestUserOnlyReaderSuppression:
+    def test_preferred_suppression_works_when_overlay_is_base_repo(
+        self, user_repo, overlay_reader
+    ) -> None:
+        """get_user_tag_reader() 相当 (OverlayTagReader を base_repo、user_repo=None) でも
+        tombstone が効く (Codex P2)。"""
+        user_repo.write_translation_preference("base", 10, "ja", "隠す主訳")
+        user_repo.write_translation_tombstone("base", 10, "ja", "隠す主訳")
+        merged = MergedTagReader(base_repo=overlay_reader)
+
+        assert merged.get_preferred_translations_batch([10]) == {}
+
+    def test_patch_suppression_works_when_overlay_is_base_repo(self, user_repo, overlay_reader) -> None:
+        user_repo.write_translation_patch("base", 10, "ja", "誤った訳")
+        user_repo.write_translation_tombstone("base", 10, "ja", "誤った訳")
+        merged = MergedTagReader(base_repo=overlay_reader)
+
+        assert merged.get_translations_batch([10]) == {}
+
+
+class TestBulkSearchSuppression:
+    @pytest.fixture()
+    def base_search_fixture(self, user_session_factory):
+        """検索可能な base タグ (翻訳 'bad' のみが keyword 一致源) を作る。"""
+        from genai_tag_db_tools.db.schema import TagFormat, TagStatus, TagTypeFormatMapping, TagTypeName
+
+        with user_session_factory() as session:
+            session.add(TagFormat(format_id=1, format_name="danbooru"))
+            session.add(TagTypeName(type_name_id=1, type_name="general"))
+            session.add(TagTypeFormatMapping(format_id=1, type_id=0, type_name_id=1))
+            session.add(Tag(tag_id=10, source_tag="tag ten", tag="tag ten"))
+            session.add(
+                TagStatus(tag_id=10, format_id=1, type_id=0, alias=False, preferred_tag_id=10)
+            )
+            session.add(TagTranslation(tag_id=10, language="ja", translation="bad"))
+            session.commit()
+
+    def test_bulk_drops_keyword_when_only_matching_translation_is_tombstoned(
+        self, base_search_fixture, user_repo, merged
+    ) -> None:
+        """suppress 後、翻訳のみで一致していた keyword は bulk 結果から消える (Codex P2)。"""
+        before = merged.search_tags_bulk(["bad"])
+        assert "bad" in before
+
+        user_repo.write_translation_tombstone("base", 10, "ja", "bad")
+
+        assert merged.search_tags_bulk(["bad"]) == {}
+
+    def test_bulk_all_drops_keyword_when_only_matching_translation_is_tombstoned(
+        self, base_search_fixture, user_repo, merged
+    ) -> None:
+        before = merged.search_tags_bulk_all(["bad"])
+        assert before.get("bad")
+
+        user_repo.write_translation_tombstone("base", 10, "ja", "bad")
+
+        assert merged.search_tags_bulk_all(["bad"]) == {}
+
+    def test_bulk_keeps_keyword_matching_by_tag_name(
+        self, base_search_fixture, user_repo, merged
+    ) -> None:
+        """タグ名で一致する keyword は tombstone に影響されない。"""
+        user_repo.write_translation_tombstone("base", 10, "ja", "bad")
+
+        result = merged.search_tags_bulk(["tag ten"])
+
+        assert "tag ten" in result
+        assert result["tag ten"]["tag_id"] == 10

--- a/tests/unit/test_translation_tombstone.py
+++ b/tests/unit/test_translation_tombstone.py
@@ -399,3 +399,33 @@ class TestTombstoneScopeIsolation:
 
         assert [(t.language, t.translation) for t in batch[10]] == [("en", "user only")]
         assert [(t.language, t.translation) for t in single] == [("en", "user only")]
+
+
+class TestPreferenceTombstoneScope:
+    """preference の tombstone 除外は行の target_scope で照合する (Codex P2 round4)。"""
+
+    def test_base_tombstone_does_not_hide_user_scope_preference(
+        self, user_repo, overlay_reader, merged
+    ) -> None:
+        user_repo.write_translation_preference("user", 10, "ja", "同名の主訳")
+        user_repo.write_translation_tombstone("base", 10, "ja", "同名の主訳")
+
+        assert overlay_reader.get_preferred_translations_batch([10]) == {10: {"ja": "同名の主訳"}}
+        assert merged.get_preferred_translations_batch([10]) == {10: {"ja": "同名の主訳"}}
+
+    def test_scope_matched_tombstone_hides_preference(self, user_repo, overlay_reader, merged) -> None:
+        user_repo.write_translation_preference("base", 10, "ja", "隠す主訳")
+        user_repo.write_translation_tombstone("base", 10, "ja", "隠す主訳")
+
+        assert overlay_reader.get_preferred_translations_batch([10]) == {}
+        assert merged.get_preferred_translations_batch([10]) == {}
+
+    def test_user_wins_merge_after_base_preference_suppressed(
+        self, user_repo, overlay_reader
+    ) -> None:
+        """base 側主訳だけ suppress した場合、user 側主訳がそのまま残る。"""
+        user_repo.write_translation_preference("base", 10, "ja", "base主訳")
+        user_repo.write_translation_preference("user", 10, "ja", "user主訳")
+        user_repo.write_translation_tombstone("base", 10, "ja", "base主訳")
+
+        assert overlay_reader.get_preferred_translations_batch([10]) == {10: {"ja": "user主訳"}}


### PR DESCRIPTION
## 概要

user overlay の翻訳 (`USER_TAG_TRANSLATION_PATCH`) は追加専用で、下流 (LoRAIro #1054 の誤翻訳修正導線) が必要とする「削除」「base 翻訳の抑制」「言語の付け替え」を表現できなかった。

Closes #121

## 変更内容 (Issue の期待 API 1〜3 に対応)

1. **patch 行の削除**: `delete_user_translation(repo, tag_id, language, translation) -> bool` — user 由来の誤登録の取り消し
2. **base 翻訳の抑制 (tombstone)**: `suppress_translation` / `unsuppress_translation` — base DB は書き換えず、`USER_TAG_TRANSLATION_TOMBSTONE` (新設テーブル) に「この (tag_id, language, translation) は表示しない」を記録。マージ側は
   - `OverlayTagReader.get_translations*` / `_load_translation_patches` (search 行) で patch 由来を除外
   - `MergedTagReader.get_translations*` / `get_preferred_translations_batch` / `_apply_user_patches_to_search_rows` で base 由来を除外
3. **言語付け替え**: 「旧言語行の suppress + 新言語での `write_user_translation`」の組み合わせで表現 (専用 API なし。end-to-end テストでシナリオを固定)

## 設計メモ

- schema 案のうち **専用テーブル方式**を採用: `init_user_db` は毎回 `create_all` するため、既存 user DB への列追加 (ALTER) migration が不要になる
- 公開 API は `write_user_translation` と同じ scope 解決契約 (`_resolve_patch_scope`: reader 注入時は実在チェック、未注入時は offset ヒューリスティック)
- tombstone を提供しない legacy reader (duck-typed) を user_repo に挿した場合は従来挙動 (getattr ガード)

## 検証

- 新規テスト 13 件 (`tests/unit/test_translation_tombstone.py`): patch 削除 / tombstone 冪等・取り消し / overlay・merged 双方の除外 / 主訳抑制 / search 行マージ除外 / scope 解決つき公開経路 / 言語付け替え e2e
- `pytest -m "not slow and not network"` (CI-equivalent filter, QT_QPA_PLATFORM=offscreen) → **842 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)