### PR TITLE
fix: atomic tag+status 登録で低並行下の FK 制約失敗を塞ぐ

### DIFF
--- a/src/genai_tag_db_tools/db/repository.py
+++ b/src/genai_tag_db_tools/db/repository.py
@@ -661,7 +661,7 @@ class TagRepository:
         tag: str,
         existing_tag_id: int | None,
         format_id: int,
-        type_id: int,
+        type_id: int | None,
         alias: bool,
         preferred_tag_id: int | None,
         translations: list[tuple[str, str]] | None = None,
@@ -677,7 +677,7 @@ class TagRepository:
             tag: 正規タグ文字列。
             existing_tag_id: 呼び出し元が reader で解決済みの既存 tag_id。None なら新規作成。
             format_id: フォーマットID。
-            type_id: タイプID。
+            type_id: タイプID。None なら既存 status の値を保持し、新規なら 0 を使う。
             alias: エイリアスかどうか。
             preferred_tag_id: alias=True のとき解決済みの推奨タグID。alias=False では無視され、
                 新規/既存 tag 自身の id を使う。
@@ -720,7 +720,15 @@ class TagRepository:
                     preferred_tag_id=preferred_tag_id,
                     translations=translations,
                 )
-                session.commit()
+                try:
+                    session.commit()
+                except IntegrityError as retry_error:
+                    # 稀な double-race や TAG_STATUS 由来の衝突では raw IntegrityError を
+                    # 呼び出し元へ漏らさず ValueError に包んで返す (LoRAIro #1249)。
+                    session.rollback()
+                    msg = ErrorMessages.DB_OPERATION_FAILED.format(error_msg=str(retry_error))
+                    self.logger.error(msg)
+                    raise ValueError(msg) from retry_error
             invalidate_case_exception_cache(session.get_bind())
             return tag_id
 
@@ -730,7 +738,7 @@ class TagRepository:
         *,
         tag_id: int,
         format_id: int,
-        type_id: int,
+        type_id: int | None,
         alias: bool,
         preferred_tag_id: int | None,
         translations: list[tuple[str, str]] | None,

--- a/src/genai_tag_db_tools/gui/services/tag_register_service.py
+++ b/src/genai_tag_db_tools/gui/services/tag_register_service.py
@@ -90,21 +90,24 @@ class GuiTagRegisterService(GuiServiceBase):
             # format固有のtype_idを正しく解決する
             type_id = self._reader.get_type_id_for_format(type_name, fmt_id) if type_name else None
 
-            tag_id = self._repo.create_tag(source_tag, normalized_tag)
+            # TAGS 行・TAG_STATUS 行・翻訳を単一トランザクションで束ねる (LoRAIro #1249)。
+            # create_tag → 別 session で update_tag_status に分けると、並行アクセス下で
+            # child(TAG_STATUS) が直前の parent(TAGS) を可視化できず FK 制約失敗になりうる。
+            # usage_count は TAGS 行の commit 後に別途更新する (FK 上 tag 存在が前提)。
+            fallback_translations = [(language, translation)] if language and translation else None
+            tag_id = self._repo.register_tag_with_status(
+                source_tag=source_tag,
+                tag=normalized_tag,
+                existing_tag_id=None,
+                format_id=fmt_id,
+                type_id=type_id,
+                alias=False,
+                preferred_tag_id=None,
+                translations=fallback_translations,
+            )
 
             if usage_count > 0:
                 self._repo.update_usage_count(tag_id, fmt_id, usage_count)
-
-            if language and translation:
-                self._repo.add_or_update_translation(tag_id, language, translation)
-
-            self._repo.update_tag_status(
-                tag_id=tag_id,
-                format_id=fmt_id,
-                alias=False,
-                preferred_tag_id=tag_id,
-                type_id=type_id,
-            )
 
             return tag_id
 

--- a/src/genai_tag_db_tools/services/base_patch/apply.py
+++ b/src/genai_tag_db_tools/services/base_patch/apply.py
@@ -148,24 +148,32 @@ class BasePatchApplyService:
         format_id = self._resolve_or_create_format(patch.format_name)
 
         preferred_id = self._ensure_tag(preferred_tag)
-        alias_id = self._ensure_tag(alias_tag)
-        if alias_id == preferred_id:
+        # alias タグは新規作成する場合があるため、ここでは解決のみに留める。新規作成は
+        # 下の register_tag_with_status で TAG_STATUS と単一トランザクションに束ねる
+        # (LoRAIro #1249)。create_tag → 別 session で update_tag_status に分けると、
+        # 並行アクセス下で child(TAG_STATUS) が直前の parent(TAGS) を可視化できず
+        # FK 制約失敗になりうる。
+        alias_id = self._resolve_tag_id(alias_tag)
+        if alias_id is not None and alias_id == preferred_id:
             raise _ApplyReject("alias tag and preferred tag resolve to the same tag")
 
-        existing = self._tag_status(alias_id, format_id)
+        existing = self._tag_status(alias_id, format_id) if alias_id is not None else None
         if existing is not None and existing.alias and existing.preferred_tag_id == preferred_id:
             return None
         type_id = self._alias_type_id(existing, preferred_id, format_id)
         if self._dry_run:
-            return [f"TAG_STATUS.alias tag_id={alias_id} -> preferred_tag_id={preferred_id}"]
-        self._repo.update_tag_status(
-            tag_id=alias_id,
+            alias_label = alias_id if alias_id is not None else -1
+            return [f"TAG_STATUS.alias tag_id={alias_label} -> preferred_tag_id={preferred_id}"]
+        resolved_alias_id = self._repo.register_tag_with_status(
+            source_tag=alias_tag,
+            tag=alias_tag,
+            existing_tag_id=alias_id,
             format_id=format_id,
+            type_id=type_id,
             alias=True,
             preferred_tag_id=preferred_id,
-            type_id=type_id,
         )
-        return [f"TAG_STATUS.alias tag_id={alias_id} -> preferred_tag_id={preferred_id}"]
+        return [f"TAG_STATUS.alias tag_id={resolved_alias_id} -> preferred_tag_id={preferred_id}"]
 
     def _apply_preferred_correction(self, patch: BaseCorrectionPatch) -> list[str] | None:
         alias_tag = _require(patch.target_tag, "target.tag")

--- a/src/genai_tag_db_tools/services/tag_register.py
+++ b/src/genai_tag_db_tools/services/tag_register.py
@@ -104,10 +104,16 @@ class TagRegister:
                 if not dep_tag:
                     continue
 
-                alias_tag_id = self._repo.create_tag(dep_tag, dep_tag)
-                self._repo.update_tag_status(
-                    tag_id=alias_tag_id,
+                # TAGS 行と TAG_STATUS 行を単一トランザクションで束ねる (LoRAIro #1249)。
+                # create_tag → 別 session で update_tag_status に分けると、並行アクセス下で
+                # child(TAG_STATUS) が直前の parent(TAGS) を可視化できず FK 制約失敗になりうる。
+                # type_id=None で既存 status の値を保持し、新規なら 0 を使う従来挙動を維持する。
+                self._repo.register_tag_with_status(
+                    source_tag=dep_tag,
+                    tag=dep_tag,
+                    existing_tag_id=None,
                     format_id=format_id,
+                    type_id=None,
                     alias=True,
                     preferred_tag_id=tag_id,
                 )
@@ -448,13 +454,16 @@ class TagRegisterService:
             )
 
         # 5. 実際に作成
-        new_alias_tag_id = self._repo.create_tag(entry.alias, entry.alias)
-        self._repo.update_tag_status(
-            tag_id=new_alias_tag_id,
+        # TAGS 行と TAG_STATUS 行を単一トランザクションで束ねる (LoRAIro #1249)。
+        # existing_tag_id には reader で解決済みの alias_tag_id (未存在なら None) を渡す。
+        new_alias_tag_id = self._repo.register_tag_with_status(
+            source_tag=entry.alias,
+            tag=entry.alias,
+            existing_tag_id=alias_tag_id,
             format_id=fmt_id,
+            type_id=type_id,
             alias=True,
             preferred_tag_id=preferred_tag_id,
-            type_id=type_id,
         )
         return AliasRegisterItemResult(
             alias=entry.alias,

--- a/tests/gui/unit/test_gui_tag_register_service.py
+++ b/tests/gui/unit/test_gui_tag_register_service.py
@@ -18,6 +18,7 @@ class DummyRepo:
         self.status_updates: list[tuple[int, int, bool, int, int | None]] = []
         self.translations: list[tuple[int, str, str]] = []
         self.usage_updates: list[tuple[int, int, int]] = []
+        self.atomic_calls: list[dict] = []
         self._tag_ids: dict[str, int] = {}
 
     def create_tag(self, source_tag: str, tag: str) -> int:
@@ -56,6 +57,18 @@ class DummyRepo:
         既存アサーション (created_tags / status_updates / translations) を保つため
         同じ記録配列に書き込む。
         """
+        self.atomic_calls.append(
+            {
+                "source_tag": source_tag,
+                "tag": tag,
+                "existing_tag_id": existing_tag_id,
+                "format_id": format_id,
+                "type_id": type_id,
+                "alias": alias,
+                "preferred_tag_id": preferred_tag_id,
+                "translations": list(translations) if translations else None,
+            }
+        )
         if existing_tag_id is not None:
             tag_id = existing_tag_id
         else:
@@ -296,6 +309,43 @@ class TestGuiTagRegisterService:
         # Verify tag creation through legacy path
         assert tag_id == 10
         assert service._repo.created_tags == [("legacy_tag", "legacy_tag")]
+
+    def test_register_or_update_tag_fallback_bundles_translation_and_status_atomically(
+        self, service: GuiTagRegisterService, qtbot
+    ):
+        """#1249: format/type 未指定の fallback 経路でも、create_tag→別 session の
+        update_tag_status / add_or_update_translation という非 atomic な分離ではなく、
+        register_tag_with_status で TAGS 行・TAG_STATUS 行・翻訳を単一トランザクションに
+        束ねる。低並行下で child(TAG_STATUS) が直前の parent(TAGS) を可視化できず
+        FK 制約失敗になる潜在バグを塞ぐ。
+        """
+        tag_info = {
+            "normalized_tag": "fallback_tag",
+            "source_tag": "fallback_src",
+            "format_name": "danbooru",
+            "type_name": "",  # type 未指定 → fallback 経路
+            "use_count": 30,
+            "language": "ja",
+            "translation": "フォールバック",
+        }
+
+        tag_id = service.register_or_update_tag(tag_info)
+
+        assert tag_id == 10
+        repo = service._repo
+        # 単一の atomic 呼び出しに翻訳が束ねられる
+        assert len(repo.atomic_calls) == 1
+        call = repo.atomic_calls[0]
+        assert call["source_tag"] == "fallback_src"
+        assert call["tag"] == "fallback_tag"
+        assert call["alias"] is False
+        assert call["preferred_tag_id"] is None
+        assert call["type_id"] is None
+        assert call["translations"] == [("ja", "フォールバック")]
+        # 翻訳を別 session (add_or_update_translation) で二重書きしていない (atomic 内の1件のみ)
+        assert repo.translations == [(10, "ja", "フォールバック")]
+        # usage_count は TAGS 行の commit 後に別途更新される
+        assert repo.usage_updates == [(10, 1, 30)]
 
     def test_register_or_update_tag_with_usage_count(self, service: GuiTagRegisterService, qtbot):
         """register_or_update_tag updates usage count when provided"""

--- a/tests/unit/test_base_patch_apply.py
+++ b/tests/unit/test_base_patch_apply.py
@@ -103,6 +103,51 @@ def test_apply_alias_addition(service: BasePatchApplyService, session_factory) -
         assert status.preferred_tag_id == 1
 
 
+def test_apply_alias_addition_uses_atomic_register(session_factory, monkeypatch) -> None:
+    """#1249: 新規 alias タグの作成と TAG_STATUS 書き込みを register_tag_with_status で
+    単一トランザクションに束ねる。create_tag(_ensure_tag)→別 session の update_tag_status
+    という非 atomic な分離をやめ、低並行下の FK 制約失敗を塞ぐ。
+    """
+    reader = MergedTagReader(base_repo=TagReader(session_factory))
+    repo = TagRepository(session_factory, reader=reader)
+    calls = {"atomic": 0, "update_status": 0}
+    real_register = repo.register_tag_with_status
+    real_update = repo.update_tag_status
+
+    def spy_register(**kwargs):
+        calls["atomic"] += 1
+        return real_register(**kwargs)
+
+    def spy_update(*args, **kwargs):
+        calls["update_status"] += 1
+        return real_update(*args, **kwargs)
+
+    monkeypatch.setattr(repo, "register_tag_with_status", spy_register)
+    monkeypatch.setattr(repo, "update_tag_status", spy_update)
+    service = BasePatchApplyService(repo, reader)
+
+    patch = _patch(
+        "alias_addition",
+        {"target_type": "alias", "tag": "blakc hair", "format_name": "danbooru"},
+        {"alias": True, "preferred_tag": "black hair"},
+    )
+    row = service.apply_patch(patch)
+
+    assert row.status == "applied"
+    # alias の parent(TAGS) + child(TAG_STATUS) は atomic 経路のみで書く
+    assert calls["atomic"] == 1
+    assert calls["update_status"] == 0
+    with session_factory() as session:
+        alias_tag = session.query(Tag).filter(Tag.tag == "blakc hair").one()
+        status = (
+            session.query(TagStatus)
+            .filter(TagStatus.tag_id == alias_tag.tag_id, TagStatus.format_id == 1)
+            .one()
+        )
+        assert status.alias is True
+        assert status.preferred_tag_id == 1
+
+
 def test_apply_translation(service: BasePatchApplyService, session_factory) -> None:
     patch = _patch(
         "translation_correction",

--- a/tests/unit/test_cli_aliases_register.py
+++ b/tests/unit/test_cli_aliases_register.py
@@ -22,6 +22,7 @@ class DummyRepo:
     def __init__(self) -> None:
         self.created_tags: list[tuple[str, str]] = []
         self.status_updates: list[dict] = []
+        self.atomic_calls: list[dict] = []
         self._tag_ids: dict[str, int] = {}
         self._next_id = 100
 
@@ -46,6 +47,48 @@ class DummyRepo:
 
     def add_or_update_translation(self, tag_id: int, language: str, translation: str) -> None:
         pass
+
+    def register_tag_with_status(
+        self,
+        *,
+        source_tag: str,
+        tag: str,
+        existing_tag_id: int | None,
+        format_id: int,
+        type_id: int | None,
+        alias: bool,
+        preferred_tag_id: int | None,
+        translations: list[tuple[str, str]] | None = None,
+    ) -> int:
+        """#1249: create_tag + update_tag_status を単一トランザクションに束ねる atomic API。
+
+        既存アサーション (status_updates) を保つため、新規作成時は create_tag を通し
+        status を同じ配列に記録する。
+        """
+        self.atomic_calls.append(
+            {
+                "source_tag": source_tag,
+                "tag": tag,
+                "existing_tag_id": existing_tag_id,
+                "type_id": type_id,
+                "alias": alias,
+                "preferred_tag_id": preferred_tag_id,
+            }
+        )
+        if existing_tag_id is not None:
+            tag_id_val = existing_tag_id
+        else:
+            tag_id_val = self.create_tag(source_tag, tag)
+        effective_preferred = preferred_tag_id if alias else tag_id_val
+        self.status_updates.append(
+            {
+                "tag_id": tag_id_val,
+                "format_id": format_id,
+                "alias": alias,
+                "preferred_tag_id": effective_preferred,
+            }
+        )
+        return tag_id_val
 
     def create_format_if_not_exists(
         self, format_name: str, description: str | None = None, reader: object = None
@@ -132,6 +175,48 @@ class TestRegisterAliasEntry:
         assert len(repo.status_updates) == 1
         assert repo.status_updates[0]["alias"] is True
         assert repo.status_updates[0]["preferred_tag_id"] == 99
+
+    def test_apply_uses_atomic_register_with_status(self) -> None:
+        """#1249: create_tag→別 session の update_tag_status ではなく register_tag_with_status で
+        TAGS 行と TAG_STATUS 行を単一トランザクションに束ねて登録する。"""
+        repo = DummyRepo()
+        service = TagRegisterService(repository=repo, reader=DummyReader())
+        entry = AliasRegisterInput(
+            alias="weding dress",
+            preferred="wedding dress",
+            format_name="Lorairo",
+            type_name="unknown",
+        )
+        service.register_alias_entry(entry, dry_run=False)
+
+        assert len(repo.atomic_calls) == 1
+        call = repo.atomic_calls[0]
+        assert call["tag"] == "weding dress"
+        assert call["alias"] is True
+        assert call["preferred_tag_id"] == 99
+        # 新規 alias なので reader 解決結果 (None) を existing_tag_id として渡す
+        assert call["existing_tag_id"] is None
+
+    def test_apply_reuses_existing_tag_id_without_alias_status(self) -> None:
+        """#1249: alias タグが既存 (alias status 無し) なら register_tag_with_status に
+        既存 tag_id を渡し、重複 TAGS 行を作らない。"""
+        reader = DummyReader()
+        reader._tags["weding dress"] = 200  # 既存だが alias status 未設定
+        repo = DummyRepo()
+        service = TagRegisterService(repository=repo, reader=reader)
+        entry = AliasRegisterInput(
+            alias="weding dress",
+            preferred="wedding dress",
+            format_name="Lorairo",
+            type_name="unknown",
+        )
+        result = service.register_alias_entry(entry, dry_run=False)
+
+        assert result.status == "created"
+        assert len(repo.atomic_calls) == 1
+        assert repo.atomic_calls[0]["existing_tag_id"] == 200
+        # 既存 id を再利用するので create_tag は呼ばれない
+        assert repo.created_tags == []
 
     def test_skipped_when_same_preferred_exists(self) -> None:
         reader = DummyReader()

--- a/tests/unit/test_tag_register.py
+++ b/tests/unit/test_tag_register.py
@@ -83,24 +83,50 @@ def test_update_translations_skips_empty_values():
 
 
 @pytest.mark.db_tools
-def test_update_deprecated_tags_registers_aliases():
+def test_update_deprecated_tags_registers_aliases_atomically():
+    """#1249: deprecated alias は create_tag→別 session の update_tag_status という非 atomic な
+    分離ではなく、register_tag_with_status で TAGS 行と TAG_STATUS 行を単一トランザクションに
+    束ねて登録する。低並行下で child(TAG_STATUS) が直前の parent(TAGS) を可視化できず
+    FK 制約失敗になる潜在バグを塞ぐ。
+    """
+
     class DummyRepo:
         def __init__(self):
-            self.created = []
-            self.status_updates = []
+            self.atomic_calls: list[dict] = []
+            self.legacy_create_calls: list[tuple[str, str]] = []
+            self.legacy_status_calls: list[dict] = []
 
-        def create_tag(self, tag: str, source_tag: str) -> int:
-            self.created.append((tag, source_tag))
-            return len(self.created) + 200
-
-        def update_tag_status(
+        def register_tag_with_status(
             self,
-            tag_id: int,
+            *,
+            source_tag: str,
+            tag: str,
+            existing_tag_id: int | None,
             format_id: int,
+            type_id: int | None,
             alias: bool,
-            preferred_tag_id: int,
-        ) -> None:
-            self.status_updates.append((tag_id, format_id, alias, preferred_tag_id))
+            preferred_tag_id: int | None,
+            translations: list[tuple[str, str]] | None = None,
+        ) -> int:
+            self.atomic_calls.append(
+                {
+                    "source_tag": source_tag,
+                    "tag": tag,
+                    "existing_tag_id": existing_tag_id,
+                    "format_id": format_id,
+                    "type_id": type_id,
+                    "alias": alias,
+                    "preferred_tag_id": preferred_tag_id,
+                }
+            )
+            return len(self.atomic_calls) + 200
+
+        def create_tag(self, source_tag: str, tag: str) -> int:  # 旧非 atomic 経路
+            self.legacy_create_calls.append((source_tag, tag))
+            return 999
+
+        def update_tag_status(self, **kwargs) -> None:  # 旧非 atomic 経路
+            self.legacy_status_calls.append(kwargs)
 
     repo = DummyRepo()
     register = TagRegister(repository=repo)
@@ -109,5 +135,17 @@ def test_update_deprecated_tags_registers_aliases():
     register.update_deprecated_tags(df, format_id=3)
 
     cleaned = [TagCleaner.clean_format("old_tag"), TagCleaner.clean_format("old_tag2")]
-    assert repo.created == [(cleaned[0], cleaned[0]), (cleaned[1], cleaned[1])]
-    assert repo.status_updates == [(201, 3, True, 10), (202, 3, True, 10)]
+    # 非 atomic な旧経路 (create_tag + update_tag_status の分離呼び出し) は使わない
+    assert repo.legacy_create_calls == []
+    assert repo.legacy_status_calls == []
+    # 単一トランザクションの atomic 経路のみを使う
+    assert [c["tag"] for c in repo.atomic_calls] == cleaned
+    assert [c["source_tag"] for c in repo.atomic_calls] == cleaned
+    for call in repo.atomic_calls:
+        assert call["alias"] is True
+        assert call["preferred_tag_id"] == 10
+        assert call["format_id"] == 3
+        # type_id=None で既存 status の値を保持し、新規なら 0 を使う従来挙動を維持
+        assert call["type_id"] is None
+        # existing_tag_id=None で session 内解決 (新規/既存の両対応) に委ねる
+        assert call["existing_tag_id"] is None

--- a/tests/unit/test_tag_repository.py
+++ b/tests/unit/test_tag_repository.py
@@ -1024,3 +1024,59 @@ def test_register_tag_with_status_reuses_existing_tag_id(
             .one()
         )
         assert status.preferred_tag_id == existing_id
+
+
+def test_register_tag_with_status_type_id_none_defaults_and_preserves(
+    session_factory: Callable[[], Session],
+) -> None:
+    """#1249: type_id=None は新規 status では 0、既存 status では現在値を保持する。
+
+    update_deprecated_tags / GUI fallback は type_id を渡さない従来挙動を持つため、
+    register_tag_with_status が type_id=None を「既存値保持 / 新規は 0」として扱えることを
+    保証する。
+    """
+    _seed_format_and_mapping(session_factory)
+    # 非 0 の type mapping (format_id=1, type_id=2) も seed する
+    with session_factory() as session:
+        session.add(TagTypeName(type_name_id=2, type_name="character"))
+        session.add(TagTypeFormatMapping(format_id=1, type_id=2, type_name_id=2))
+        session.commit()
+    reader = TagReader(session_factory)
+    repo = TagRepository(session_factory, reader=MergedTagReader(base_repo=reader))
+
+    # 新規 status: type_id=None -> 0
+    new_id = repo.register_tag_with_status(
+        source_tag="newdep",
+        tag="newdep",
+        existing_tag_id=None,
+        format_id=1,
+        type_id=None,
+        alias=False,
+        preferred_tag_id=None,
+    )
+    with session_factory() as session:
+        status = (
+            session.query(TagStatus)
+            .filter(TagStatus.tag_id == new_id, TagStatus.format_id == 1)
+            .one()
+        )
+        assert status.type_id == 0
+
+    # 既存 status を type_id=2 で作り直してから type_id=None で更新 -> 2 を保持
+    repo.update_tag_status(tag_id=new_id, format_id=1, alias=False, preferred_tag_id=new_id, type_id=2)
+    repo.register_tag_with_status(
+        source_tag="newdep",
+        tag="newdep",
+        existing_tag_id=new_id,
+        format_id=1,
+        type_id=None,
+        alias=False,
+        preferred_tag_id=None,
+    )
+    with session_factory() as session:
+        status = (
+            session.query(TagStatus)
+            .filter(TagStatus.tag_id == new_id, TagStatus.format_id == 1)
+            .one()
+        )
+        assert status.type_id == 2


### PR DESCRIPTION
## 概要

`create_tag()` (parent TAGS を別 session で commit) → 後で `update_tag_status()` (child TAG_STATUS を別 session で commit) という**非 atomic** な parent/child 分離呼び出しをしている 4 箇所を、既存の atomic メソッド `register_tag_with_status()` に移行する。低並行下で child(TAG_STATUS) が直前の parent(TAGS) を可視化できず `FOREIGN KEY constraint failed` になる潜在バグを塞ぐ。

LoRAIro #1249 (https://github.com/NEXTAltair/LoRAIro/issues/1249) follow-up
(別リポジトリの issue のため `Closes` は使わない)

## 変更点

### 移行した 4 箇所
1. **`services/tag_register.py` `TagRegister.update_deprecated_tags`** — deprecated tag を alias 登録するループ。`type_id=None` で従来挙動 (既存 status 値保持 / 新規は 0) を維持。
2. **`services/tag_register.py` `TagRegisterService.register_alias_entry`** — alias エントリ登録。reader 解決済み `alias_tag_id` を `existing_tag_id` に渡す。
3. **`gui/services/tag_register_service.py` `GuiTagRegisterService.register_or_update_tag`** — format/type 未指定の **fallback 経路のみ**。翻訳を atomic 呼び出しに束ね、`usage_count` は TAGS commit 後に別途更新。前半 (format+type あり) は既に `register_tag` 経由で atomic なため対象外。
4. **`services/base_patch/apply.py` `BasePatchApplyService._apply_alias_addition`** — 新規 alias タグ作成と TAG_STATUS 書き込みを束ねる。dry_run 分岐は維持し、`_ensure_tag` による事前作成をやめて `register_tag_with_status(existing_tag_id=...)` に一本化。

### 付随修正
- `register_tag_with_status` / `_write_status_and_translations_in_session` の `type_id` を `int | None` に緩和 (上記 1・3 が `type_id` を渡さない従来挙動を保つため)。
- `register_tag_with_status` の `IntegrityError` recovery 内 2 回目の `session.commit()` を try/except で包み、稀な double-race で raw `IntegrityError` を漏らさず `ValueError` にする (非 blocking 指摘への対応)。

## テスト
各箇所にリグレッションテストを追加:
- `test_tag_register.py`: `update_deprecated_tags` が非 atomic 分離を使わず atomic 経路のみを使うことを検証。
- `test_cli_aliases_register.py`: `register_alias_entry` の atomic 経路 + 既存 tag_id 再利用。
- `test_gui_tag_register_service.py`: fallback 経路で翻訳+status が atomic に束ねられること。
- `test_base_patch_apply.py`: `_apply_alias_addition` が `register_tag_with_status` のみを使い `update_tag_status` を直呼びしないこと。
- `test_tag_repository.py`: `type_id=None` の「新規は 0 / 既存は保持」挙動。

CI-equivalent filter (`-m "not slow and not network"`) 全 pass: **883 passed, 86.34% coverage**。mypy / ruff (src) clean。

## 未対応 (follow-up)
非 blocking 指摘のうち、recovery ロジックが TAG_STATUS 由来の IntegrityError で再失敗しうるエッジケースは、現状 TAGS unique 衝突を前提とした設計であり、実発生には並行 alias 登録の特殊な競合が必要なため今回は据え置き。

🤖 Generated with [Claude Code](https://claude.com/claude-code)