### PR TITLE
fix: materialize tag parent for type status updates

### DIFF
--- a/src/genai_tag_db_tools/core_api.py
+++ b/src/genai_tag_db_tools/core_api.py
@@ -454,7 +454,8 @@ def _search_exact_recommendation_rows(
     format_name: str,
     format_id: int | None,
 ) -> list[TagSearchRow]:
-    effective_format_name = format_name if format_id is not None else None
+    has_user_overlay = bool(getattr(repo, "_has_user", lambda: False)())
+    effective_format_name = None if has_user_overlay else (format_name if format_id is not None else None)
     return repo.search_tags(
         tag,
         partial=False,

--- a/src/genai_tag_db_tools/db/repository.py
+++ b/src/genai_tag_db_tools/db/repository.py
@@ -1465,6 +1465,7 @@ class TagRepository:
             raise ValueError(f"tag='{source.tag}' already exists with tag_id={existing_by_tag.tag_id}")
 
         session.add(Tag(tag_id=tag_id, source_tag=source.source_tag, tag=source.tag))
+        session.flush()
 
     def update_tags_type_batch(
         self,
@@ -1838,7 +1839,8 @@ class MergedTagReader:
         if limit is None:
             for repo in repos:
                 for row in repo.search_tags(keyword, limit=None, offset=0, **kwargs):
-                    merged[row["tag_id"]] = row
+                    if not self._preserve_existing_search_row(merged.get(row["tag_id"]), row):
+                        merged[row["tag_id"]] = row
             rows = [merged[tag_id] for tag_id in sorted(merged)]
             return rows[offset:] if offset else rows
 
@@ -1869,12 +1871,25 @@ class MergedTagReader:
                 if len(rows) < chunk_size:
                     exhausted.add(index)
                 for row in rows:
-                    merged[row["tag_id"]] = row
+                    if not self._preserve_existing_search_row(merged.get(row["tag_id"]), row):
+                        merged[row["tag_id"]] = row
             if not made_progress:
                 break
 
         rows = [merged[tag_id] for tag_id in sorted(merged)]
         return rows[offset:target]
+
+    @staticmethod
+    def _preserve_existing_search_row(
+        existing: TagSearchRow | None,
+        candidate: TagSearchRow,
+    ) -> bool:
+        if existing is None:
+            return False
+        return (
+            existing["tag"] == candidate["tag"]
+            and existing.get("source_tag") == candidate.get("source_tag")
+        )
 
     def _requested_format_id(
         self,

--- a/src/genai_tag_db_tools/db/repository.py
+++ b/src/genai_tag_db_tools/db/repository.py
@@ -1835,11 +1835,16 @@ class MergedTagReader:
             repos.append(self.user_repo)
 
         merged: dict[int, TagSearchRow] = {}
+        user_repo_index = len(repos) - 1 if self._has_user() else None
 
         if limit is None:
-            for repo in repos:
+            for index, repo in enumerate(repos):
                 for row in repo.search_tags(keyword, limit=None, offset=0, **kwargs):
-                    if not self._preserve_existing_search_row(merged.get(row["tag_id"]), row):
+                    if not self._preserve_existing_search_row(
+                        merged.get(row["tag_id"]),
+                        row,
+                        candidate_is_user=index == user_repo_index,
+                    ):
                         merged[row["tag_id"]] = row
             rows = [merged[tag_id] for tag_id in sorted(merged)]
             return rows[offset:] if offset else rows
@@ -1871,7 +1876,11 @@ class MergedTagReader:
                 if len(rows) < chunk_size:
                     exhausted.add(index)
                 for row in rows:
-                    if not self._preserve_existing_search_row(merged.get(row["tag_id"]), row):
+                    if not self._preserve_existing_search_row(
+                        merged.get(row["tag_id"]),
+                        row,
+                        candidate_is_user=index == user_repo_index,
+                    ):
                         merged[row["tag_id"]] = row
             if not made_progress:
                 break
@@ -1883,8 +1892,10 @@ class MergedTagReader:
     def _preserve_existing_search_row(
         existing: TagSearchRow | None,
         candidate: TagSearchRow,
+        *,
+        candidate_is_user: bool,
     ) -> bool:
-        if existing is None:
+        if existing is None or not candidate_is_user:
             return False
         return (
             existing["tag"] == candidate["tag"]
@@ -2570,13 +2581,26 @@ class MergedTagReader:
         format_name: str | None = None,
         resolve_preferred: bool = False,
     ) -> dict[str, TagSearchRow]:
-        merged: dict[str, TagSearchRow] = self._merge_by_key(
-            "search_tags_bulk",
-            None,
-            keywords,
-            format_name=format_name,
-            resolve_preferred=False,
-        )
+        repos: list[TagReader | OverlayTagReader] = [*self._iter_base_repos_low_to_high()]
+        if self._has_user():
+            assert self.user_repo is not None
+            repos.append(self.user_repo)
+        user_repo_index = len(repos) - 1 if self._has_user() else None
+
+        merged: dict[str, TagSearchRow] = {}
+        for index, repo in enumerate(repos):
+            result = repo.search_tags_bulk(
+                keywords,
+                format_name=format_name,
+                resolve_preferred=False,
+            )
+            for keyword, row in result.items():
+                if not self._preserve_existing_search_row(
+                    merged.get(keyword),
+                    row,
+                    candidate_is_user=index == user_repo_index,
+                ):
+                    merged[keyword] = row
         if merged:
             requested_format_id = self._requested_format_id(format_name)
             patched = self._apply_user_patches_to_search_rows(
@@ -2653,7 +2677,12 @@ class MergedTagReader:
             for keyword, rows in result.items():
                 bucket = merged_by_keyword.setdefault(keyword, {})
                 for row in rows:
-                    bucket[row["tag_id"]] = row
+                    if not self._preserve_existing_search_row(
+                        bucket.get(row["tag_id"]),
+                        row,
+                        candidate_is_user=repo is self.user_repo,
+                    ):
+                        bucket[row["tag_id"]] = row
         # tag_id 昇順で返す (`_merge_search_tags_adaptive` / `TagReader.search_tags_bulk_all` と
         # 同じ決定的順序。batch へ切替えても per-query search と行順が一致する、Codex PR #115 P3)。
         merged: dict[str, list[TagSearchRow]] = {

--- a/src/genai_tag_db_tools/db/repository.py
+++ b/src/genai_tag_db_tools/db/repository.py
@@ -1898,7 +1898,8 @@ class MergedTagReader:
         if existing is None or not candidate_is_user:
             return False
         return (
-            existing["tag"] == candidate["tag"]
+            existing["tag_id"] == candidate["tag_id"]
+            and existing["tag"] == candidate["tag"]
             and existing.get("source_tag") == candidate.get("source_tag")
         )
 

--- a/src/genai_tag_db_tools/db/repository.py
+++ b/src/genai_tag_db_tools/db/repository.py
@@ -7,7 +7,7 @@ if TYPE_CHECKING:
     from genai_tag_db_tools.db.overlay_reader import OverlayTagReader
 
 import polars as pl
-from sqlalchemy import func, or_
+from sqlalchemy import func, inspect, or_
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -30,6 +30,7 @@ from genai_tag_db_tools.db.schema import (
     TagTypeFormatMapping,
     TagTypeName,
     TagUsageCounts,
+    UserTagStatusPatch,
 )
 from genai_tag_db_tools.models import TagSearchRow
 from genai_tag_db_tools.utils.messages import ErrorMessages
@@ -1442,30 +1443,111 @@ class TagRepository:
 
         return cache[type_name]
 
-    def _ensure_local_tag_row_for_status_in_session(self, session: "Session", tag_id: int) -> None:
-        """Ensure the local TAGS table can satisfy TAG_STATUS foreign keys.
+    def _get_or_create_format_id_in_session(self, session: "Session", format_name: str, format_id: int) -> int:
+        format_obj = session.query(TagFormat).filter(TagFormat.format_id == format_id).one_or_none()
+        if format_obj is not None:
+            return format_obj.format_id
+        session.add(TagFormat(format_id=format_id, format_name=format_name))
+        return format_id
 
-        Type/status overrides are stored in the user DB TAG_STATUS table. When the
-        target tag only exists in a base DB, the user DB still needs a minimal TAGS
-        parent row with the same tag_id before TAG_STATUS can reference it.
-        """
-        existing_by_id = session.query(Tag).filter(Tag.tag_id == tag_id).one_or_none()
-        if existing_by_id is not None:
+    def _get_or_create_type_name_id_in_session(self, session: "Session", type_name: str) -> int:
+        type_obj = session.query(TagTypeName).filter(TagTypeName.type_name == type_name).one_or_none()
+        if type_obj is not None:
+            return type_obj.type_name_id
+        type_obj = TagTypeName(type_name=type_name)
+        session.add(type_obj)
+        session.flush()
+        return type_obj.type_name_id
+
+    def _resolve_type_id_for_format_in_session(
+        self,
+        session: "Session",
+        type_name: str,
+        type_name_id: int,
+        format_id: int,
+        cache: dict[str, int],
+    ) -> int:
+        if type_name in cache:
+            return cache[type_name]
+
+        mapping_by_name = (
+            session.query(TagTypeFormatMapping)
+            .filter(
+                TagTypeFormatMapping.format_id == format_id,
+                TagTypeFormatMapping.type_name_id == type_name_id,
+            )
+            .one_or_none()
+        )
+        if mapping_by_name is not None:
+            cache[type_name] = mapping_by_name.type_id
+            return mapping_by_name.type_id
+
+        max_type_id = (
+            session.query(func.max(TagTypeFormatMapping.type_id))
+            .filter(TagTypeFormatMapping.format_id == format_id)
+            .scalar()
+        )
+        candidate_type_id = 0 if max_type_id is None else int(max_type_id) + 1
+        while (
+            session.query(TagTypeFormatMapping)
+            .filter(
+                TagTypeFormatMapping.format_id == format_id,
+                TagTypeFormatMapping.type_id == candidate_type_id,
+            )
+            .one_or_none()
+            is not None
+        ):
+            candidate_type_id += 1
+
+        session.add(
+            TagTypeFormatMapping(
+                format_id=format_id,
+                type_id=candidate_type_id,
+                type_name_id=type_name_id,
+            )
+        )
+        cache[type_name] = candidate_type_id
+        return candidate_type_id
+
+    def _write_status_patch_in_session(
+        self,
+        session: "Session",
+        *,
+        target_scope: str,
+        target_tag_id: int,
+        format_id: int,
+        type_id: int,
+        deprecated: bool,
+    ) -> None:
+        existing = (
+            session.query(UserTagStatusPatch)
+            .filter(
+                UserTagStatusPatch.target_scope == target_scope,
+                UserTagStatusPatch.target_tag_id == target_tag_id,
+                UserTagStatusPatch.format_id == format_id,
+            )
+            .one_or_none()
+        )
+        if existing is not None:
+            existing.type_id = type_id
+            existing.alias = False
+            existing.preferred_scope = target_scope
+            existing.preferred_tag_id = target_tag_id
+            existing.deprecated = deprecated
             return
 
-        if self._reader is None:
-            raise ValueError(f"Tag ID not found in local TAGS and no reader is available: {tag_id}")
-
-        source = self._reader.get_tag_by_id(tag_id)
-        if source is None or not source.tag or not source.source_tag:
-            raise ValueError(f"Tag ID not found: {tag_id}")
-
-        existing_by_tag = session.query(Tag).filter(Tag.tag == source.tag).one_or_none()
-        if existing_by_tag is not None and existing_by_tag.tag_id != tag_id:
-            raise ValueError(f"tag='{source.tag}' already exists with tag_id={existing_by_tag.tag_id}")
-
-        session.add(Tag(tag_id=tag_id, source_tag=source.source_tag, tag=source.tag))
-        session.flush()
+        session.add(
+            UserTagStatusPatch(
+                target_scope=target_scope,
+                target_tag_id=target_tag_id,
+                format_id=format_id,
+                type_id=type_id,
+                alias=False,
+                preferred_scope=target_scope,
+                preferred_tag_id=target_tag_id,
+                deprecated=deprecated,
+            )
+        )
 
     def update_tags_type_batch(
         self,
@@ -1499,11 +1581,61 @@ class TagRepository:
             return
 
         with self.session_factory() as session:
+            overlay_available = inspect(session.get_bind()).has_table("USER_TAG_STATUS_PATCH")
+
+        format_name = None
+        if overlay_available:
+            if self._reader is not None:
+                try:
+                    format_name = self._reader.get_format_name(format_id)
+                except (AttributeError, ValueError):
+                    format_name = None
+
+        with self.session_factory() as session:
             try:
+                overlay_format_id = format_id
+                if overlay_available:
+                    overlay_format_id = self._get_or_create_format_id_in_session(
+                        session, format_name or str(format_id), format_id
+                    )
+
                 # Cache for type_name -> type_id mapping (format-specific)
                 type_name_to_type_id: dict[str, int] = {}
+                overlay_type_name_to_type_id: dict[str, int] = {}
 
                 for update in tag_updates:
+                    scope = self._reader.get_tag_scope(update.tag_id) if self._reader is not None else None
+                    if overlay_available and scope in {"base", "user"}:
+                        type_name_id = self._get_or_create_type_name_id_in_session(session, update.type_name)
+                        patch_type_id = self._resolve_type_id_for_format_in_session(
+                            session,
+                            update.type_name,
+                            type_name_id,
+                            overlay_format_id,
+                            overlay_type_name_to_type_id,
+                        )
+                        existing_patch = (
+                            session.query(UserTagStatusPatch)
+                            .filter(
+                                UserTagStatusPatch.target_scope == scope,
+                                UserTagStatusPatch.target_tag_id == update.tag_id,
+                                UserTagStatusPatch.format_id == overlay_format_id,
+                            )
+                            .one_or_none()
+                        )
+                        self._write_status_patch_in_session(
+                            session,
+                            target_scope=scope,
+                            target_tag_id=update.tag_id,
+                            format_id=overlay_format_id,
+                            type_id=patch_type_id,
+                            deprecated=existing_patch.deprecated if existing_patch is not None else False,
+                        )
+                        continue
+
+                    # Non-overlay DBs and unresolved tag IDs keep the legacy TAG_STATUS path.
+                    # The default LoRAIro runtime has USER_TAG_STATUS_PATCH and scope-known
+                    # base/user tags use the overlay patch branch above.
                     # Step 1: Get or create type_name_id
                     type_name_id = self.create_type_name_if_not_exists(update.type_name)
 
@@ -1513,7 +1645,6 @@ class TagRepository:
                     )
 
                     # Step 3: Update tag status with new type_id
-                    self._ensure_local_tag_row_for_status_in_session(session, update.tag_id)
                     self._write_tag_status_in_session(
                         session,
                         tag_id=update.tag_id,
@@ -1835,17 +1966,11 @@ class MergedTagReader:
             repos.append(self.user_repo)
 
         merged: dict[int, TagSearchRow] = {}
-        user_repo_index = len(repos) - 1 if self._has_user() else None
 
         if limit is None:
-            for index, repo in enumerate(repos):
+            for repo in repos:
                 for row in repo.search_tags(keyword, limit=None, offset=0, **kwargs):
-                    if not self._preserve_existing_search_row(
-                        merged.get(row["tag_id"]),
-                        row,
-                        candidate_is_user=index == user_repo_index,
-                    ):
-                        merged[row["tag_id"]] = row
+                    merged[row["tag_id"]] = row
             rows = [merged[tag_id] for tag_id in sorted(merged)]
             return rows[offset:] if offset else rows
 
@@ -1876,32 +2001,12 @@ class MergedTagReader:
                 if len(rows) < chunk_size:
                     exhausted.add(index)
                 for row in rows:
-                    if not self._preserve_existing_search_row(
-                        merged.get(row["tag_id"]),
-                        row,
-                        candidate_is_user=index == user_repo_index,
-                    ):
-                        merged[row["tag_id"]] = row
+                    merged[row["tag_id"]] = row
             if not made_progress:
                 break
 
         rows = [merged[tag_id] for tag_id in sorted(merged)]
         return rows[offset:target]
-
-    @staticmethod
-    def _preserve_existing_search_row(
-        existing: TagSearchRow | None,
-        candidate: TagSearchRow,
-        *,
-        candidate_is_user: bool,
-    ) -> bool:
-        if existing is None or not candidate_is_user:
-            return False
-        return (
-            existing["tag_id"] == candidate["tag_id"]
-            and existing["tag"] == candidate["tag"]
-            and existing.get("source_tag") == candidate.get("source_tag")
-        )
 
     def _requested_format_id(
         self,
@@ -1915,6 +2020,28 @@ class MergedTagReader:
             return self.get_format_id(names[0])
         except (AttributeError, ValueError):
             return None
+
+    def _requested_format_ids(
+        self,
+        format_name: str | None = None,
+        format_names: list[str] | None = None,
+    ) -> set[int]:
+        names = format_names or ([format_name] if format_name else [])
+        format_ids: set[int] = set()
+        for name in names:
+            try:
+                format_id = self.get_format_id(name)
+            except (AttributeError, ValueError):
+                continue
+            if format_id is not None:
+                format_ids.add(format_id)
+        return format_ids
+
+    def _row_has_user_status_patch(self, row: TagSearchRow, requested_format_ids: set[int]) -> bool:
+        if not requested_format_ids or not self._has_user():
+            return False
+        assert self.user_repo is not None
+        return any(status.format_id in requested_format_ids for status in self.user_repo.list_tag_statuses(row["tag_id"]))
 
     def _format_name_for_id(self, format_id: int) -> str:
         try:
@@ -1966,6 +2093,13 @@ class MergedTagReader:
         for row in rows:
             updated = dict(row)
             format_statuses = dict(row.get("format_statuses") or {})
+            if requested_format_id is not None:
+                requested_format_name = self._format_name_for_id(requested_format_id)
+                requested_status = self._format_status_dict(format_statuses.get(requested_format_name))
+                if requested_status:
+                    for key in ("alias", "deprecated", "type_id", "type_name", "usage_count"):
+                        if key in requested_status:
+                            updated[key] = requested_status[key]
 
             # 検索行の translations は base 由来値が主 (user patch は overlay 側で
             # scope-aware に除外済みの値が後段でマージされる) ため、base 宛 tombstone
@@ -2446,6 +2580,7 @@ class MergedTagReader:
         offset: int = 0,
     ) -> list[TagSearchRow]:
         requested_format_id = self._requested_format_id(format_name, format_names)
+        requested_format_ids = self._requested_format_ids(format_name, format_names)
         rows = self._merge_search_tags_adaptive(
             keyword,
             limit=None,
@@ -2462,6 +2597,27 @@ class MergedTagReader:
             deprecated=None,
             resolve_preferred=False,
         )
+        if self._has_user() and requested_format_ids:
+            rows.extend(
+                row
+                for row in self._merge_search_tags_adaptive(
+                    keyword,
+                    limit=None,
+                    offset=0,
+                    partial=partial,
+                    format_name=None,
+                    format_names=None,
+                    type_name=None,
+                    type_names=None,
+                    language=None,
+                    min_usage=None,
+                    max_usage=None,
+                    alias=None,
+                    deprecated=None,
+                    resolve_preferred=False,
+                )
+                if self._row_has_user_status_patch(row, requested_format_ids)
+            )
         rows.extend(
             self._base_rows_for_user_translation_matches(
                 keyword,
@@ -2582,25 +2738,24 @@ class MergedTagReader:
         format_name: str | None = None,
         resolve_preferred: bool = False,
     ) -> dict[str, TagSearchRow]:
-        repos: list[TagReader | OverlayTagReader] = [*self._iter_base_repos_low_to_high()]
-        if self._has_user():
-            assert self.user_repo is not None
-            repos.append(self.user_repo)
-        user_repo_index = len(repos) - 1 if self._has_user() else None
-
-        merged: dict[str, TagSearchRow] = {}
-        for index, repo in enumerate(repos):
-            result = repo.search_tags_bulk(
+        requested_format_ids = self._requested_format_ids(format_name)
+        merged: dict[str, TagSearchRow] = self._merge_by_key(
+            "search_tags_bulk",
+            None,
+            keywords,
+            format_name=format_name,
+            resolve_preferred=False,
+        )
+        if self._has_user() and requested_format_ids:
+            patched_candidates: dict[str, TagSearchRow] = self._merge_by_key(
+                "search_tags_bulk",
+                None,
                 keywords,
-                format_name=format_name,
+                format_name=None,
                 resolve_preferred=False,
             )
-            for keyword, row in result.items():
-                if not self._preserve_existing_search_row(
-                    merged.get(keyword),
-                    row,
-                    candidate_is_user=index == user_repo_index,
-                ):
+            for keyword, row in patched_candidates.items():
+                if self._row_has_user_status_patch(row, requested_format_ids):
                     merged[keyword] = row
         if merged:
             requested_format_id = self._requested_format_id(format_name)
@@ -2667,6 +2822,7 @@ class MergedTagReader:
         if self._has_user():
             assert self.user_repo is not None
             repos.append(self.user_repo)
+        requested_format_ids = self._requested_format_ids(format_name)
 
         merged_by_keyword: dict[str, dict[int, TagSearchRow]] = {}
         for repo in repos:
@@ -2678,12 +2834,19 @@ class MergedTagReader:
             for keyword, rows in result.items():
                 bucket = merged_by_keyword.setdefault(keyword, {})
                 for row in rows:
-                    if not self._preserve_existing_search_row(
-                        bucket.get(row["tag_id"]),
-                        row,
-                        candidate_is_user=repo is self.user_repo,
-                    ):
-                        bucket[row["tag_id"]] = row
+                    bucket[row["tag_id"]] = row
+        if self._has_user() and requested_format_ids:
+            for repo in repos:
+                result = repo.search_tags_bulk_all(
+                    keywords,
+                    format_name=None,
+                    resolve_preferred=False,
+                )
+                for keyword, rows in result.items():
+                    bucket = merged_by_keyword.setdefault(keyword, {})
+                    for row in rows:
+                        if self._row_has_user_status_patch(row, requested_format_ids):
+                            bucket[row["tag_id"]] = row
         # tag_id 昇順で返す (`_merge_search_tags_adaptive` / `TagReader.search_tags_bulk_all` と
         # 同じ決定的順序。batch へ切替えても per-query search と行順が一致する、Codex PR #115 P3)。
         merged: dict[str, list[TagSearchRow]] = {

--- a/src/genai_tag_db_tools/db/repository.py
+++ b/src/genai_tag_db_tools/db/repository.py
@@ -1442,6 +1442,30 @@ class TagRepository:
 
         return cache[type_name]
 
+    def _ensure_local_tag_row_for_status_in_session(self, session: "Session", tag_id: int) -> None:
+        """Ensure the local TAGS table can satisfy TAG_STATUS foreign keys.
+
+        Type/status overrides are stored in the user DB TAG_STATUS table. When the
+        target tag only exists in a base DB, the user DB still needs a minimal TAGS
+        parent row with the same tag_id before TAG_STATUS can reference it.
+        """
+        existing_by_id = session.query(Tag).filter(Tag.tag_id == tag_id).one_or_none()
+        if existing_by_id is not None:
+            return
+
+        if self._reader is None:
+            raise ValueError(f"Tag ID not found in local TAGS and no reader is available: {tag_id}")
+
+        source = self._reader.get_tag_by_id(tag_id)
+        if source is None or not source.tag or not source.source_tag:
+            raise ValueError(f"Tag ID not found: {tag_id}")
+
+        existing_by_tag = session.query(Tag).filter(Tag.tag == source.tag).one_or_none()
+        if existing_by_tag is not None and existing_by_tag.tag_id != tag_id:
+            raise ValueError(f"tag='{source.tag}' already exists with tag_id={existing_by_tag.tag_id}")
+
+        session.add(Tag(tag_id=tag_id, source_tag=source.source_tag, tag=source.tag))
+
     def update_tags_type_batch(
         self,
         tag_updates: list,  # list[TagTypeUpdate] - avoid circular import
@@ -1488,7 +1512,9 @@ class TagRepository:
                     )
 
                     # Step 3: Update tag status with new type_id
-                    self.update_tag_status(
+                    self._ensure_local_tag_row_for_status_in_session(session, update.tag_id)
+                    self._write_tag_status_in_session(
+                        session,
                         tag_id=update.tag_id,
                         format_id=format_id,
                         alias=False,

--- a/tests/unit/test_tag_repository.py
+++ b/tests/unit/test_tag_repository.py
@@ -893,6 +893,47 @@ def test_merged_reader_search_tags_higher_priority_base_row_wins(
     assert result[0]["translations"] == {"japanese": ["猫A"]}
 
 
+def test_merged_reader_search_tags_bulk_keeps_distinct_user_tag_with_same_name(
+    session_factory: Callable[[], Session],
+) -> None:
+    """同じ tag/source_tag でも別 tag_id の user tag は materialized parent 扱いしない。"""
+    user_factory = _memory_session_factory()
+    base_reader = TagReader(session_factory)
+    user_reader = TagReader(user_factory)
+
+    with session_factory() as session:
+        session.add(TagFormat(format_id=1, format_name="test"))
+        session.add(TagTypeName(type_name_id=1, type_name="general"))
+        session.add(TagTypeFormatMapping(format_id=1, type_id=0, type_name_id=1))
+        session.add(Tag(tag_id=1, tag="cat", source_tag="cat"))
+        session.add(TagStatus(tag_id=1, format_id=1, type_id=0, alias=False, preferred_tag_id=1))
+        session.add(TagTranslation(tag_id=1, language="japanese", translation="猫base"))
+        session.commit()
+
+    with user_factory() as session:
+        session.add(TagFormat(format_id=1000, format_name="Lorairo"))
+        session.add(TagTypeName(type_name_id=1, type_name="general"))
+        session.add(TagTypeFormatMapping(format_id=1000, type_id=0, type_name_id=1))
+        session.add(Tag(tag_id=1_000_000_001, tag="cat", source_tag="cat"))
+        session.add(
+            TagStatus(
+                tag_id=1_000_000_001,
+                format_id=1000,
+                type_id=0,
+                alias=False,
+                preferred_tag_id=1_000_000_001,
+            )
+        )
+        session.add(TagTranslation(tag_id=1_000_000_001, language="japanese", translation="猫user"))
+        session.commit()
+
+    merged = MergedTagReader(base_repo=base_reader, user_repo=user_reader)
+    result = merged.search_tags_bulk(["cat"])
+
+    assert result["cat"]["tag_id"] == 1_000_000_001
+    assert result["cat"]["translations"] == {"japanese": ["猫user"]}
+
+
 def _seed_bulk_all_rows(session: Session) -> None:
     """1 keyword が複数 tag_id にマッチする状況を作る (tag 直接一致 + 翻訳経由一致)。"""
     session.add(TagFormat(format_id=1, format_name="test"))

--- a/tests/unit/test_tag_repository.py
+++ b/tests/unit/test_tag_repository.py
@@ -4,7 +4,7 @@ from collections.abc import Callable
 
 import polars as pl
 import pytest
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, event
 from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import StaticPool
 
@@ -23,15 +23,64 @@ from genai_tag_db_tools.db.schema import (
 pytestmark = pytest.mark.db_tools
 
 
-@pytest.fixture()
-def session_factory() -> Callable[[], Session]:
+def _memory_session_factory(*, foreign_keys: bool = False) -> Callable[[], Session]:
     engine = create_engine(
         "sqlite://",
         connect_args={"check_same_thread": False},
         poolclass=StaticPool,
     )
+    if foreign_keys:
+
+        @event.listens_for(engine, "connect")
+        def _enable_foreign_keys(dbapi_connection, connection_record) -> None:
+            dbapi_connection.execute("PRAGMA foreign_keys=ON")
+
     Base.metadata.create_all(engine)
     return sessionmaker(bind=engine, autoflush=False, autocommit=False)
+
+
+@pytest.fixture()
+def session_factory() -> Callable[[], Session]:
+    return _memory_session_factory()
+
+
+def test_update_tags_type_batch_materializes_base_tag_parent_in_user_db() -> None:
+    """Base DB 由来タグの type 補正時に user DB 側 TAGS 親行を保証する (#1268)。"""
+    from genai_tag_db_tools.models import TagTypeUpdate
+
+    base_factory = _memory_session_factory()
+    user_factory = _memory_session_factory(foreign_keys=True)
+    base_reader = TagReader(base_factory)
+    user_reader = TagReader(user_factory)
+    merged_reader = MergedTagReader(base_repo=base_reader, user_repo=user_reader)
+    repo = TagRepository(user_factory, reader=merged_reader)
+
+    base_tag_id = 197273
+    with base_factory() as session:
+        session.add(Tag(tag_id=base_tag_id, tag="base_only_tag", source_tag="Base Only Tag"))
+        session.commit()
+
+    with user_factory() as session:
+        session.add(TagFormat(format_id=1000, format_name="Lorairo"))
+        session.commit()
+
+    repo.update_tags_type_batch([TagTypeUpdate(tag_id=base_tag_id, type_name="general")], format_id=1000)
+
+    with user_factory() as session:
+        tag = session.query(Tag).filter(Tag.tag_id == base_tag_id).one()
+        status = session.query(TagStatus).filter(TagStatus.tag_id == base_tag_id).one()
+        type_name = (
+            session.query(TagTypeName.type_name)
+            .join(TagTypeFormatMapping, TagTypeName.type_name_id == TagTypeFormatMapping.type_name_id)
+            .filter(TagTypeFormatMapping.format_id == 1000, TagTypeFormatMapping.type_id == status.type_id)
+            .scalar()
+        )
+
+    assert tag.tag == "base_only_tag"
+    assert tag.source_tag == "Base Only Tag"
+    assert status.format_id == 1000
+    assert status.preferred_tag_id == base_tag_id
+    assert type_name == "general"
 
 
 def test_create_tag_returns_existing_id(session_factory: Callable[[], Session]) -> None:

--- a/tests/unit/test_tag_repository.py
+++ b/tests/unit/test_tag_repository.py
@@ -57,14 +57,25 @@ def test_update_tags_type_batch_materializes_base_tag_parent_in_user_db() -> Non
 
     base_tag_id = 197273
     with base_factory() as session:
+        session.add(TagFormat(format_id=1, format_name="danbooru"))
+        session.add(TagTypeName(type_name_id=1, type_name="general"))
+        session.add(TagTypeFormatMapping(format_id=1, type_id=0, type_name_id=1))
         session.add(Tag(tag_id=base_tag_id, tag="base_only_tag", source_tag="Base Only Tag"))
+        session.add(TagStatus(tag_id=base_tag_id, format_id=1, type_id=0, alias=False, preferred_tag_id=base_tag_id))
+        session.add(TagTranslation(tag_id=base_tag_id, language="ja", translation="ベースのみ"))
         session.commit()
 
     with user_factory() as session:
         session.add(TagFormat(format_id=1000, format_name="Lorairo"))
         session.commit()
 
-    repo.update_tags_type_batch([TagTypeUpdate(tag_id=base_tag_id, type_name="general")], format_id=1000)
+    repo.update_tags_type_batch(
+        [
+            TagTypeUpdate(tag_id=base_tag_id, type_name="general"),
+            TagTypeUpdate(tag_id=base_tag_id, type_name="general"),
+        ],
+        format_id=1000,
+    )
 
     with user_factory() as session:
         tag = session.query(Tag).filter(Tag.tag_id == base_tag_id).one()
@@ -81,6 +92,14 @@ def test_update_tags_type_batch_materializes_base_tag_parent_in_user_db() -> Non
     assert status.format_id == 1000
     assert status.preferred_tag_id == base_tag_id
     assert type_name == "general"
+
+    rows = merged_reader.search_tags("base_only_tag")
+
+    assert len(rows) == 1
+    assert rows[0]["tag_id"] == base_tag_id
+    assert rows[0]["translations"] == {"ja": ["ベースのみ"]}
+    assert "danbooru" in rows[0]["format_statuses"]
+    assert "Lorairo" in rows[0]["format_statuses"]
 
 
 def test_create_tag_returns_existing_id(session_factory: Callable[[], Session]) -> None:

--- a/tests/unit/test_tag_repository.py
+++ b/tests/unit/test_tag_repository.py
@@ -101,6 +101,14 @@ def test_update_tags_type_batch_materializes_base_tag_parent_in_user_db() -> Non
     assert "danbooru" in rows[0]["format_statuses"]
     assert "Lorairo" in rows[0]["format_statuses"]
 
+    bulk_row = merged_reader.search_tags_bulk(["base_only_tag"])["base_only_tag"]
+    bulk_all_row = merged_reader.search_tags_bulk_all(["base_only_tag"])["base_only_tag"][0]
+
+    assert bulk_row["translations"] == {"ja": ["ベースのみ"]}
+    assert "Lorairo" in bulk_row["format_statuses"]
+    assert bulk_all_row["translations"] == {"ja": ["ベースのみ"]}
+    assert "Lorairo" in bulk_all_row["format_statuses"]
+
 
 def test_create_tag_returns_existing_id(session_factory: Callable[[], Session]) -> None:
     reader = TagReader(session_factory)
@@ -844,6 +852,45 @@ def test_merged_reader_search_tags_applies_offset_after_merge(
     result = merged.search_tags("sample", partial=True, limit=2, offset=3)
 
     assert [row["tag_id"] for row in result] == [4, 5]
+
+
+def test_merged_reader_search_tags_higher_priority_base_row_wins(
+    session_factory: Callable[[], Session],
+) -> None:
+    """同一 tag_id/tag/source_tag でも高優先度 base DB の検索行を採用する。"""
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+    from sqlalchemy.pool import StaticPool
+
+    engine_b = create_engine("sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool)
+    Base.metadata.create_all(engine_b)
+    session_factory_b: Callable[[], Session] = sessionmaker(
+        bind=engine_b, autoflush=False, autocommit=False
+    )
+
+    def _seed_cat(session: Session, translation: str) -> None:
+        session.add(TagFormat(format_id=1, format_name="test"))
+        session.add(TagTypeName(type_name_id=1, type_name="general"))
+        session.add(TagTypeFormatMapping(format_id=1, type_id=0, type_name_id=1))
+        session.add(Tag(tag_id=1, tag="cat", source_tag="cat"))
+        session.add(
+            TagStatus(tag_id=1, format_id=1, type_id=0, alias=False, preferred_tag_id=1, deprecated=False)
+        )
+        session.add(TagTranslation(tag_id=1, language="japanese", translation=translation))
+        session.commit()
+
+    reader_a = TagReader(session_factory)
+    reader_b = TagReader(session_factory_b)
+    with session_factory() as session:
+        _seed_cat(session, "猫A")
+    with session_factory_b() as session:
+        _seed_cat(session, "猫B")
+
+    merged = MergedTagReader(base_repo=[reader_a, reader_b])
+    result = merged.search_tags("cat")
+
+    assert len(result) == 1
+    assert result[0]["translations"] == {"japanese": ["猫A"]}
 
 
 def _seed_bulk_all_rows(session: Session) -> None:

--- a/tests/unit/test_tag_repository.py
+++ b/tests/unit/test_tag_repository.py
@@ -4,10 +4,11 @@ from collections.abc import Callable
 
 import polars as pl
 import pytest
-from sqlalchemy import create_engine, event
+from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import StaticPool
 
+from genai_tag_db_tools.db.overlay_reader import OverlayTagReader
 from genai_tag_db_tools.db.repository import MergedTagReader, TagReader, TagRepository
 from genai_tag_db_tools.db.schema import (
     Base,
@@ -18,24 +19,22 @@ from genai_tag_db_tools.db.schema import (
     TagTypeFormatMapping,
     TagTypeName,
     TagUsageCounts,
+    UserOverlayBase,
+    UserTagStatusPatch,
 )
 
 pytestmark = pytest.mark.db_tools
 
 
-def _memory_session_factory(*, foreign_keys: bool = False) -> Callable[[], Session]:
+def _memory_session_factory(*, overlay: bool = False) -> Callable[[], Session]:
     engine = create_engine(
         "sqlite://",
         connect_args={"check_same_thread": False},
         poolclass=StaticPool,
     )
-    if foreign_keys:
-
-        @event.listens_for(engine, "connect")
-        def _enable_foreign_keys(dbapi_connection, connection_record) -> None:
-            dbapi_connection.execute("PRAGMA foreign_keys=ON")
-
     Base.metadata.create_all(engine)
+    if overlay:
+        UserOverlayBase.metadata.create_all(engine)
     return sessionmaker(bind=engine, autoflush=False, autocommit=False)
 
 
@@ -44,14 +43,14 @@ def session_factory() -> Callable[[], Session]:
     return _memory_session_factory()
 
 
-def test_update_tags_type_batch_materializes_base_tag_parent_in_user_db() -> None:
-    """Base DB 由来タグの type 補正時に user DB 側 TAGS 親行を保証する (#1268)。"""
+def test_update_tags_type_batch_writes_base_tag_type_overlay_patch() -> None:
+    """Base DB 由来タグの type 補正は USER_TAG_STATUS_PATCH に保存する (#1268/#136)。"""
     from genai_tag_db_tools.models import TagTypeUpdate
 
     base_factory = _memory_session_factory()
-    user_factory = _memory_session_factory(foreign_keys=True)
+    user_factory = _memory_session_factory(overlay=True)
     base_reader = TagReader(base_factory)
-    user_reader = TagReader(user_factory)
+    user_reader = OverlayTagReader(user_factory)
     merged_reader = MergedTagReader(base_repo=base_reader, user_repo=user_reader)
     repo = TagRepository(user_factory, reader=merged_reader)
 
@@ -78,22 +77,30 @@ def test_update_tags_type_batch_materializes_base_tag_parent_in_user_db() -> Non
     )
 
     with user_factory() as session:
-        tag = session.query(Tag).filter(Tag.tag_id == base_tag_id).one()
-        status = session.query(TagStatus).filter(TagStatus.tag_id == base_tag_id).one()
+        assert session.query(Tag).filter(Tag.tag_id == base_tag_id).one_or_none() is None
+        assert session.query(TagStatus).filter(TagStatus.tag_id == base_tag_id).one_or_none() is None
+        patch = (
+            session.query(UserTagStatusPatch)
+            .filter(
+                UserTagStatusPatch.target_scope == "base",
+                UserTagStatusPatch.target_tag_id == base_tag_id,
+                UserTagStatusPatch.format_id == 1000,
+            )
+            .one()
+        )
         type_name = (
             session.query(TagTypeName.type_name)
             .join(TagTypeFormatMapping, TagTypeName.type_name_id == TagTypeFormatMapping.type_name_id)
-            .filter(TagTypeFormatMapping.format_id == 1000, TagTypeFormatMapping.type_id == status.type_id)
+            .filter(TagTypeFormatMapping.format_id == 1000, TagTypeFormatMapping.type_id == patch.type_id)
             .scalar()
         )
 
-    assert tag.tag == "base_only_tag"
-    assert tag.source_tag == "Base Only Tag"
-    assert status.format_id == 1000
-    assert status.preferred_tag_id == base_tag_id
+    assert patch.alias is False
+    assert patch.preferred_scope == "base"
+    assert patch.preferred_tag_id == base_tag_id
     assert type_name == "general"
 
-    rows = merged_reader.search_tags("base_only_tag")
+    rows = merged_reader.search_tags("base_only_tag", format_name="Lorairo", type_name="general")
 
     assert len(rows) == 1
     assert rows[0]["tag_id"] == base_tag_id
@@ -101,13 +108,76 @@ def test_update_tags_type_batch_materializes_base_tag_parent_in_user_db() -> Non
     assert "danbooru" in rows[0]["format_statuses"]
     assert "Lorairo" in rows[0]["format_statuses"]
 
-    bulk_row = merged_reader.search_tags_bulk(["base_only_tag"])["base_only_tag"]
-    bulk_all_row = merged_reader.search_tags_bulk_all(["base_only_tag"])["base_only_tag"][0]
+    bulk_row = merged_reader.search_tags_bulk(["base_only_tag"], format_name="Lorairo")["base_only_tag"]
+    bulk_all_row = merged_reader.search_tags_bulk_all(["base_only_tag"], format_name="Lorairo")[
+        "base_only_tag"
+    ][0]
 
     assert bulk_row["translations"] == {"ja": ["ベースのみ"]}
     assert "Lorairo" in bulk_row["format_statuses"]
     assert bulk_all_row["translations"] == {"ja": ["ベースのみ"]}
     assert "Lorairo" in bulk_all_row["format_statuses"]
+
+    with base_factory() as session:
+        session.add(Tag(tag_id=base_tag_id + 1, tag="unpatched_base", source_tag="Unpatched Base"))
+        session.add(
+            TagStatus(
+                tag_id=base_tag_id + 1,
+                format_id=1,
+                type_id=0,
+                alias=False,
+                preferred_tag_id=base_tag_id + 1,
+            )
+        )
+        session.commit()
+
+    assert merged_reader.search_tags("unpatched_base", format_name="Lorairo") == []
+    assert merged_reader.search_tags_bulk(["unpatched_base"], format_name="Lorairo") == {}
+    assert merged_reader.search_tags_bulk_all(["unpatched_base"], format_name="Lorairo") == {}
+
+
+def test_update_tags_type_batch_rolls_back_overlay_patch_when_batch_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """後続更新が失敗したら、同一 batch 内の overlay patch も rollback する。"""
+    from genai_tag_db_tools.models import TagTypeUpdate
+
+    base_factory = _memory_session_factory()
+    user_factory = _memory_session_factory(overlay=True)
+    base_reader = TagReader(base_factory)
+    user_reader = OverlayTagReader(user_factory)
+    merged_reader = MergedTagReader(base_repo=base_reader, user_repo=user_reader)
+    repo = TagRepository(user_factory, reader=merged_reader)
+
+    base_tag_id = 197273
+    with base_factory() as session:
+        session.add(TagFormat(format_id=1, format_name="danbooru"))
+        session.add(TagTypeName(type_name_id=1, type_name="general"))
+        session.add(TagTypeFormatMapping(format_id=1, type_id=0, type_name_id=1))
+        session.add(Tag(tag_id=base_tag_id, tag="base_only_tag", source_tag="Base Only Tag"))
+        session.add(TagStatus(tag_id=base_tag_id, format_id=1, type_id=0, alias=False, preferred_tag_id=base_tag_id))
+        session.commit()
+
+    with user_factory() as session:
+        session.add(TagFormat(format_id=1000, format_name="Lorairo"))
+        session.commit()
+
+    def _raise_on_legacy_path(*args: object, **kwargs: object) -> None:
+        raise RuntimeError("legacy path failed")
+
+    monkeypatch.setattr(repo, "_write_tag_status_in_session", _raise_on_legacy_path)
+
+    with pytest.raises(RuntimeError, match="legacy path failed"):
+        repo.update_tags_type_batch(
+            [
+                TagTypeUpdate(tag_id=base_tag_id, type_name="general"),
+                TagTypeUpdate(tag_id=999999, type_name="general"),
+            ],
+            format_id=1000,
+        )
+
+    with user_factory() as session:
+        assert session.query(UserTagStatusPatch).all() == []
 
 
 def test_create_tag_returns_existing_id(session_factory: Callable[[], Session]) -> None:
@@ -852,86 +922,6 @@ def test_merged_reader_search_tags_applies_offset_after_merge(
     result = merged.search_tags("sample", partial=True, limit=2, offset=3)
 
     assert [row["tag_id"] for row in result] == [4, 5]
-
-
-def test_merged_reader_search_tags_higher_priority_base_row_wins(
-    session_factory: Callable[[], Session],
-) -> None:
-    """同一 tag_id/tag/source_tag でも高優先度 base DB の検索行を採用する。"""
-    from sqlalchemy import create_engine
-    from sqlalchemy.orm import sessionmaker
-    from sqlalchemy.pool import StaticPool
-
-    engine_b = create_engine("sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool)
-    Base.metadata.create_all(engine_b)
-    session_factory_b: Callable[[], Session] = sessionmaker(
-        bind=engine_b, autoflush=False, autocommit=False
-    )
-
-    def _seed_cat(session: Session, translation: str) -> None:
-        session.add(TagFormat(format_id=1, format_name="test"))
-        session.add(TagTypeName(type_name_id=1, type_name="general"))
-        session.add(TagTypeFormatMapping(format_id=1, type_id=0, type_name_id=1))
-        session.add(Tag(tag_id=1, tag="cat", source_tag="cat"))
-        session.add(
-            TagStatus(tag_id=1, format_id=1, type_id=0, alias=False, preferred_tag_id=1, deprecated=False)
-        )
-        session.add(TagTranslation(tag_id=1, language="japanese", translation=translation))
-        session.commit()
-
-    reader_a = TagReader(session_factory)
-    reader_b = TagReader(session_factory_b)
-    with session_factory() as session:
-        _seed_cat(session, "猫A")
-    with session_factory_b() as session:
-        _seed_cat(session, "猫B")
-
-    merged = MergedTagReader(base_repo=[reader_a, reader_b])
-    result = merged.search_tags("cat")
-
-    assert len(result) == 1
-    assert result[0]["translations"] == {"japanese": ["猫A"]}
-
-
-def test_merged_reader_search_tags_bulk_keeps_distinct_user_tag_with_same_name(
-    session_factory: Callable[[], Session],
-) -> None:
-    """同じ tag/source_tag でも別 tag_id の user tag は materialized parent 扱いしない。"""
-    user_factory = _memory_session_factory()
-    base_reader = TagReader(session_factory)
-    user_reader = TagReader(user_factory)
-
-    with session_factory() as session:
-        session.add(TagFormat(format_id=1, format_name="test"))
-        session.add(TagTypeName(type_name_id=1, type_name="general"))
-        session.add(TagTypeFormatMapping(format_id=1, type_id=0, type_name_id=1))
-        session.add(Tag(tag_id=1, tag="cat", source_tag="cat"))
-        session.add(TagStatus(tag_id=1, format_id=1, type_id=0, alias=False, preferred_tag_id=1))
-        session.add(TagTranslation(tag_id=1, language="japanese", translation="猫base"))
-        session.commit()
-
-    with user_factory() as session:
-        session.add(TagFormat(format_id=1000, format_name="Lorairo"))
-        session.add(TagTypeName(type_name_id=1, type_name="general"))
-        session.add(TagTypeFormatMapping(format_id=1000, type_id=0, type_name_id=1))
-        session.add(Tag(tag_id=1_000_000_001, tag="cat", source_tag="cat"))
-        session.add(
-            TagStatus(
-                tag_id=1_000_000_001,
-                format_id=1000,
-                type_id=0,
-                alias=False,
-                preferred_tag_id=1_000_000_001,
-            )
-        )
-        session.add(TagTranslation(tag_id=1_000_000_001, language="japanese", translation="猫user"))
-        session.commit()
-
-    merged = MergedTagReader(base_repo=base_reader, user_repo=user_reader)
-    result = merged.search_tags_bulk(["cat"])
-
-    assert result["cat"]["tag_id"] == 1_000_000_001
-    assert result["cat"]["translations"] == {"japanese": ["猫user"]}
 
 
 def _seed_bulk_all_rows(session: Session) -> None:


### PR DESCRIPTION
Fixes NEXTAltair/LoRAIro#1268.\n\nBranch: issue-1268-tag-type-fk\n\n## Summary\n- ensure user DB TAGS parent rows exist before writing TAG_STATUS for type updates\n- write TAG_STATUS in the same session as the parent materialization\n- add a regression test for base-only tag type correction with SQLite foreign keys enabled\n\n## Verification\n- UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run pytest local_packages/genai-tag-db-tools/tests/unit/test_tag_repository.py -q\n- UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run ruff check local_packages/genai-tag-db-tools/src/genai_tag_db_tools/db/repository.py local_packages/genai-tag-db-tools/tests/unit/test_tag_repository.py