### PR TITLE
fix(resolve): dedup case-variant user tag to base canonical (LoRAIro #1223/#1212)

### DIFF
--- a/src/genai_tag_db_tools/db/repository.py
+++ b/src/genai_tag_db_tools/db/repository.py
@@ -2302,7 +2302,57 @@ class MergedTagReader:
             rows = rows[offset:]
         if resolve_preferred:
             rows = self._resolve_cross_scope_preferred(rows)
+            rows = self._dedup_case_variant_user_rows(rows)
         return rows
+
+    def _base_has_case_variant(self, tag: str) -> bool:
+        """いずれかの base repo に ``tag`` と casefold 一致する canonical タグが存在するか。
+
+        base の完全一致検索は case-insensitive のため、``tag`` にマッチした base 行のうち
+        ``tag`` 文字列 (canonical) が casefold 一致するものだけを重複とみなす。翻訳や
+        source_tag だけがマッチした行 (canonical が別文字列) は重複扱いしない。
+
+        Args:
+            tag: user 行の canonical タグ文字列。
+
+        Returns:
+            base に case-variant の canonical タグがあれば ``True``。
+        """
+        needle = tag.casefold()
+        for repo in self._iter_base_repos():
+            for base_row in repo.search_tags(tag, partial=False):
+                if base_row["tag"].casefold() == needle:
+                    return True
+        return False
+
+    def _dedup_case_variant_user_rows(self, rows: list[TagSearchRow]) -> list[TagSearchRow]:
+        """user overlay タグが base タグの大文字小文字違い重複なら結果から落とす (#1223)。
+
+        user が独自登録した case-variant 重複 (例: base ``anime`` に対する user ``Anime``) は
+        merge 時に base canonical を覆い隠し、手動タグ追加 (``resolve_preferred=True``) の
+        exact 検索が既存 base タグへ解決できず重複を再生産する。casefold 一致する base タグが
+        存在する user-scope 行を落とし、呼び出し側 (LoRAIro の 3 段フォールバック等) が
+        base canonical を解決できるようにする。
+
+        - 別文字列の user alias (typo 補正 #1183) は casefold が一致しないため触れない。
+        - base タグの deprecated 有無は判定に用いない (#1212: deprecated と case 重複は別軸)。
+        - ``resolve_preferred=True`` の解決経路でのみ呼ばれる (ブラウズ検索は user 行をそのまま
+          表示する)。
+
+        Args:
+            rows: cross-scope preferred 解決済みの TagSearchRow リスト。
+
+        Returns:
+            case-variant な user 重複を除いた TagSearchRow リスト。
+        """
+        if not self._has_user() or not rows:
+            return rows
+        kept: list[TagSearchRow] = []
+        for row in rows:
+            if self.get_tag_scope(row["tag_id"]) == "user" and self._base_has_case_variant(row["tag"]):
+                continue
+            kept.append(row)
+        return kept
 
     def search_tags_bulk(
         self,

--- a/src/genai_tag_db_tools/db/repository.py
+++ b/src/genai_tag_db_tools/db/repository.py
@@ -2305,35 +2305,60 @@ class MergedTagReader:
             rows = self._dedup_case_variant_user_rows(rows)
         return rows
 
-    def _base_has_case_variant(self, tag: str) -> bool:
-        """いずれかの base repo に ``tag`` と casefold 一致する canonical タグが存在するか。
+    def _base_has_case_variant(self, tag: str, *, exclude_tag_id: int) -> bool:
+        """いずれかの base repo に ``tag`` と casefold 一致する別 tag_id の canonical タグがあるか。
 
         base の完全一致検索は case-insensitive のため、``tag`` にマッチした base 行のうち
         ``tag`` 文字列 (canonical) が casefold 一致するものだけを重複とみなす。翻訳や
         source_tag だけがマッチした行 (canonical が別文字列) は重複扱いしない。
+        ``exclude_tag_id`` と同じ tag_id の行は「自分自身」なので除外する (legacy 数値衝突で
+        base タグ自身が誤って重複判定されるのを防ぐ、Codex P2)。
 
         Args:
-            tag: user 行の canonical タグ文字列。
+            tag: 判定対象行の canonical タグ文字列。
+            exclude_tag_id: 判定対象行の tag_id。この tag_id の base 行は自己一致として無視する。
 
         Returns:
-            base に case-variant の canonical タグがあれば ``True``。
+            別 tag_id の base に case-variant の canonical タグがあれば ``True``。
         """
         needle = tag.casefold()
         for repo in self._iter_base_repos():
             for base_row in repo.search_tags(tag, partial=False):
-                if base_row["tag"].casefold() == needle:
+                if base_row["tag_id"] != exclude_tag_id and base_row["tag"].casefold() == needle:
                     return True
         return False
+
+    def _is_overlay_origin_row(self, row: TagSearchRow) -> bool:
+        """行が user overlay 由来かを、数値 ID scope 推定に依らず実体で判定する (Codex P2)。
+
+        legacy 低 ID の user タグは base タグと tag_id を共有し得るため、``get_tag_scope`` の
+        scope 推定 (衝突時 user 優先) では base 由来行を user と誤判定する。overlay が同一の
+        ``(tag_id, tag)`` を実際に保持しているかで由来を判定することで、ID 衝突に依存しない。
+
+        Args:
+            row: 判定対象の TagSearchRow。
+
+        Returns:
+            overlay が同一 tag_id で同一 canonical タグ文字列を保持していれば ``True``。
+        """
+        if not self._has_user():
+            return False
+        assert self.user_repo is not None
+        user_tag = self.user_repo.get_tag_by_id(row["tag_id"])
+        return user_tag is not None and user_tag.tag == row["tag"]
 
     def _dedup_case_variant_user_rows(self, rows: list[TagSearchRow]) -> list[TagSearchRow]:
         """user overlay タグが base タグの大文字小文字違い重複なら結果から落とす (#1223)。
 
         user が独自登録した case-variant 重複 (例: base ``anime`` に対する user ``Anime``) は
         merge 時に base canonical を覆い隠し、手動タグ追加 (``resolve_preferred=True``) の
-        exact 検索が既存 base タグへ解決できず重複を再生産する。casefold 一致する base タグが
-        存在する user-scope 行を落とし、呼び出し側 (LoRAIro の 3 段フォールバック等) が
-        base canonical を解決できるようにする。
+        exact 検索が既存 base タグへ解決できず重複を再生産する。別 tag_id の base に casefold
+        一致する canonical タグがある overlay 由来行を落とし、呼び出し側 (LoRAIro の 3 段
+        フォールバック等) が base canonical を解決できるようにする。
 
+        - 由来判定は数値 ID scope 推定でなく overlay の実体 (``_is_overlay_origin_row``) で行う
+          ため、legacy 低 ID の user タグと base タグの ID 衝突で base 行を誤って落とさない
+          (Codex P2)。
         - 別文字列の user alias (typo 補正 #1183) は casefold が一致しないため触れない。
         - base タグの deprecated 有無は判定に用いない (#1212: deprecated と case 重複は別軸)。
         - ``resolve_preferred=True`` の解決経路でのみ呼ばれる (ブラウズ検索は user 行をそのまま
@@ -2343,13 +2368,15 @@ class MergedTagReader:
             rows: cross-scope preferred 解決済みの TagSearchRow リスト。
 
         Returns:
-            case-variant な user 重複を除いた TagSearchRow リスト。
+            case-variant な overlay 重複を除いた TagSearchRow リスト。
         """
         if not self._has_user() or not rows:
             return rows
         kept: list[TagSearchRow] = []
         for row in rows:
-            if self.get_tag_scope(row["tag_id"]) == "user" and self._base_has_case_variant(row["tag"]):
+            if self._is_overlay_origin_row(row) and self._base_has_case_variant(
+                row["tag"], exclude_tag_id=row["tag_id"]
+            ):
                 continue
             kept.append(row)
         return kept

--- a/tests/unit/test_merged_case_variant_dedup.py
+++ b/tests/unit/test_merged_case_variant_dedup.py
@@ -1,0 +1,187 @@
+"""MergedTagReader の case-variant user 重複 dedup テスト (#1223 / #1212)。
+
+user が独自登録した「base タグの大文字小文字違い重複」(例: base ``anime`` に対する
+user ``Anime``) が resolve_preferred 解決経路で base canonical を覆い隠さないことを
+検証する。別文字列の user alias (#1183) や deprecated base タグ (#1212) の解決は
+壊さない。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from sqlalchemy import StaticPool, create_engine
+from sqlalchemy.orm import sessionmaker
+
+from genai_tag_db_tools.db.overlay_reader import OverlayTagReader
+from genai_tag_db_tools.db.repository import MergedTagReader, TagReader
+from genai_tag_db_tools.db.schema import (
+    USER_TAG_ID_OFFSET,
+    Base,
+    Tag,
+    TagFormat,
+    TagStatus,
+    TagTypeFormatMapping,
+    TagTypeName,
+    UserOverlayBase,
+    UserTag,
+    UserTagStatusPatch,
+)
+
+_DANBOORU_FORMAT_ID = 1
+_LORAIRO_FORMAT_ID = 1000
+_BASE_ANIME_ID = 166991
+_USER_ANIME_ID = USER_TAG_ID_OFFSET + 11756
+
+
+# ------------------------------------------------------------------
+# Fixtures
+# ------------------------------------------------------------------
+
+
+@pytest.fixture
+def base_session_factory(tmp_path: Path):
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'base.sqlite'}",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine, autoflush=False, autocommit=False)
+
+
+@pytest.fixture
+def user_session_factory(tmp_path: Path):
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'user.sqlite'}",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    UserOverlayBase.metadata.create_all(engine)
+    return sessionmaker(bind=engine, autoflush=False, autocommit=False)
+
+
+@pytest.fixture
+def populated_base(base_session_factory):
+    """Base DB に deprecated な danbooru タグ ``anime`` を挿入する。"""
+    with base_session_factory() as session:
+        session.add(TagFormat(format_id=_DANBOORU_FORMAT_ID, format_name="danbooru"))
+        session.add(TagTypeName(type_name_id=1, type_name="general"))
+        session.add(TagTypeFormatMapping(format_id=_DANBOORU_FORMAT_ID, type_id=0, type_name_id=1))
+        session.add(Tag(tag_id=_BASE_ANIME_ID, source_tag="anime", tag="anime"))
+        session.flush()
+        session.add(
+            TagStatus(
+                tag_id=_BASE_ANIME_ID,
+                format_id=_DANBOORU_FORMAT_ID,
+                type_id=0,
+                alias=False,
+                preferred_tag_id=_BASE_ANIME_ID,
+                deprecated=True,
+            )
+        )
+        session.commit()
+
+
+@pytest.fixture
+def populated_user_case_dup(user_session_factory):
+    """User DB に base ``anime`` の case 重複 ``Anime`` (非 alias / 非 deprecated) を挿入する。"""
+    with user_session_factory() as session:
+        session.add(UserTag(tag_id=_USER_ANIME_ID, source_tag="Anime", tag="Anime"))
+        session.flush()
+        session.add(
+            UserTagStatusPatch(
+                target_scope="user",
+                target_tag_id=_USER_ANIME_ID,
+                format_id=_LORAIRO_FORMAT_ID,
+                type_id=0,
+                alias=False,
+                preferred_scope="user",
+                preferred_tag_id=_USER_ANIME_ID,
+                deprecated=False,
+            )
+        )
+        session.commit()
+
+
+@pytest.fixture
+def merged(base_session_factory, user_session_factory, populated_base, populated_user_case_dup):
+    base_repo = TagReader(session_factory=base_session_factory)
+    user_repo = OverlayTagReader(session_factory=user_session_factory)
+    return MergedTagReader(base_repo=base_repo, user_repo=user_repo)
+
+
+# ------------------------------------------------------------------
+# Tests
+# ------------------------------------------------------------------
+
+
+class TestCaseVariantUserDedup:
+    """resolve_preferred 経路で user case 重複が base canonical を覆い隠さない。"""
+
+    def test_stage1_nondeprecated_danbooru_drops_user_dup(self, merged):
+        """LoRAIro stage1 相当: 非 deprecated danbooru では user ``Anime`` を返さない。
+
+        base ``anime`` は deprecated で除外され、user ``Anime`` は case 重複として
+        dedup されるため結果は空になる (呼び出し側は次段へフォールバックできる)。
+        """
+        rows = merged.search_tags(
+            "anime",
+            format_names=["danbooru"],
+            deprecated=False,
+            resolve_preferred=True,
+        )
+        assert all(row["tag_id"] < USER_TAG_ID_OFFSET for row in rows)
+        assert rows == []
+
+    def test_stage3_deprecated_included_returns_base_canonical(self, merged):
+        """LoRAIro stage3 相当: deprecated 込みなら base ``anime`` (166991) を返す。"""
+        rows = merged.search_tags(
+            "anime",
+            format_names=["danbooru"],
+            resolve_preferred=True,
+        )
+        assert len(rows) == 1
+        assert rows[0]["tag_id"] == _BASE_ANIME_ID
+        assert rows[0]["tag"] == "anime"
+
+    def test_browsing_without_resolve_preferred_keeps_user_dup(self, merged):
+        """resolve_preferred=False (ブラウズ) では dedup せず user ``Anime`` を残す。"""
+        rows = merged.search_tags("anime", deprecated=False, resolve_preferred=False)
+        assert any(row["tag_id"] == _USER_ANIME_ID for row in rows)
+
+
+class TestUserAliasNotDeduped:
+    """別文字列の user alias (#1183) は case dedup 対象外。"""
+
+    @pytest.fixture
+    def merged_alias(self, base_session_factory, user_session_factory, populated_base):
+        # base ``anime`` に対する user alias ``aniime`` (typo, 別文字列)。
+        with user_session_factory() as session:
+            alias_id = USER_TAG_ID_OFFSET + 5000
+            session.add(UserTag(tag_id=alias_id, source_tag="aniime", tag="aniime"))
+            session.flush()
+            session.add(
+                UserTagStatusPatch(
+                    target_scope="user",
+                    target_tag_id=alias_id,
+                    format_id=_LORAIRO_FORMAT_ID,
+                    type_id=0,
+                    alias=True,
+                    preferred_scope="base",
+                    preferred_tag_id=_BASE_ANIME_ID,
+                    deprecated=False,
+                )
+            )
+            session.commit()
+        base_repo = TagReader(session_factory=base_session_factory)
+        user_repo = OverlayTagReader(session_factory=user_session_factory)
+        return MergedTagReader(base_repo=base_repo, user_repo=user_repo)
+
+    def test_different_string_alias_resolves_to_base(self, merged_alias):
+        """``aniime`` は base ``anime`` の case 重複ではないため alias→preferred 解決が生きる。"""
+        rows = merged_alias.search_tags("aniime", resolve_preferred=True)
+        assert len(rows) == 1
+        assert rows[0]["tag_id"] == _BASE_ANIME_ID
+        assert rows[0]["tag"] == "anime"

--- a/tests/unit/test_merged_case_variant_dedup.py
+++ b/tests/unit/test_merged_case_variant_dedup.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-from sqlalchemy import StaticPool, create_engine
+from sqlalchemy import StaticPool, create_engine, text
 from sqlalchemy.orm import sessionmaker
 
 from genai_tag_db_tools.db.overlay_reader import OverlayTagReader
@@ -185,3 +185,69 @@ class TestUserAliasNotDeduped:
         assert len(rows) == 1
         assert rows[0]["tag_id"] == _BASE_ANIME_ID
         assert rows[0]["tag"] == "anime"
+
+
+class TestLegacyIdCollisionNotDropped:
+    """legacy 低 ID の user タグと base タグが tag_id 衝突しても base 行を落とさない (Codex P2)。"""
+
+    _COLLIDING_ID = 500  # base と user で数値 ID を共有する legacy ケース
+
+    @pytest.fixture
+    def merged_collision(self, base_session_factory, user_session_factory):
+        # base: 非 deprecated タグ ``sunglasses`` (tag_id=500)。
+        with base_session_factory() as session:
+            session.add(TagFormat(format_id=_DANBOORU_FORMAT_ID, format_name="danbooru"))
+            session.add(TagTypeName(type_name_id=1, type_name="general"))
+            session.add(TagTypeFormatMapping(format_id=_DANBOORU_FORMAT_ID, type_id=0, type_name_id=1))
+            session.add(Tag(tag_id=self._COLLIDING_ID, source_tag="sunglasses", tag="sunglasses"))
+            session.flush()
+            session.add(
+                TagStatus(
+                    tag_id=self._COLLIDING_ID,
+                    format_id=_DANBOORU_FORMAT_ID,
+                    type_id=0,
+                    alias=False,
+                    preferred_tag_id=self._COLLIDING_ID,
+                    deprecated=False,
+                )
+            )
+            session.commit()
+        # user: base と同じ tag_id=500 だが別文字列 ``myfav`` (legacy 数値衝突)。
+        # ck_user_tag_id_offset (USER_TAG_ID_OFFSET 以上) は現行スキーマの制約だが、
+        # legacy DB には低 ID 行が残り得る。CHECK 強制を切って legacy 行を再現する。
+        with user_session_factory() as session:
+            session.execute(text("PRAGMA ignore_check_constraints = ON"))
+            session.add(UserTag(tag_id=self._COLLIDING_ID, source_tag="myfav", tag="myfav"))
+            session.flush()
+            session.add(
+                UserTagStatusPatch(
+                    target_scope="user",
+                    target_tag_id=self._COLLIDING_ID,
+                    format_id=_LORAIRO_FORMAT_ID,
+                    type_id=0,
+                    alias=False,
+                    preferred_scope="user",
+                    preferred_tag_id=self._COLLIDING_ID,
+                    deprecated=False,
+                )
+            )
+            session.commit()
+        base_repo = TagReader(session_factory=base_session_factory)
+        user_repo = OverlayTagReader(session_factory=user_session_factory)
+        return MergedTagReader(base_repo=base_repo, user_repo=user_repo)
+
+    def test_base_tag_not_self_dropped_on_id_collision(self, merged_collision):
+        """base ``sunglasses`` (tag_id=500) は user と ID 衝突しても drop されず解決される。
+
+        get_tag_scope(500) は衝突時 "user" を返すため、由来を ID scope で推定すると
+        base 行が自分自身を case-variant とみなして落ちてしまう (Codex P2 回帰)。
+        """
+        rows = merged_collision.search_tags(
+            "sunglasses",
+            format_names=["danbooru"],
+            deprecated=False,
+            resolve_preferred=True,
+        )
+        assert len(rows) == 1
+        assert rows[0]["tag_id"] == self._COLLIDING_ID
+        assert rows[0]["tag"] == "sunglasses"


### PR DESCRIPTION
## 概要

user overlay の大文字小文字違い重複タグ (`Anime`) が base canonical タグ (`anime`) を覆い隠し、LoRAIro `tags add` が既存タグに解決されず重複を再生産する問題を修正する。

## 根本原因

`MergedTagReader.search_tags` は base (TagReader, format/deprecated を SQL ハードフィルタ) と user overlay (OverlayTagReader, format ハードフィルタなし・完全一致は COLLATE NOCASE) をマージする。LoRAIro の解決経路 (danbooru 非deprecated → Lorairo → danbooru deprecated込みの3段) で base `anime` が deprecated のため第1段で除外される一方、user `Anime` が COLLATE NOCASE で残って短絡し、正しい base canonical へ到達しない。

## 修正

`MergedTagReader.search_tags` の **`resolve_preferred=True` 経路のみ** で `_resolve_cross_scope_preferred` 直後に `_dedup_case_variant_user_rows` を追加。user-scope 行が既存 base タグの case-insensitive 重複 (canonical 一致) の場合に drop し base canonical へ寄せる。ブラウズ (resolve_preferred=False) は無変更で blast radius 最小化。

## 非退行

- 別文字列 user alias (`aniime`→`anime`) は casefold 不一致で dedup 対象外 → 解決優先維持。
- deprecated base タグ (`sparkles` 等) は user-scope 行のみ drop するため無影響。
- 全 suite 872 passed (QT_QPA_PLATFORM=offscreen)。

## テスト

新規 tests/unit/test_merged_case_variant_dedup.py (4テスト)。

Related: LoRAIro #1223 (バグB), #1212

🤖 Generated with [Claude Code](https://claude.com/claude-code)