### PR TITLE
fix(db): base 登録経路で user scope tag_id を信頼せず FK 違反を防ぐ

### DIFF
--- a/src/genai_tag_db_tools/db/repository.py
+++ b/src/genai_tag_db_tools/db/repository.py
@@ -644,8 +644,16 @@ class TagRepository:
         Returns:
             既存または新規作成した tag_id（新規時は flush 済みで id 割当済み）。
         """
+        # existing_tag_id を無条件に信頼しない (LoRAIro #1265)。呼び出し元の reader が
+        # MergedTagReader だと user scope 優先で解決するため、user scope の tag_id
+        # (USER_TAG_ID_OFFSET=1e9 以上) が渡ることがある。その値は base TAGS には実在せず、
+        # そのまま TAG_STATUS へ INSERT すると FOREIGN KEY constraint failed になる。
+        # この session (= base TagRepository の session) の TAGS に実在するか検証し、
+        # 無ければ tag 文字列で再解決 → 新規作成にフォールバックする。
         if existing_tag_id is not None:
-            return existing_tag_id
+            existing_by_id = session.get(Tag, existing_tag_id)
+            if existing_by_id is not None:
+                return existing_by_id.tag_id
         existing = session.query(Tag).filter(Tag.tag == tag).one_or_none()
         if existing is not None:
             return existing.tag_id

--- a/tests/unit/test_tag_repository.py
+++ b/tests/unit/test_tag_repository.py
@@ -1026,6 +1026,82 @@ def test_register_tag_with_status_reuses_existing_tag_id(
         assert status.preferred_tag_id == existing_id
 
 
+def test_register_tag_with_status_ignores_user_scope_existing_tag_id(
+    session_factory: Callable[[], Session],
+) -> None:
+    """#1265: base TAGS に存在しない existing_tag_id (user scope 由来の 1e9+ id 等) を渡されても、
+    その id を信頼せず tag 文字列で再解決/新規作成する。
+
+    MergedTagReader は user scope 優先で解決するため、base 登録経路に user scope の tag_id が
+    渡ることがある。その値を base TAGS 実在チェック無しに TAG_STATUS へ INSERT すると
+    ``FOREIGN KEY constraint failed`` になっていた (#1265)。
+    """
+    _seed_format_and_mapping(session_factory)
+    reader = TagReader(session_factory)
+    repo = TagRepository(session_factory, reader=MergedTagReader(base_repo=reader))
+
+    user_scope_id = 1_000_009_635  # base TAGS には存在しない user scope の tag_id
+
+    returned_id = repo.register_tag_with_status(
+        source_tag="dataset_tag",
+        tag="dataset_tag",
+        existing_tag_id=user_scope_id,
+        format_id=1,
+        type_id=0,
+        alias=False,
+        preferred_tag_id=None,
+    )
+
+    # user scope id をそのまま使わず base に採番された新 id を返す
+    assert returned_id != user_scope_id
+    with session_factory() as session:
+        tag_row = session.query(Tag).filter(Tag.tag == "dataset_tag").one()
+        assert tag_row.tag_id == returned_id
+        # status は base の新 tag_id で挿入され FK 違反にならない
+        status = (
+            session.query(TagStatus)
+            .filter(TagStatus.tag_id == returned_id, TagStatus.format_id == 1)
+            .one()
+        )
+        assert status.preferred_tag_id == returned_id
+        # user scope id の孤児 status 行が残らないこと
+        assert session.query(TagStatus).filter(TagStatus.tag_id == user_scope_id).count() == 0
+
+
+def test_register_tag_with_status_reresolves_by_tag_when_existing_id_missing(
+    session_factory: Callable[[], Session],
+) -> None:
+    """#1265: existing_tag_id が base TAGS に存在せず、同名 tag が既に base TAGS にある場合は
+    その既存 base 行を再利用し、重複 TAGS 行を作らない。"""
+    _seed_format_and_mapping(session_factory)
+    reader = TagReader(session_factory)
+    repo = TagRepository(session_factory, reader=MergedTagReader(base_repo=reader))
+
+    base_id = repo.create_tag("shared", "shared")
+    bogus_id = 1_000_042_000  # base TAGS に存在しない (user scope 由来を模した値)
+
+    returned_id = repo.register_tag_with_status(
+        source_tag="shared",
+        tag="shared",
+        existing_tag_id=bogus_id,
+        format_id=1,
+        type_id=0,
+        alias=False,
+        preferred_tag_id=None,
+    )
+
+    assert returned_id == base_id
+    with session_factory() as session:
+        # 重複 TAGS 行を作らず既存 base 行を再利用する
+        assert session.query(Tag).filter(Tag.tag == "shared").count() == 1
+        status = (
+            session.query(TagStatus)
+            .filter(TagStatus.tag_id == base_id, TagStatus.format_id == 1)
+            .one()
+        )
+        assert status.preferred_tag_id == base_id
+
+
 def test_register_tag_with_status_type_id_none_defaults_and_preserves(
     session_factory: Callable[[], Session],
 ) -> None:


### PR DESCRIPTION
## 概要

`_resolve_or_create_tag_in_session()` が `existing_tag_id` を base `TAGS` 実在チェック無しで返していたため、`MergedTagReader` が user scope 優先で解決した user scope の tag_id (`USER_TAG_ID_OFFSET`=1e9 以上) が base 登録経路に渡ると、base `TAGS` に存在しないその id で `TAG_STATUS` へ INSERT しようとして `FOREIGN KEY constraint failed` になっていた。#1239/#1249 の atomic 化 (単一トランザクション化) では、そもそも渡された id が対象テーブルに存在しないため防げない不整合。

LoRAIro #1265 (https://github.com/NEXTAltair/LoRAIro/issues/1265) follow-up

## 実機再現 (Issue より)
```
INSERT INTO "TAG_STATUS" ... VALUES (1000009635, 1000, 0, 0, 1000009635, ...)
→ sqlite3.IntegrityError: FOREIGN KEY constraint failed
```
`tag_id=1000009635` は `USER_TAG_ID_OFFSET` 以上 = user scope の tag_id。過去に同名タグが `USER_TAGS` に登録済みだと `get_tag_id_by_name()` (user優先) がその id を返し、base 登録経路がそれを base `TAGS` の id として扱っていた。

## 修正
`session.get(Tag, existing_tag_id)` で base `TAGS` の実在を検証し、無ければ `tag` 文字列で再解決 → 新規作成にフォールバックする。`register_tag_with_status()` を呼ぶ #1249 の5箇所すべてに効く。

## テスト
- `test_register_tag_with_status_ignores_user_scope_existing_tag_id`: user scope id (base TAGS 非存在) を渡しても tag 文字列で再解決/新規作成され、`TAG_STATUS` 挿入が FK 違反にならない。孤児 status 行が残らない。
- `test_register_tag_with_status_reresolves_by_tag_when_existing_id_missing`: `existing_tag_id` 非存在かつ同名 tag が base `TAGS` にある場合は既存 base 行を再利用 (重複 `TAGS` 行を作らない)。
- 既存 `test_register_tag_with_status_reuses_existing_tag_id` で「実在する existing_tag_id は従来通り再利用」を継続カバー。

CI-equivalent filter (`-m "not slow and not network"`) 全 pass: **885 passed, 86.36% coverage**。mypy / ruff (src) clean。

🤖 Generated with [Claude Code](https://claude.com/claude-code)