### PR TITLE
fix(db): register_tag を atomic 化 + tag DB engine を WAL/busy_timeout で hardening (LoRAIro #1239)

### DIFF
--- a/src/genai_tag_db_tools/db/repository.py
+++ b/src/genai_tag_db_tools/db/repository.py
@@ -629,6 +629,129 @@ class TagRepository:
             invalidate_case_exception_cache(session.get_bind())
             return new_tag.tag_id
 
+    @staticmethod
+    def _resolve_or_create_tag_in_session(
+        session: "Session", source_tag: str, tag: str, existing_tag_id: int | None
+    ) -> int:
+        """同一 session 内で TAGS 行を取得または新規作成し tag_id を返す（commit なし）。
+
+        Args:
+            session: SQLAlchemyセッション（commit しない）。
+            source_tag: ソースタグ文字列。
+            tag: 正規タグ文字列。
+            existing_tag_id: 呼び出し元が reader で解決済みの既存 tag_id。None なら新規作成。
+
+        Returns:
+            既存または新規作成した tag_id（新規時は flush 済みで id 割当済み）。
+        """
+        if existing_tag_id is not None:
+            return existing_tag_id
+        existing = session.query(Tag).filter(Tag.tag == tag).one_or_none()
+        if existing is not None:
+            return existing.tag_id
+        new_tag = Tag(source_tag=source_tag, tag=tag)
+        session.add(new_tag)
+        session.flush()
+        return new_tag.tag_id
+
+    def register_tag_with_status(
+        self,
+        *,
+        source_tag: str,
+        tag: str,
+        existing_tag_id: int | None,
+        format_id: int,
+        type_id: int,
+        alias: bool,
+        preferred_tag_id: int | None,
+        translations: list[tuple[str, str]] | None = None,
+    ) -> int:
+        """TAGS 行・TAG_STATUS 行・任意の翻訳を単一トランザクションで束ねて登録する。
+
+        parent (TAGS) と child (TAG_STATUS / TAG_TRANSLATIONS) を1コミットで束ねること
+        で、child insert が直前の parent を可視化できない並行アクセス下の
+        ``FOREIGN KEY constraint failed`` を防ぐ (LoRAIro #1239)。
+
+        Args:
+            source_tag: ソースタグ文字列。
+            tag: 正規タグ文字列。
+            existing_tag_id: 呼び出し元が reader で解決済みの既存 tag_id。None なら新規作成。
+            format_id: フォーマットID。
+            type_id: タイプID。
+            alias: エイリアスかどうか。
+            preferred_tag_id: alias=True のとき解決済みの推奨タグID。alias=False では無視され、
+                新規/既存 tag 自身の id を使う。
+            translations: (language, translation) タプルのリスト。
+
+        Returns:
+            登録された tag の tag_id。
+
+        Raises:
+            ValueError: 型マッピング不整合・バリデーション失敗・DB 操作失敗時。
+        """
+        with self.session_factory() as session:
+            tag_id = self._resolve_or_create_tag_in_session(session, source_tag, tag, existing_tag_id)
+            self._write_status_and_translations_in_session(
+                session,
+                tag_id=tag_id,
+                format_id=format_id,
+                type_id=type_id,
+                alias=alias,
+                preferred_tag_id=preferred_tag_id,
+                translations=translations,
+            )
+            try:
+                session.commit()
+            except IntegrityError as e:
+                session.rollback()
+                # 並行登録に負けた場合は勝者 id を引いて status/translations を張り直す。
+                winner = session.query(Tag).filter(Tag.tag == tag).one_or_none()
+                if winner is None:
+                    msg = ErrorMessages.DB_OPERATION_FAILED.format(error_msg=str(e))
+                    self.logger.error(msg)
+                    raise ValueError(msg) from e
+                tag_id = winner.tag_id
+                self._write_status_and_translations_in_session(
+                    session,
+                    tag_id=tag_id,
+                    format_id=format_id,
+                    type_id=type_id,
+                    alias=alias,
+                    preferred_tag_id=preferred_tag_id,
+                    translations=translations,
+                )
+                session.commit()
+            invalidate_case_exception_cache(session.get_bind())
+            return tag_id
+
+    def _write_status_and_translations_in_session(
+        self,
+        session: "Session",
+        *,
+        tag_id: int,
+        format_id: int,
+        type_id: int,
+        alias: bool,
+        preferred_tag_id: int | None,
+        translations: list[tuple[str, str]] | None,
+    ) -> None:
+        """TAG_STATUS と翻訳を同一 session 内で書き込む（commit は呼び出し元）。"""
+        effective_preferred = preferred_tag_id if alias else tag_id
+        if effective_preferred is None:
+            raise ValueError("preferred_tag_id が未設定です")
+        self._validate_tag_status_params(alias, effective_preferred, tag_id)
+        self._write_tag_status_in_session(
+            session,
+            tag_id=tag_id,
+            format_id=format_id,
+            alias=alias,
+            preferred_tag_id=effective_preferred,
+            type_id=type_id,
+        )
+        if translations:
+            for language, translation in translations:
+                self._add_translation_in_session(session, tag_id, language, translation)
+
     def update_tag(self, tag_id: int, *, source_tag: str | None = None, tag: str | None = None) -> None:
         with self.session_factory() as session:
             tag_obj = session.get(Tag, tag_id)
@@ -752,34 +875,24 @@ class TagRepository:
         self._validate_tag_status_params(alias, preferred_tag_id, tag_id)
 
         with self.session_factory() as session:
-            if type_id is not None:
-                self._validate_type_mapping(session, format_id, type_id)
-
-            status_obj = (
-                session.query(TagStatus)
-                .filter(TagStatus.tag_id == tag_id, TagStatus.format_id == format_id)
-                .one_or_none()
+            self._write_tag_status_in_session(
+                session,
+                tag_id=tag_id,
+                format_id=format_id,
+                alias=alias,
+                preferred_tag_id=preferred_tag_id,
+                type_id=type_id,
+                deprecated=deprecated,
+                deprecated_at=deprecated_at,
+                source_created_at=source_created_at,
+                updated_at=updated_at,
             )
-
-            effective_type_id = (
-                type_id if type_id is not None else (status_obj.type_id if status_obj else 0)
-            )
-
-            optional_fields = {
-                "deprecated": deprecated,
-                "deprecated_at": deprecated_at,
-                "source_created_at": source_created_at,
-                "updated_at": updated_at,
-            }
-
-            if status_obj:
-                self._apply_status_update(
-                    session, status_obj, effective_type_id, alias, preferred_tag_id, optional_fields
-                )
-            else:
-                self._create_new_status(
-                    session, tag_id, format_id, effective_type_id, alias, preferred_tag_id, optional_fields
-                )
+            try:
+                session.commit()
+            except IntegrityError as e:
+                session.rollback()
+                msg = ErrorMessages.DB_OPERATION_FAILED.format(error_msg=str(e))
+                raise ValueError(msg) from e
 
     @staticmethod
     def _validate_tag_status_params(alias: bool, preferred_tag_id: int, tag_id: int) -> None:
@@ -826,73 +939,76 @@ class TagRepository:
             raise ValueError(msg)
 
     @staticmethod
-    def _apply_status_update(
+    def _write_tag_status_in_session(
         session: "Session",
-        status_obj: TagStatus,
-        effective_type_id: int,
-        alias: bool,
-        preferred_tag_id: int,
-        optional_fields: dict[str, Any],
-    ) -> None:
-        """既存のTagStatusレコードを更新する。
-
-        Args:
-            session: SQLAlchemyセッション。
-            status_obj: 更新対象のTagStatusオブジェクト。
-            effective_type_id: 適用するタイプID。
-            alias: エイリアスフラグ。
-            preferred_tag_id: 優先タグID。
-            optional_fields: オプションフィールド（deprecated, deprecated_at等）。
-        """
-        status_obj.type_id = effective_type_id
-        status_obj.alias = alias
-        status_obj.preferred_tag_id = preferred_tag_id
-        for field_name, value in optional_fields.items():
-            if value is not None:
-                setattr(status_obj, field_name, value)
-        session.commit()
-
-    @staticmethod
-    def _create_new_status(
-        session: "Session",
+        *,
         tag_id: int,
         format_id: int,
-        effective_type_id: int,
         alias: bool,
         preferred_tag_id: int,
-        optional_fields: dict[str, Any],
+        type_id: int | None = None,
+        deprecated: bool | None = None,
+        deprecated_at: datetime | None = None,
+        source_created_at: datetime | None = None,
+        updated_at: datetime | None = None,
     ) -> None:
-        """新規TagStatusレコードを作成する。
+        """TAG_STATUS を同一 session 内で upsert する（commit は呼び出し元）。
+
+        parent (TAGS) と child (TAG_STATUS) を単一トランザクションで束ねられるよう、
+        commit を持たない session ボディを提供する。これにより並行アクセス下で child が
+        直前に作られた parent を可視化できずに ``FOREIGN KEY constraint failed`` になる
+        欠陥を防ぐ (LoRAIro #1239)。
 
         Args:
-            session: SQLAlchemyセッション。
-            tag_id: タグID。
+            session: SQLAlchemyセッション（commit しない）。
+            tag_id: 対象タグID。
             format_id: フォーマットID。
-            effective_type_id: タイプID。
-            alias: エイリアスフラグ。
+            alias: エイリアスかどうか。
             preferred_tag_id: 優先タグID。
-            optional_fields: オプションフィールド。
-
-        Raises:
-            ValueError: IntegrityErrorが発生した場合。
+            type_id: タイプID（Noneなら既存値または0を使用）。
+            deprecated: 非推奨フラグ。
+            deprecated_at: 非推奨になった日時。
+            source_created_at: ソース作成日時。
+            updated_at: 更新日時。
         """
-        try:
-            status_obj = TagStatus(
-                tag_id=tag_id,
-                format_id=format_id,
-                type_id=effective_type_id,
-                alias=alias,
-                preferred_tag_id=preferred_tag_id,
-                deprecated=optional_fields.get("deprecated", False) or False,
-                deprecated_at=optional_fields.get("deprecated_at"),
-                source_created_at=optional_fields.get("source_created_at"),
+        if type_id is not None:
+            TagRepository._validate_type_mapping(session, format_id, type_id)
+
+        status_obj = (
+            session.query(TagStatus)
+            .filter(TagStatus.tag_id == tag_id, TagStatus.format_id == format_id)
+            .one_or_none()
+        )
+
+        effective_type_id = type_id if type_id is not None else (status_obj.type_id if status_obj else 0)
+
+        optional_fields = {
+            "deprecated": deprecated,
+            "deprecated_at": deprecated_at,
+            "source_created_at": source_created_at,
+            "updated_at": updated_at,
+        }
+
+        if status_obj:
+            status_obj.type_id = effective_type_id
+            status_obj.alias = alias
+            status_obj.preferred_tag_id = preferred_tag_id
+            for field_name, value in optional_fields.items():
+                if value is not None:
+                    setattr(status_obj, field_name, value)
+        else:
+            session.add(
+                TagStatus(
+                    tag_id=tag_id,
+                    format_id=format_id,
+                    type_id=effective_type_id,
+                    alias=alias,
+                    preferred_tag_id=preferred_tag_id,
+                    deprecated=optional_fields.get("deprecated", False) or False,
+                    deprecated_at=optional_fields.get("deprecated_at"),
+                    source_created_at=optional_fields.get("source_created_at"),
+                )
             )
-            session.add(status_obj)
-            session.commit()
-        except IntegrityError as e:
-            session.rollback()
-            msg = ErrorMessages.DB_OPERATION_FAILED.format(error_msg=str(e))
-            raise ValueError(msg) from e
 
     def delete_tag_status(self, tag_id: int, format_id: int) -> None:
         with self.session_factory() as session:
@@ -933,29 +1049,38 @@ class TagRepository:
 
     def add_or_update_translation(self, tag_id: int, language: str, translation: str) -> None:
         with self.session_factory() as session:
-            tag = session.query(Tag).filter(Tag.tag_id == tag_id).one_or_none()
-            if not tag:
-                raise ValueError(f"Tag ID not found: {tag_id}")
-
-            existing = (
-                session.query(TagTranslation)
-                .filter(
-                    TagTranslation.tag_id == tag_id,
-                    TagTranslation.language == language,
-                    TagTranslation.translation == translation,
-                )
-                .one_or_none()
-            )
-            if existing:
-                return
-
+            self._add_translation_in_session(session, tag_id, language, translation)
             try:
-                translation_obj = TagTranslation(tag_id=tag_id, language=language, translation=translation)
-                session.add(translation_obj)
                 session.commit()
             except IntegrityError as e:
                 session.rollback()
                 raise ValueError(f"DB operation failed: {e}") from e
+
+    @staticmethod
+    def _add_translation_in_session(
+        session: "Session", tag_id: int, language: str, translation: str
+    ) -> None:
+        """TAG_TRANSLATIONS へ翻訳を追加する同一 session ボディ（commit は呼び出し元）。
+
+        parent (TAGS) と同一トランザクションで翻訳を書けるよう commit を持たない
+        (LoRAIro #1239)。既に同一 (tag_id, language, translation) があれば何もしない。
+        """
+        tag = session.query(Tag).filter(Tag.tag_id == tag_id).one_or_none()
+        if not tag:
+            raise ValueError(f"Tag ID not found: {tag_id}")
+
+        existing = (
+            session.query(TagTranslation)
+            .filter(
+                TagTranslation.tag_id == tag_id,
+                TagTranslation.language == language,
+                TagTranslation.translation == translation,
+            )
+            .one_or_none()
+        )
+        if existing:
+            return
+        session.add(TagTranslation(tag_id=tag_id, language=language, translation=translation))
 
     def create_format_if_not_exists(
         self, format_name: str, description: str | None = None, reader: "MergedTagReader | None" = None

--- a/src/genai_tag_db_tools/db/runtime.py
+++ b/src/genai_tag_db_tools/db/runtime.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Any
 
 from sqlalchemy import Engine, create_engine, event
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session, sessionmaker
 
 from genai_tag_db_tools.db.schema import Base, UserOverlayBase
@@ -25,6 +26,11 @@ _query_abort_check: Callable[[], bool] | None = None
 # progress handler の呼び出し間隔 (SQLite VM 命令数)。小さいほど応答が速いが
 # オーバーヘッドが増える。長時間クエリの協調キャンセル用途なので粗くてよい。
 _PROGRESS_HANDLER_INTERVAL = 4000
+
+# ロック競合時の待機上限 (ms)。GUI (書き) と CLI/RefinementWorker (読み) が
+# user_tags.sqlite を共有するため、瞬間的な排他ロックを即時失敗させず待機させる
+# (LoRAIro #1239)。LoRAIro 本体 DB (db_core.BUSY_TIMEOUT_MS) と同値。
+_BUSY_TIMEOUT_MS = 30000
 
 
 def set_query_abort_check(check: Callable[[], bool] | None) -> None:
@@ -82,6 +88,44 @@ def enable_foreign_keys(dbapi_connection: Any, connection_record: Any) -> None:
     cursor.close()
 
 
+def set_busy_timeout(dbapi_connection: Any, connection_record: Any) -> None:
+    """接続ごとに busy_timeout を設定する (LoRAIro #1239)。
+
+    busy_timeout はロック待機の設定であり WAL への切り替え (#1165 でクラッシュした
+    per-connection ``PRAGMA journal_mode=WAL``) のような排他取得は伴わないため、
+    接続ごとに設定して安全。foreign_keys とは独立に単独 cursor で設定する。
+    """
+    cursor = dbapi_connection.cursor()
+    try:
+        cursor.execute(f"PRAGMA busy_timeout={_BUSY_TIMEOUT_MS}")
+    finally:
+        cursor.close()
+
+
+def _ensure_wal_journal_mode(engine: Engine) -> None:
+    """file-backed DB に WAL journal mode を DB 準備時 1 回だけ永続化する (LoRAIro #1165)。
+
+    journal_mode=WAL は DB ヘッダに永続化されるため接続ごとに設定する必要はない。
+    毎接続で ``PRAGMA journal_mode=WAL`` を実行すると、GUI/CLI 併用 (9p bind mount) 時に
+    その一瞬の排他取得が busy_timeout の効かないまま ``database is locked`` /
+    ``disk I/O error`` になり接続セットアップがクラッシュする。そこで準備時に一度だけ
+    設定し、既に WAL の場合は書き換え (ロック取得) を避けて読み取りだけで済ませる。
+
+    Args:
+        engine: 対象の SQLAlchemy エンジン。``:memory:`` DB では何もしない。
+    """
+    if ":memory:" in str(engine.url):
+        return
+    try:
+        with engine.connect() as connection:
+            current = connection.exec_driver_sql("PRAGMA journal_mode").scalar()
+            if current is not None and str(current).lower() == "wal":
+                return
+            connection.exec_driver_sql("PRAGMA journal_mode=WAL")
+    except SQLAlchemyError:
+        logger.warning("Failed to set WAL journal mode at DB preparation", exc_info=True)
+
+
 def _create_engine(db_path: Path) -> Engine:
     engine = create_engine(
         f"sqlite:///{db_path.absolute()}",
@@ -89,6 +133,8 @@ def _create_engine(db_path: Path) -> Engine:
         echo=False,
     )
     event.listen(engine, "connect", enable_foreign_keys)
+    # ロック競合時に即時失敗させず待機する (GUI/CLI 併用、LoRAIro #1239)。
+    event.listen(engine, "connect", set_busy_timeout)
     # 協調キャンセルで実行中 SQL を中断できるようにする (set_query_abort_check)。
     # 判定関数未登録時は None チェックのみで実質オーバーヘッドなし。
     event.listen(engine, "connect", _install_progress_handler)
@@ -151,6 +197,11 @@ def init_user_db(user_db_dir: Path | None = None, *, format_name: str | None = N
 
     _user_db_path = user_db_path
     _user_engine = _create_engine(user_db_path)
+
+    # user_tags.sqlite は GUI (書き) と CLI/RefinementWorker (読み) が共有する唯一の
+    # 書き込み先。WAL は writer/reader 同時アクセスの並行性を上げ、単独巨大ロックを
+    # 避ける。per-connection ではなく DB 準備時に 1 回だけ設定する (#1165/#1239)。
+    _ensure_wal_journal_mode(_user_engine)
 
     # overlay テーブルを先に作成してから legacy 移行を実行する。
     # 移行関数が USER_TAGS / USER_TAG_STATUS_PATCH 等への INSERT を行うため、

--- a/src/genai_tag_db_tools/services/tag_register.py
+++ b/src/genai_tag_db_tools/services/tag_register.py
@@ -284,10 +284,10 @@ class TagRegisterService:
         type_id = self._resolve_type_id(type_name, request.format_name, fmt_id)
 
         existing_id = self._reader.get_tag_id_by_name(tag, partial=False)
-        tag_id = self._repo.create_tag(source_tag, tag)
-        created = existing_id is None
 
-        preferred_tag_id: int | None = tag_id
+        # alias の preferred は書き込み前に解決する。preferred を先に確定しておくと、
+        # 解決失敗時に TAGS 行だけ残る中途半端な状態を作らずに済む。
+        preferred_tag_id: int | None = None
         if request.alias:
             if not request.preferred_tag:
                 raise ValueError("alias=True の場合 preferred_tag が必須です")
@@ -295,22 +295,25 @@ class TagRegisterService:
             if preferred_tag_id is None:
                 raise ValueError(f"推奨タグが見つかりません: {request.preferred_tag}")
 
-        if request.translations:
-            for tr in request.translations:
-                self._repo.add_or_update_translation(tag_id, tr.language, tr.translation)
-
-        if preferred_tag_id is None:
-            raise ValueError("preferred_tag_id が未設定です")
-
-        self._repo.update_tag_status(
-            tag_id=tag_id,
-            format_id=fmt_id,
-            alias=request.alias,
-            preferred_tag_id=preferred_tag_id,
-            type_id=type_id,
+        translations = (
+            [(tr.language, tr.translation) for tr in request.translations] if request.translations else None
         )
 
-        return TagRegisterResult(created=created, tag_id=tag_id)
+        # create_tag + translations + update_tag_status を単一トランザクションで束ねる
+        # (LoRAIro #1239)。parent (TAGS) と child (TAG_STATUS) が別 session で個別 commit
+        # されると、並行アクセス下で child が parent を可視化できず FK 制約失敗になっていた。
+        tag_id = self._repo.register_tag_with_status(
+            source_tag=source_tag,
+            tag=tag,
+            existing_tag_id=existing_id,
+            format_id=fmt_id,
+            type_id=type_id,
+            alias=request.alias,
+            preferred_tag_id=preferred_tag_id,
+            translations=translations,
+        )
+
+        return TagRegisterResult(created=existing_id is None, tag_id=tag_id)
 
     def _register_user_tag(self, request: "TagRegisterRequest") -> "TagRegisterResult":
         """USER_TAGS / USER_TAG_STATUS_PATCH にタグを登録する。

--- a/tests/gui/unit/test_gui_tag_register_service.py
+++ b/tests/gui/unit/test_gui_tag_register_service.py
@@ -39,6 +39,34 @@ class DummyRepo:
     def add_or_update_translation(self, tag_id: int, language: str, translation: str) -> None:
         self.translations.append((tag_id, language, translation))
 
+    def register_tag_with_status(
+        self,
+        *,
+        source_tag: str,
+        tag: str,
+        existing_tag_id: int | None,
+        format_id: int,
+        type_id: int,
+        alias: bool,
+        preferred_tag_id: int | None,
+        translations: list[tuple[str, str]] | None = None,
+    ) -> int:
+        """create_tag + status + translations を単一トランザクションで束ねる新 API (#1239)。
+
+        既存アサーション (created_tags / status_updates / translations) を保つため
+        同じ記録配列に書き込む。
+        """
+        if existing_tag_id is not None:
+            tag_id = existing_tag_id
+        else:
+            tag_id = self.create_tag(source_tag, tag)
+        effective_preferred = preferred_tag_id if alias else tag_id
+        self.status_updates.append((tag_id, format_id, alias, effective_preferred, type_id))
+        if translations:
+            for language, translation in translations:
+                self.translations.append((tag_id, language, translation))
+        return tag_id
+
     def update_usage_count(self, tag_id: int, format_id: int, count: int) -> None:
         self.usage_updates.append((tag_id, format_id, count))
 

--- a/tests/unit/test_runtime_engine_concurrency.py
+++ b/tests/unit/test_runtime_engine_concurrency.py
@@ -137,3 +137,41 @@ def test_query_abort_check_noop_when_unregistered(tmp_path: Path) -> None:
         assert result == 10000
     finally:
         engine.dispose()
+
+
+def test_create_engine_sets_busy_timeout(tmp_path: Path) -> None:
+    """_create_engine() の接続は busy_timeout が設定される (LoRAIro #1239)。
+
+    GUI (書き) と CLI/RefinementWorker (読み) が user_tags.sqlite を共有するため、
+    瞬間的なロック競合を即時失敗させず待機させる必要がある。
+    """
+    from sqlalchemy import text
+
+    from genai_tag_db_tools.db.runtime import _BUSY_TIMEOUT_MS
+
+    db_path = tmp_path / "busy_timeout.sqlite"
+    engine = _create_engine(db_path)
+    try:
+        with engine.connect() as connection:
+            timeout = connection.execute(text("PRAGMA busy_timeout")).scalar()
+        assert timeout == _BUSY_TIMEOUT_MS
+    finally:
+        engine.dispose()
+
+
+def test_ensure_wal_journal_mode_persists_wal(tmp_path: Path) -> None:
+    """_ensure_wal_journal_mode() が file-backed DB を WAL に切り替える (LoRAIro #1165/#1239)。"""
+    from sqlalchemy import text
+
+    from genai_tag_db_tools.db.runtime import _ensure_wal_journal_mode
+
+    db_path = tmp_path / "wal_mode.sqlite"
+    engine = _create_engine(db_path)
+    Base.metadata.create_all(engine)
+    try:
+        _ensure_wal_journal_mode(engine)
+        with engine.connect() as connection:
+            mode = connection.execute(text("PRAGMA journal_mode")).scalar()
+        assert str(mode).lower() == "wal"
+    finally:
+        engine.dispose()

--- a/tests/unit/test_tag_register_service.py
+++ b/tests/unit/test_tag_register_service.py
@@ -45,6 +45,34 @@ class DummyRepo:
     def add_or_update_translation(self, tag_id: int, language: str, translation: str) -> None:
         self.translations.append((tag_id, language, translation))
 
+    def register_tag_with_status(
+        self,
+        *,
+        source_tag: str,
+        tag: str,
+        existing_tag_id: int | None,
+        format_id: int,
+        type_id: int,
+        alias: bool,
+        preferred_tag_id: int | None,
+        translations: list[tuple[str, str]] | None = None,
+    ) -> int:
+        """create_tag + status + translations を単一トランザクションで束ねる新 API (#1239)。
+
+        既存アサーションを保つため、create_tag/update_tag_status/add_or_update_translation
+        と同じ記録配列に書き込む。
+        """
+        if existing_tag_id is not None:
+            tag_id = existing_tag_id
+        else:
+            tag_id = self.create_tag(source_tag, tag)
+        effective_preferred = preferred_tag_id if alias else tag_id
+        self.status_updates.append((tag_id, format_id, alias, effective_preferred, type_id))
+        if translations:
+            for language, translation in translations:
+                self.translations.append((tag_id, language, translation))
+        return tag_id
+
     def update_usage_count(self, tag_id: int, format_id: int, count: int) -> None:
         self.usage_updates.append((tag_id, format_id, count))
 

--- a/tests/unit/test_tag_repository.py
+++ b/tests/unit/test_tag_repository.py
@@ -912,3 +912,115 @@ def _seed_search_rows(session: Session, tag_ids: range) -> None:
             )
         )
     session.commit()
+
+
+# ==============================================================================
+# register_tag_with_status: parent(TAGS) + child(TAG_STATUS) の atomicity (#1239)
+# ==============================================================================
+
+
+def _seed_format_and_mapping(session_factory: Callable[[], Session]) -> None:
+    """format_id=1 / type_id=0(unknown) の mapping を seed する。"""
+    with session_factory() as session:
+        session.add(TagFormat(format_id=1, format_name="danbooru"))
+        session.add(TagTypeName(type_name_id=0, type_name="unknown"))
+        session.add(TagTypeFormatMapping(format_id=1, type_id=0, type_name_id=0))
+        session.commit()
+
+
+def test_register_tag_with_status_writes_parent_and_child_atomically(
+    session_factory: Callable[[], Session],
+) -> None:
+    """#1239: TAGS 行・TAG_STATUS 行・翻訳を単一トランザクションで束ねて書く。"""
+    _seed_format_and_mapping(session_factory)
+    reader = TagReader(session_factory)
+    repo = TagRepository(session_factory, reader=MergedTagReader(base_repo=reader))
+
+    tag_id = repo.register_tag_with_status(
+        source_tag="newtag",
+        tag="newtag",
+        existing_tag_id=None,
+        format_id=1,
+        type_id=0,
+        alias=False,
+        preferred_tag_id=None,
+        translations=[("ja", "新タグ")],
+    )
+
+    with session_factory() as session:
+        tag_row = session.query(Tag).filter(Tag.tag == "newtag").one()
+        assert tag_row.tag_id == tag_id
+        status = (
+            session.query(TagStatus)
+            .filter(TagStatus.tag_id == tag_id, TagStatus.format_id == 1)
+            .one()
+        )
+        assert status.alias is False
+        # alias=False では preferred_tag_id は自身の id に一致する
+        assert status.preferred_tag_id == tag_id
+        assert status.type_id == 0
+        translation = session.query(TagTranslation).filter(TagTranslation.tag_id == tag_id).one()
+        assert translation.translation == "新タグ"
+
+
+def test_register_tag_with_status_rolls_back_parent_when_status_fails(
+    session_factory: Callable[[], Session],
+) -> None:
+    """#1239: child(TAG_STATUS) 書き込みが失敗したら parent(TAGS) も rollback される。
+
+    非 atomic な旧実装では create_tag が単独 commit するため、後続の status 失敗時に
+    TAGS 行だけが孤児として残っていた。atomic 化後は type_id マッピング不整合で
+    status 書き込みが失敗すると、直前に flush した TAGS 行も一緒に rollback される。
+    """
+    _seed_format_and_mapping(session_factory)
+    reader = TagReader(session_factory)
+    repo = TagRepository(session_factory, reader=MergedTagReader(base_repo=reader))
+
+    # type_id=5 は mapping が無いため _validate_type_mapping が commit 前に ValueError を送出
+    with pytest.raises(ValueError):
+        repo.register_tag_with_status(
+            source_tag="orphan",
+            tag="orphan",
+            existing_tag_id=None,
+            format_id=1,
+            type_id=5,
+            alias=False,
+            preferred_tag_id=None,
+        )
+
+    with session_factory() as session:
+        # parent TAGS 行が孤児として残っていないこと
+        assert session.query(Tag).filter(Tag.tag == "orphan").one_or_none() is None
+        assert session.query(TagStatus).count() == 0
+
+
+def test_register_tag_with_status_reuses_existing_tag_id(
+    session_factory: Callable[[], Session],
+) -> None:
+    """#1239: existing_tag_id 指定時は新規 TAGS 行を作らず既存 id に status を張る。"""
+    _seed_format_and_mapping(session_factory)
+    reader = TagReader(session_factory)
+    repo = TagRepository(session_factory, reader=MergedTagReader(base_repo=reader))
+
+    existing_id = repo.create_tag("existing", "existing")
+
+    returned_id = repo.register_tag_with_status(
+        source_tag="existing",
+        tag="existing",
+        existing_tag_id=existing_id,
+        format_id=1,
+        type_id=0,
+        alias=False,
+        preferred_tag_id=None,
+    )
+
+    assert returned_id == existing_id
+    with session_factory() as session:
+        # 重複 TAGS 行を作っていないこと
+        assert session.query(Tag).filter(Tag.tag == "existing").count() == 1
+        status = (
+            session.query(TagStatus)
+            .filter(TagStatus.tag_id == existing_id, TagStatus.format_id == 1)
+            .one()
+        )
+        assert status.preferred_tag_id == existing_id

--- a/tests/unit/test_user_tag_repository.py
+++ b/tests/unit/test_user_tag_repository.py
@@ -10,9 +10,9 @@ import pytest
 from sqlalchemy import text
 from sqlalchemy.orm import sessionmaker
 
-from genai_tag_db_tools.db.runtime import _create_engine
 from genai_tag_db_tools.core_api import write_user_translation
 from genai_tag_db_tools.db.repository import TagRepository
+from genai_tag_db_tools.db.runtime import _create_engine
 from genai_tag_db_tools.db.schema import (
     USER_TAG_ID_OFFSET,
     Base,
@@ -358,6 +358,30 @@ class _DummyRepo:
 
     def add_or_update_translation(self, tag_id: int, language: str, translation: str) -> None:
         pass
+
+    def register_tag_with_status(
+        self,
+        *,
+        source_tag: str,
+        tag: str,
+        existing_tag_id: int | None,
+        format_id: int,
+        type_id: int,
+        alias: bool,
+        preferred_tag_id: int | None,
+        translations: list[tuple[str, str]] | None = None,
+    ) -> int:
+        """create_tag + status を単一トランザクションで束ねる新 API (#1239)。
+
+        既存アサーション (created_tags / status_updates) を保つため同じ記録配列に書く。
+        """
+        if existing_tag_id is not None:
+            tag_id = existing_tag_id
+        else:
+            tag_id = self.create_tag(source_tag, tag)
+        effective_preferred = preferred_tag_id if alias else tag_id
+        self.status_updates.append((tag_id, format_id, alias, effective_preferred, type_id))
+        return tag_id
 
     def create_type_name_if_not_exists(self, type_name: str, description: str | None = None) -> int:
         return {"unknown": 0, "general": 1, "character": 2}.get(type_name, 0)


### PR DESCRIPTION
## 概要

LoRAIro の P1 データ完全性バグ (LoRAIro #1239) の根本原因を修正する。過去データセット取り込み時の並行 DB アクセスで新規タグ登録が `FOREIGN KEY constraint failed` を多発していた。

## 根本原因

`TagRegisterService.register_tag()` が `create_tag()` (独立 session で単独 commit → parent TAGS 行) と `update_tag_status()` (別の独立 session で単独 commit → child TAG_STATUS 行) を跨ぐトランザクションを持たず、並行アクセス下で child の session が parent を見えない可視性窓で FK 失敗していた。

## 変更

### Fix 1: register_tag を atomic 化 (`db/repository.py`, `services/tag_register.py`)
- `TagRepository.register_tag_with_status()` を新設し parent TAGS + 翻訳 + child TAG_STATUS を**単一 session/トランザクション (1 commit)** に束ねる
- parent Tag add 直後に `session.flush()` で INSERT を materialize (autoflush=False のため必須)。同一トランザクション内の child TAG_STATUS INSERT が SQLite の即時 FK check を通る
- 途中失敗で context manager が rollback し flush 済み未 commit の parent も破棄 (orphan TAGS 行を作らない)
- 既存の「並行登録に負けたら勝者 id を返す」IntegrityError リカバリを保持
- public メソッド (`create_tag`/`update_tag_status`/`add_or_update_translation`) のシグネチャ不変。commit-less な `_..._in_session` ボディを抽出し public はラップ
- scope=user 経路は user overlay テーブルが FK 無しのため FK 失敗せず対象外 (正しく非変更)

### Fix 2: tag DB engine を WAL + busy_timeout で hardening (`db/runtime.py`)
- LoRAIro `db_core.py` の実証済みパターンを移植: journal_mode=WAL を **DB 準備時 1 回** 設定 (per-connection でなく。LoRAIro #1165 の 9p クラッシュ教訓)。既に WAL ならスキップ、失敗時 warning + continue
- busy_timeout=30000ms を per-connection listener で設定 (lock-free PRAGMA、9p 安全)

## テスト

- `test_register_tag_with_status_rolls_back_parent_when_status_fails` (atomicity)
- `test_runtime_engine_concurrency.py` (WAL/busy_timeout)
- 既存 tag_register / tag_repository テスト互換維持、core 106 passed

## 関連

- LoRAIro #1239 (親、P1)、#127 (overlay 削除/抑制 API)

🤖 Generated with [Claude Code](https://claude.com/claude-code)