### PR TITLE
perf(db): 完全一致キーワード検索を index 活用経路に置換 + 実行中 SQL の中断フックを追加

### DIFF
--- a/src/genai_tag_db_tools/__init__.py
+++ b/src/genai_tag_db_tools/__init__.py
@@ -42,11 +42,12 @@ from .core_api import (
     search_tags,
     search_tags_batch,
     set_preferred_translation,
-    update_tags_type_batch,
     suppress_translation,
     unsuppress_translation,
+    update_tags_type_batch,
     write_user_translation,
 )
+from .db.runtime import set_query_abort_check
 from .models import (
     ApprovedDbFeedback,
     DbFeedbackProposal,
@@ -90,8 +91,8 @@ __all__ = [
     "build_downloaded_at_utc",
     "clear_preferred_translation",
     "convert_tags",
-    "delete_user_translation",
     "create_tag_register_service",
+    "delete_user_translation",
     "ensure_databases",
     "get_all_type_names",
     "get_default_reader",
@@ -115,9 +116,10 @@ __all__ = [
     "search_tags",
     "search_tags_batch",
     "set_preferred_translation",
-    "update_tags_type_batch",
+    "set_query_abort_check",
     "suppress_translation",
     "unsuppress_translation",
+    "update_tags_type_batch",
     "write_user_translation",
 ]
 

--- a/src/genai_tag_db_tools/db/query_utils.py
+++ b/src/genai_tag_db_tools/db/query_utils.py
@@ -1,3 +1,6 @@
+import re
+import string
+import weakref
 from logging import Logger
 from typing import Any, TypedDict
 
@@ -30,6 +33,44 @@ class StatusInfo(TypedDict):
 
 # tag_id IN (...) クエリのチャンクサイズ (SQLite の bind 変数上限より十分小さく取る)
 TAG_ID_IN_CHUNK = 900
+
+# SQLite の lower() / COLLATE NOCASE は ASCII A-Z のみ折り畳む。Python 側で
+# 同じ照合を再現するための変換テーブル (str.lower は Unicode 全体を畳むため不一致)。
+_ASCII_LOWER_TABLE = str.maketrans(string.ascii_uppercase, string.ascii_lowercase)
+
+# ASCII 小文字を含むか (大文字混じり行の lower() 済み値と一致し得るか) の判定
+_HAS_ASCII_LOWER_RE = re.compile(r"[a-z]")
+
+# TAGS の「ASCII 小文字化で不変でない」例外行のキャッシュ (engine 単位)。
+# base DB (数百万行) は runtime 中は不変で、例外行は全体の 0.01% 未満なので、
+# 一度のスキャン結果を保持すれば以降の完全一致照合は index だけで済む。
+# TAGS を書き換える経路 (TagRepository) は invalidate_case_exception_cache() を呼ぶこと。
+_case_exception_cache: "weakref.WeakKeyDictionary[Any, list[tuple[int, str | None, str | None]]]" = (
+    weakref.WeakKeyDictionary()
+)
+
+
+def sqlite_ascii_lower(value: str) -> str:
+    """SQLite の lower() / COLLATE NOCASE と同じ ASCII 限定の小文字化を行う。"""
+    return value.translate(_ASCII_LOWER_TABLE)
+
+
+def invalidate_case_exception_cache(bind: Any | None = None) -> None:
+    """TAGS の大小文字例外行キャッシュを無効化する。
+
+    Args:
+        bind: 無効化対象の engine。None なら全 engine 分を破棄する。
+    """
+    if bind is None:
+        _case_exception_cache.clear()
+    else:
+        _case_exception_cache.pop(bind, None)
+
+
+def _chunked_in(column: Any, values: list[int]) -> Any:
+    """IN (...) を bind 変数上限に収まるチャンクの OR に分割した条件を返す。"""
+    chunks = [values[i : i + TAG_ID_IN_CHUNK] for i in range(0, len(values), TAG_ID_IN_CHUNK)]
+    return or_(*[column.in_(chunk) for chunk in chunks])
 
 
 def contains_like_pattern(substring: str) -> str:
@@ -77,17 +118,21 @@ class TagSearchQueryBuilder:
         limit: int | None = None,
         offset: int = 0,
     ) -> set[int]:
-        # 完全一致 (use_like=False) は大文字小文字を無視して照合する (COLLATE NOCASE)。
+        # 完全一致 (use_like=False) は COLLATE NOCASE 相当の照合を index 活用経路で行う
+        # (LoRAIro #1203/#1206: NOCASE 比較は index を使えず数百万行の全表スキャンになる)。
         # LIKE は SQLite 既定で ASCII 大文字小文字を無視するため挙動は変えない。
-        tag_conditions = or_(
-            Tag.tag.like(keyword) if use_like else Tag.tag.collate("NOCASE") == keyword,
-            Tag.source_tag.like(keyword) if use_like else Tag.source_tag.collate("NOCASE") == keyword,
-        )
-        translation_condition = (
-            TagTranslation.translation.like(keyword)
-            if use_like
-            else TagTranslation.translation.collate("NOCASE") == keyword
-        )
+        if not use_like:
+            ids = sorted(self._exact_match_tag_ids({sqlite_ascii_lower(keyword)}))
+            # ページングを決定的にするため tag_id 昇順で offset/limit を適用する (従来の
+            # UNION + order_by と同じ意味論)。
+            if offset:
+                ids = ids[offset:]
+            if limit is not None:
+                ids = ids[:limit]
+            return set(ids)
+
+        tag_conditions = or_(Tag.tag.like(keyword), Tag.source_tag.like(keyword))
+        translation_condition = TagTranslation.translation.like(keyword)
 
         tag_query = self.session.query(Tag.tag_id.label("tag_id")).filter(tag_conditions)
         translation_query = self.session.query(TagTranslation.tag_id.label("tag_id")).filter(
@@ -105,6 +150,89 @@ class TagSearchQueryBuilder:
             union_query = union_query.limit(limit)
 
         return {row[0] for row in union_query.all()}
+
+    def _exact_match_tag_rows(self, match_keys: set[str]) -> list[tuple[int, str | None, str | None]]:
+        """ASCII 小文字化済みキーに case-insensitive 完全一致する TAGS 行を返す。
+
+        `lower(col) IN (...)` / `COLLATE NOCASE ==` は index を使えず TAGS 全表スキャン
+        (数百万行、1 回あたり秒〜十秒台) になる (LoRAIro #1203/#1206)。行の大多数は既に
+        小文字なので、(1) index が効く完全一致 IN と (2) 小文字化で不変でない例外行
+        (engine 単位で 1 回だけスキャンしキャッシュ) の Python 照合に分割し、照合結果を
+        変えずに index を活用する。
+
+        Args:
+            match_keys: `sqlite_ascii_lower` 済みの照合キー集合。
+
+        Returns:
+            (tag_id, tag, source_tag) のリスト。例外行経由の重複を含み得る
+            (呼び出し側は set に畳むため実害なし)。
+        """
+        if not match_keys:
+            return []
+        keys = list(match_keys)
+        rows: list[tuple[int, str | None, str | None]] = list(
+            self.session.query(Tag.tag_id, Tag.tag, Tag.source_tag)
+            .filter(or_(Tag.tag.in_(keys), Tag.source_tag.in_(keys)))
+            .all()
+        )
+        for tag_id, tag, source_tag in self._case_exceptional_tag_rows():
+            if (tag is not None and sqlite_ascii_lower(tag) in match_keys) or (
+                source_tag is not None and sqlite_ascii_lower(source_tag) in match_keys
+            ):
+                rows.append((tag_id, tag, source_tag))
+        return rows
+
+    def _exact_match_tag_ids(self, match_keys: set[str]) -> set[int]:
+        """`_exact_match_tag_rows` + 翻訳一致の tag_id 集合版 (単一 keyword の完全一致用)。"""
+        ids = {row[0] for row in self._exact_match_tag_rows(match_keys)}
+        ids.update(row[0] for row in self._exact_match_translation_rows(match_keys))
+        return ids
+
+    def _case_exceptional_tag_rows(self) -> list[tuple[int, str | None, str | None]]:
+        """ASCII 小文字化で不変でない TAGS 行を engine 単位のキャッシュ付きで返す。"""
+        bind = self.session.get_bind()
+        cached = _case_exception_cache.get(bind)
+        if cached is None:
+            cached = list(
+                self.session.query(Tag.tag_id, Tag.tag, Tag.source_tag)
+                .filter(
+                    or_(
+                        Tag.tag != func.lower(Tag.tag),
+                        Tag.source_tag != func.lower(Tag.source_tag),
+                    )
+                )
+                .all()
+            )
+            _case_exception_cache[bind] = cached
+        return cached
+
+    def _exact_match_translation_rows(self, match_keys: set[str]) -> list[tuple[int, str | None]]:
+        """ASCII 小文字化済みキーに case-insensitive 完全一致する翻訳行を返す。
+
+        index が効く完全一致 IN で小文字行を取り、大文字混じり行は
+        `translation <> lower(translation)` で絞った narrow スキャンで補完する
+        (TAG_TRANSLATIONS は TAGS より十分小さく、このスキャンは実測 0.1 秒台)。
+        キーが ASCII 小文字を 1 つも含まない場合 (CJK のみ等)、大文字混じり行の
+        lower() 済み値と一致し得ないため narrow スキャンを省略する。
+        """
+        if not match_keys:
+            return []
+        keys = list(match_keys)
+        rows: list[tuple[int, str | None]] = list(
+            self.session.query(TagTranslation.tag_id, TagTranslation.translation)
+            .filter(TagTranslation.translation.in_(keys))
+            .all()
+        )
+        if any(_HAS_ASCII_LOWER_RE.search(key) for key in keys):
+            rows.extend(
+                self.session.query(TagTranslation.tag_id, TagTranslation.translation)
+                .filter(
+                    TagTranslation.translation != func.lower(TagTranslation.translation),
+                    func.lower(TagTranslation.translation).in_(keys),
+                )
+                .all()
+            )
+        return rows
 
     def filtered_tag_ids(
         self,
@@ -138,11 +266,21 @@ class TagSearchQueryBuilder:
         if concrete_type_names and not type_name_ids:
             return set(), None
 
-        candidate = self._keyword_candidate_query(keyword, use_like).subquery()
-        query = self.session.query(candidate.c.tag_id)
+        resolved_format_id = format_ids[0] if len(format_ids) == 1 else None
+        if use_like:
+            candidate = self._keyword_candidate_query(keyword, use_like).subquery()
+            tag_id_column: Any = candidate.c.tag_id
+            query = self.session.query(tag_id_column)
+        else:
+            # 完全一致は index 活用経路で候補 tag_id を先に確定する (LoRAIro #1203/#1206)。
+            candidate_ids = sorted(self._exact_match_tag_ids({sqlite_ascii_lower(keyword)}))
+            if not candidate_ids:
+                return set(), resolved_format_id
+            tag_id_column = Tag.tag_id
+            query = self.session.query(Tag.tag_id).filter(_chunked_in(Tag.tag_id, candidate_ids))
         query = self._apply_status_exists_filters(
             query,
-            candidate.c.tag_id,
+            tag_id_column,
             format_ids=format_ids,
             type_name_ids=type_name_ids,
             alias=alias,
@@ -150,32 +288,27 @@ class TagSearchQueryBuilder:
         )
         query = self._apply_usage_exists_filter(
             query,
-            candidate.c.tag_id,
+            tag_id_column,
             format_ids=format_ids,
             min_usage=min_usage,
             max_usage=max_usage,
         )
-        query = self._apply_language_exists_filter(query, candidate.c.tag_id, language)
-        query = query.order_by(candidate.c.tag_id)
+        query = self._apply_language_exists_filter(query, tag_id_column, language)
+        query = query.order_by(tag_id_column)
         if offset:
             query = query.offset(offset)
         if limit is not None:
             query = query.limit(limit)
 
-        format_id = format_ids[0] if len(format_ids) == 1 else None
-        return {row[0] for row in query.all()}, format_id
+        return {row[0] for row in query.all()}, resolved_format_id
 
     def _keyword_candidate_query(self, keyword: str, use_like: bool) -> Any:
-        # 完全一致 (use_like=False) は COLLATE NOCASE で大文字小文字を無視する。
-        tag_conditions = or_(
-            Tag.tag.like(keyword) if use_like else Tag.tag.collate("NOCASE") == keyword,
-            Tag.source_tag.like(keyword) if use_like else Tag.source_tag.collate("NOCASE") == keyword,
-        )
-        translation_condition = (
-            TagTranslation.translation.like(keyword)
-            if use_like
-            else TagTranslation.translation.collate("NOCASE") == keyword
-        )
+        # LIKE (部分一致) 用の候補クエリ。完全一致は `_exact_match_tag_ids` の
+        # index 活用経路を使うため、ここには来ない (LoRAIro #1203/#1206)。
+        if not use_like:
+            raise ValueError("exact match must use _exact_match_tag_ids (index-backed path)")
+        tag_conditions = or_(Tag.tag.like(keyword), Tag.source_tag.like(keyword))
+        translation_condition = TagTranslation.translation.like(keyword)
 
         tag_query = self.session.query(Tag.tag_id.label("tag_id")).filter(tag_conditions)
         translation_query = self.session.query(TagTranslation.tag_id.label("tag_id")).filter(
@@ -298,23 +431,12 @@ class TagSearchQueryBuilder:
         keywords_by_lower: dict[str, set[str]] = {}
         for keyword in keyword_set:
             keywords_by_lower.setdefault(keyword.lower(), set()).add(keyword)
-        lower_keys = list(keywords_by_lower.keys())
+        lower_keys = set(keywords_by_lower.keys())
 
-        tag_rows = (
-            self.session.query(Tag.tag_id, Tag.tag, Tag.source_tag)
-            .filter(
-                or_(
-                    func.lower(Tag.tag).in_(lower_keys),
-                    func.lower(Tag.source_tag).in_(lower_keys),
-                )
-            )
-            .all()
-        )
-        trans_rows = (
-            self.session.query(TagTranslation.tag_id, TagTranslation.translation)
-            .filter(func.lower(TagTranslation.translation).in_(lower_keys))
-            .all()
-        )
+        # index 活用の完全一致照合 (LoRAIro #1203/#1206: 従来の lower(col) IN (...) は
+        # index を使えず keyword 数に関係なく毎回 TAGS/TAG_TRANSLATIONS の全表スキャンだった)
+        tag_rows = self._exact_match_tag_rows(lower_keys)
+        trans_rows = self._exact_match_translation_rows(lower_keys)
 
         tag_ids_by_keyword: dict[str, set[int]] = {keyword: set() for keyword in keyword_set}
         for tag_id, tag, source_tag in tag_rows:

--- a/src/genai_tag_db_tools/db/repository.py
+++ b/src/genai_tag_db_tools/db/repository.py
@@ -17,6 +17,7 @@ from genai_tag_db_tools.db.query_utils import (
     TagSearchQueryBuilder,
     TagSearchResultBuilder,
     contains_like_pattern,
+    invalidate_case_exception_cache,
     normalize_search_keyword,
 )
 from genai_tag_db_tools.db.schema import (
@@ -625,6 +626,7 @@ class TagRepository:
                 msg = ErrorMessages.DB_OPERATION_FAILED.format(error_msg=str(e))
                 self.logger.error(msg)
                 raise ValueError(msg) from e
+            invalidate_case_exception_cache(session.get_bind())
             return new_tag.tag_id
 
     def update_tag(self, tag_id: int, *, source_tag: str | None = None, tag: str | None = None) -> None:
@@ -637,6 +639,7 @@ class TagRepository:
             if tag is not None:
                 tag_obj.tag = tag
             session.commit()
+            invalidate_case_exception_cache(session.get_bind())
 
     def delete_tag(self, tag_id: int) -> None:
         with self.session_factory() as session:
@@ -647,6 +650,7 @@ class TagRepository:
                 raise ValueError(msg)
             session.delete(tag_obj)
             session.commit()
+            invalidate_case_exception_cache(session.get_bind())
 
     def bulk_insert_tags(self, df: pl.DataFrame) -> None:
         required_cols = {"source_tag", "tag"}
@@ -671,6 +675,7 @@ class TagRepository:
                 session.rollback()
                 msg = ErrorMessages.DB_OPERATION_FAILED.format(error_msg=str(e))
                 raise ValueError(msg) from e
+            invalidate_case_exception_cache(session.get_bind())
 
     def create_tag_with_id(self, tag_id: int, source_tag: str, tag: str) -> int:
         if not tag or not source_tag:
@@ -694,6 +699,7 @@ class TagRepository:
             try:
                 session.add(Tag(tag_id=tag_id, source_tag=source_tag, tag=tag))
                 session.commit()
+                invalidate_case_exception_cache(session.get_bind())
                 return tag_id
             except IntegrityError as e:
                 session.rollback()
@@ -2461,9 +2467,7 @@ class MergedTagReader:
                     result.append(tr)
         return result
 
-    def _translation_tombstones_batch(
-        self, tag_ids: list[int]
-    ) -> dict[int, set[tuple[str, str, str]]]:
+    def _translation_tombstones_batch(self, tag_ids: list[int]) -> dict[int, set[tuple[str, str, str]]]:
         """user overlay の翻訳 tombstone (#121) を取得する。
 
         tombstone を提供できる repo (base repos + user_repo) から集めて union する。
@@ -2490,9 +2494,7 @@ class MergedTagReader:
         return result
 
     @staticmethod
-    def _hidden_pairs_for_scope(
-        hidden: set[tuple[str, str, str]], scope: str
-    ) -> set[tuple[str, str]]:
+    def _hidden_pairs_for_scope(hidden: set[tuple[str, str, str]], scope: str) -> set[tuple[str, str]]:
         """指定 scope 宛の tombstone を (language, translation) 集合に射影する。"""
         return {(language, translation) for s, language, translation in hidden if s == scope}
 

--- a/src/genai_tag_db_tools/db/runtime.py
+++ b/src/genai_tag_db_tools/db/runtime.py
@@ -1,4 +1,5 @@
 import logging
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -17,6 +18,40 @@ _SessionLocal = None
 _user_db_path: Path | None = None
 _user_engine = None
 _UserSessionLocal = None
+
+# 実行中 SQL を中断させる判定関数 (ホストアプリが set_query_abort_check で登録)
+_query_abort_check: Callable[[], bool] | None = None
+
+# progress handler の呼び出し間隔 (SQLite VM 命令数)。小さいほど応答が速いが
+# オーバーヘッドが増える。長時間クエリの協調キャンセル用途なので粗くてよい。
+_PROGRESS_HANDLER_INTERVAL = 4000
+
+
+def set_query_abort_check(check: Callable[[], bool] | None) -> None:
+    """実行中 SQL を中断させる判定関数を登録する (LoRAIro #1206)。
+
+    登録した関数は SQLite の progress handler として一定 VM 命令ごとに
+    **クエリを実行しているスレッド上で** 呼ばれ、True を返すとそのクエリは
+    `OperationalError` ("interrupted") で中断される。長時間クエリを協調キャンセルで
+    打ち切りたいホストアプリが、スレッドローカルなキャンセル状態を見る関数を渡す想定。
+
+    Args:
+        check: 中断すべきなら True を返す関数。None で解除。
+    """
+    global _query_abort_check
+    _query_abort_check = check
+
+
+def _progress_handler() -> int:
+    """SQLite progress handler 本体。非 0 を返すと実行中クエリを中断する。"""
+    check = _query_abort_check
+    if check is not None and check():
+        return 1
+    return 0
+
+
+def _install_progress_handler(dbapi_connection: Any, connection_record: Any) -> None:
+    dbapi_connection.set_progress_handler(_progress_handler, _PROGRESS_HANDLER_INTERVAL)
 
 
 def set_database_path(path: Path) -> None:
@@ -54,6 +89,9 @@ def _create_engine(db_path: Path) -> Engine:
         echo=False,
     )
     event.listen(engine, "connect", enable_foreign_keys)
+    # 協調キャンセルで実行中 SQL を中断できるようにする (set_query_abort_check)。
+    # 判定関数未登録時は None チェックのみで実質オーバーヘッドなし。
+    event.listen(engine, "connect", _install_progress_handler)
     return engine
 
 

--- a/tests/unit/test_query_utils.py
+++ b/tests/unit/test_query_utils.py
@@ -11,12 +11,15 @@ from genai_tag_db_tools.db.query_utils import (
     TagSearchPreloader,
     TagSearchQueryBuilder,
     TagSearchResultBuilder,
+    invalidate_case_exception_cache,
+    sqlite_ascii_lower,
 )
 from genai_tag_db_tools.db.schema import (
     Base,
     Tag,
     TagFormat,
     TagStatus,
+    TagTranslation,
     TagTypeFormatMapping,
     TagTypeName,
     TagUsageCounts,
@@ -86,6 +89,63 @@ def test_initial_tag_ids_for_keywords_is_case_insensitive(
         result = builder.initial_tag_ids_for_keywords(["Blue Hair"])
 
     assert result == {"Blue Hair": {1}}
+
+
+def test_exact_match_finds_uppercase_stored_rows_via_exception_path(
+    session_factory: Callable[[], Session],
+) -> None:
+    """DB 側に大文字混じりで格納された行も index 迂回の例外行経路で照合できる。"""
+    with session_factory() as session:
+        session.add(Tag(tag_id=1, source_tag="Blue_Hair", tag="Blue Hair"))
+        session.add(Tag(tag_id=2, source_tag="blue_hair", tag="blue hair"))
+        session.commit()
+        builder = TagSearchQueryBuilder(session)
+        result = builder.initial_tag_ids_for_keywords(["blue hair"])
+        single = builder.initial_tag_ids("blue hair", use_like=False)
+
+    assert result == {"blue hair": {1, 2}}
+    assert single == {1, 2}
+
+
+def test_exact_match_matches_uppercase_translations(
+    session_factory: Callable[[], Session],
+) -> None:
+    """大文字混じり翻訳行も narrow スキャン経路で case-insensitive に一致する。"""
+    with session_factory() as session:
+        session.add(Tag(tag_id=1, source_tag="cat", tag="cat"))
+        session.add(TagTranslation(translation_id=1, tag_id=1, language="en", translation="Cat Ears"))
+        session.add(TagTranslation(translation_id=2, tag_id=1, language="ja", translation="猫耳"))
+        session.commit()
+        builder = TagSearchQueryBuilder(session)
+        result = builder.initial_tag_ids_for_keywords(["cat ears", "猫耳"])
+
+    assert result == {"cat ears": {1}, "猫耳": {1}}
+
+
+def test_case_exception_cache_is_refreshed_after_invalidate(
+    session_factory: Callable[[], Session],
+) -> None:
+    """例外行キャッシュは invalidate 後に再構築され、後から入った大文字行を拾える。"""
+    with session_factory() as session:
+        session.add(Tag(tag_id=1, source_tag="cat", tag="cat"))
+        session.commit()
+        builder = TagSearchQueryBuilder(session)
+        assert builder.initial_tag_ids_for_keywords(["mixed case"]) == {}
+
+        # キャッシュ構築後に大文字混じり行を直接追加 (通常は TagRepository が invalidate する)
+        session.add(Tag(tag_id=2, source_tag="Mixed_Case", tag="Mixed Case"))
+        session.commit()
+        invalidate_case_exception_cache(session.get_bind())
+        result = builder.initial_tag_ids_for_keywords(["mixed case"])
+
+    assert result == {"mixed case": {2}}
+
+
+def test_sqlite_ascii_lower_folds_ascii_only() -> None:
+    """SQLite lower()/NOCASE と同じく ASCII のみ折り畳み、非 ASCII は保持する。"""
+    assert sqlite_ascii_lower("Blue Hair") == "blue hair"
+    assert sqlite_ascii_lower("CAFÉ") == "cafÉ"
+    assert sqlite_ascii_lower("猫耳") == "猫耳"
 
 
 def test_filtered_tag_ids_applies_filters_before_limit(

--- a/tests/unit/test_runtime_engine_concurrency.py
+++ b/tests/unit/test_runtime_engine_concurrency.py
@@ -61,9 +61,13 @@ def test_concurrent_sessions_do_not_raise_interface_error(tmp_path: Path) -> Non
         try:
             for _ in range(ITERATIONS_PER_THREAD):
                 with session_factory() as session:
-                    result = session.execute(
-                        select(TagFormat.format_id).where(TagFormat.format_name.in_(["danbooru"]))
-                    ).scalars().all()
+                    result = (
+                        session.execute(
+                            select(TagFormat.format_id).where(TagFormat.format_name.in_(["danbooru"]))
+                        )
+                        .scalars()
+                        .all()
+                    )
                     assert result == [1]
         except BaseException as exc:  # スレッド内例外を親スレッドで検知するため意図的に広く捕捉
             with errors_lock:
@@ -80,3 +84,56 @@ def test_concurrent_sessions_do_not_raise_interface_error(tmp_path: Path) -> Non
     assert not any(thread.is_alive() for thread in threads), "スレッドがタイムアウトしました"
     if errors:
         pytest.fail(f"並行アクセス中に例外が発生しました: {errors!r}")
+
+
+def test_query_abort_check_interrupts_running_query(tmp_path: Path) -> None:
+    """set_query_abort_check 登録中は実行中クエリが OperationalError で中断される (LoRAIro #1206)。"""
+    from sqlalchemy import text
+    from sqlalchemy.exc import OperationalError
+
+    from genai_tag_db_tools.db.runtime import set_query_abort_check
+
+    db_path = tmp_path / "abort_check.sqlite"
+    engine = _create_engine(db_path)
+    Base.metadata.create_all(engine)
+    factory = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+
+    # progress handler が確実に呼ばれる長さの再帰クエリ (数百万 VM 命令)
+    long_query = text(
+        "WITH RECURSIVE seq(n) AS (SELECT 1 UNION ALL SELECT n + 1 FROM seq WHERE n < 3000000) "
+        "SELECT count(*) FROM seq"
+    )
+
+    set_query_abort_check(lambda: True)
+    try:
+        with factory() as session:
+            with pytest.raises(OperationalError):
+                session.execute(long_query).scalar()
+    finally:
+        set_query_abort_check(None)
+        engine.dispose()
+
+
+def test_query_abort_check_noop_when_unregistered(tmp_path: Path) -> None:
+    """判定関数未登録 (None) ならクエリは通常どおり完走する。"""
+    from sqlalchemy import text
+
+    from genai_tag_db_tools.db.runtime import set_query_abort_check
+
+    db_path = tmp_path / "abort_noop.sqlite"
+    engine = _create_engine(db_path)
+    Base.metadata.create_all(engine)
+    factory = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+
+    set_query_abort_check(None)
+    try:
+        with factory() as session:
+            result = session.execute(
+                text(
+                    "WITH RECURSIVE seq(n) AS (SELECT 1 UNION ALL SELECT n + 1 FROM seq WHERE n < 10000) "
+                    "SELECT count(*) FROM seq"
+                )
+            ).scalar()
+        assert result == 10000
+    finally:
+        engine.dispose()


### PR DESCRIPTION
## 概要

完全一致キーワード検索 (`lower(col) IN (...)` / `COLLATE NOCASE ==`) は BINARY collation の既存 index を使えず、keyword 数に関係なく毎回 TAGS (4.48M 行) / TAG_TRANSLATIONS (2.04M 行) の全表スキャンになっていた。

下流 (LoRAIro) での実害:
- NEXTAltair/LoRAIro#1203: CLI `tags translations show` が 70 タグ x 210 回の per-call スキャンで約 5 分 (実測 305s/321s)
- NEXTAltair/LoRAIro#1206: GUI TagMetadataWorker が `search_tags_bulk_all` の fetchall に 15 分以上滞留し、協調キャンセルも実行中 SQL を中断できずフリーズの一因に

## 変更内容

### 1. 完全一致照合の index 活用化 (query_utils)

照合結果を変えずに、以下の 2 段に分割:
1. **index が効く完全一致 IN**: 行の大多数 (4.48M 中、非小文字は tag 48 行 / source_tag 49 行) は既に小文字なので、小文字化済みキーの `IN` で index ヒットする
2. **例外行の Python 照合**: ASCII 小文字化で不変でない行だけを engine 単位で 1 回スキャンしてキャッシュし、`sqlite_ascii_lower` (SQLite の lower()/NOCASE と同じ ASCII 限定畳み込み) で照合

翻訳は例外行が多い (385k) ためキャッシュせず、`translation <> lower(translation)` で絞った narrow スキャン (実測 0.1 秒台) で補完。キーに ASCII 小文字が無い場合 (CJK のみ等) は省略。

TAGS を書き換える `TagRepository` の各経路 (create/update/delete/bulk_insert) にキャッシュ invalidate を追加。

### 2. 実行中 SQL の協調中断フック (runtime)

`set_query_abort_check(check)` を公開 API に追加。SQLite progress handler として一定 VM 命令ごとに **クエリ実行スレッド上で** 呼ばれ、True を返すとそのクエリを `OperationalError` (interrupted) で中断する。長時間クエリを協調キャンセルで打ち切りたいホストアプリ (LoRAIro #1206) 向け。未登録時は None チェックのみで実質オーバーヘッドなし。

## 実測 (4.48M 行 base DB, devcontainer)

| 経路 | 従来 | 本 PR |
|---|---|---|
| 全表スキャン 1 回 (cold) | 9.2s | - |
| `search_tags_bulk_all` 72 keywords (cold) | スキャン数秒〜 | **1.48s** (例外集合構築込) |
| 同 (warm) | ~1s | **0.19s** |
| index 完全一致 | - | 3ms |

## テスト

- 大文字格納行の例外経路照合 / 大文字翻訳の narrow スキャン / キャッシュ invalidate / `sqlite_ascii_lower` の ASCII 限定畳み込み / abort フックの中断・未登録時完走を追加
- `QT_QPA_PLATFORM=offscreen uv run pytest -m 'not slow and not network'` → **868 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)