### PR TITLE
fix: apply overlay status to unknown type listing

### DIFF
--- a/src/genai_tag_db_tools/db/overlay_reader.py
+++ b/src/genai_tag_db_tools/db/overlay_reader.py
@@ -248,29 +248,29 @@ class OverlayTagReader:
             type_rows = type_query.all()
 
             statuses: dict[tuple[int, int], TagStatus] = {}
-            for row in status_rows:
-                statuses[(row.target_tag_id, row.format_id)] = TagStatus(
-                    tag_id=row.target_tag_id,
-                    format_id=row.format_id,
-                    type_id=row.type_id,
-                    alias=row.alias,
-                    preferred_tag_id=row.preferred_tag_id,
-                    deprecated=row.deprecated,
-                    deprecated_at=row.deprecated_at,
+            for status_row in status_rows:
+                statuses[(status_row.target_tag_id, status_row.format_id)] = TagStatus(
+                    tag_id=status_row.target_tag_id,
+                    format_id=status_row.format_id,
+                    type_id=status_row.type_id,
+                    alias=status_row.alias,
+                    preferred_tag_id=status_row.preferred_tag_id,
+                    deprecated=status_row.deprecated,
+                    deprecated_at=status_row.deprecated_at,
                 )
 
-            for row in type_rows:
-                key = (row.target_tag_id, row.format_id)
+            for type_row in type_rows:
+                key = (type_row.target_tag_id, type_row.format_id)
                 existing = statuses.get(key)
                 if existing is not None:
-                    existing.type_id = row.type_id
+                    existing.type_id = type_row.type_id
                     continue
                 statuses[key] = TagStatus(
-                    tag_id=row.target_tag_id,
-                    format_id=row.format_id,
-                    type_id=row.type_id,
+                    tag_id=type_row.target_tag_id,
+                    format_id=type_row.format_id,
+                    type_id=type_row.type_id,
                     alias=False,
-                    preferred_tag_id=row.target_tag_id,
+                    preferred_tag_id=type_row.target_tag_id,
                     deprecated=False,
                     deprecated_at=None,
                 )

--- a/src/genai_tag_db_tools/db/overlay_reader.py
+++ b/src/genai_tag_db_tools/db/overlay_reader.py
@@ -27,6 +27,7 @@ from genai_tag_db_tools.db.schema import (
     UserTagTranslationPatch,
     UserTagTranslationPreference,
     UserTagTranslationTombstone,
+    UserTagTypePatch,
     UserTagUsagePatch,
 )
 from genai_tag_db_tools.models import TagSearchRow
@@ -197,9 +198,9 @@ class OverlayTagReader:
     # ------------------------------------------------------------------
 
     def get_tag_status(self, tag_id: int, format_id: int) -> TagStatus | None:
-        """USER_TAG_STATUS_PATCH からステータスを取得し、detached TagStatus を返す。"""
+        """USER_TAG_STATUS_PATCH + USER_TAG_TYPE_PATCH から effective status を返す。"""
         with self.session_factory() as session:
-            row = (
+            status_row = (
                 session.query(UserTagStatusPatch)
                 .filter(
                     UserTagStatusPatch.target_tag_id == tag_id,
@@ -207,36 +208,112 @@ class OverlayTagReader:
                 )
                 .one_or_none()
             )
-            if row is None:
+            type_row = (
+                session.query(UserTagTypePatch)
+                .filter(
+                    UserTagTypePatch.target_tag_id == tag_id,
+                    UserTagTypePatch.format_id == format_id,
+                )
+                .one_or_none()
+            )
+            if status_row is None and type_row is None:
                 return None
+
+            type_id = type_row.type_id if type_row is not None else status_row.type_id
+            alias = status_row.alias if status_row is not None else False
+            preferred_tag_id = status_row.preferred_tag_id if status_row is not None else tag_id
+            deprecated = status_row.deprecated if status_row is not None else False
+            deprecated_at = status_row.deprecated_at if status_row is not None else None
             return TagStatus(
-                tag_id=row.target_tag_id,
-                format_id=row.format_id,
-                type_id=row.type_id,
-                alias=row.alias,
-                preferred_tag_id=row.preferred_tag_id,
-                deprecated=row.deprecated,
-                deprecated_at=row.deprecated_at,
+                tag_id=tag_id,
+                format_id=format_id,
+                type_id=type_id,
+                alias=alias,
+                preferred_tag_id=preferred_tag_id,
+                deprecated=deprecated,
+                deprecated_at=deprecated_at,
             )
 
     def list_tag_statuses(self, tag_id: int | None = None) -> list[TagStatus]:
-        """USER_TAG_STATUS_PATCH を全件 (tag_id 指定時はフィルタ) 取得し TagStatus に変換して返す。"""
+        """USER_TAG_STATUS_PATCH + USER_TAG_TYPE_PATCH の effective status 一覧を返す。"""
+        with self.session_factory() as session:
+            status_query = session.query(UserTagStatusPatch)
+            if tag_id is not None:
+                status_query = status_query.filter(UserTagStatusPatch.target_tag_id == tag_id)
+            status_rows = status_query.all()
+
+            type_query = session.query(UserTagTypePatch)
+            if tag_id is not None:
+                type_query = type_query.filter(UserTagTypePatch.target_tag_id == tag_id)
+            type_rows = type_query.all()
+
+            statuses: dict[tuple[int, int], TagStatus] = {}
+            for row in status_rows:
+                statuses[(row.target_tag_id, row.format_id)] = TagStatus(
+                    tag_id=row.target_tag_id,
+                    format_id=row.format_id,
+                    type_id=row.type_id,
+                    alias=row.alias,
+                    preferred_tag_id=row.preferred_tag_id,
+                    deprecated=row.deprecated,
+                    deprecated_at=row.deprecated_at,
+                )
+
+            for row in type_rows:
+                key = (row.target_tag_id, row.format_id)
+                existing = statuses.get(key)
+                if existing is not None:
+                    existing.type_id = row.type_id
+                    continue
+                statuses[key] = TagStatus(
+                    tag_id=row.target_tag_id,
+                    format_id=row.format_id,
+                    type_id=row.type_id,
+                    alias=False,
+                    preferred_tag_id=row.target_tag_id,
+                    deprecated=False,
+                    deprecated_at=None,
+                )
+
+            return list(statuses.values())
+
+    def list_tag_type_patches(self, tag_id: int | None = None) -> list[UserTagTypePatch]:
+        """USER_TAG_TYPE_PATCH を全件 (tag_id 指定時はフィルタ) 取得する。"""
+        with self.session_factory() as session:
+            query = session.query(UserTagTypePatch)
+            if tag_id is not None:
+                query = query.filter(UserTagTypePatch.target_tag_id == tag_id)
+            rows = query.all()
+            return [
+                UserTagTypePatch(
+                    target_scope=row.target_scope,
+                    target_tag_id=row.target_tag_id,
+                    format_id=row.format_id,
+                    type_id=row.type_id,
+                )
+                for row in rows
+            ]
+
+    def list_status_patches(self, tag_id: int | None = None) -> list[UserTagStatusPatch]:
+        """USER_TAG_STATUS_PATCH を raw patch として取得する。"""
         with self.session_factory() as session:
             query = session.query(UserTagStatusPatch)
             if tag_id is not None:
                 query = query.filter(UserTagStatusPatch.target_tag_id == tag_id)
             rows = query.all()
             return [
-                TagStatus(
-                    tag_id=r.target_tag_id,
-                    format_id=r.format_id,
-                    type_id=r.type_id,
-                    alias=r.alias,
-                    preferred_tag_id=r.preferred_tag_id,
-                    deprecated=r.deprecated,
-                    deprecated_at=r.deprecated_at,
+                UserTagStatusPatch(
+                    target_scope=row.target_scope,
+                    target_tag_id=row.target_tag_id,
+                    format_id=row.format_id,
+                    type_id=row.type_id,
+                    alias=row.alias,
+                    preferred_scope=row.preferred_scope,
+                    preferred_tag_id=row.preferred_tag_id,
+                    deprecated=row.deprecated,
+                    deprecated_at=row.deprecated_at,
                 )
-                for r in rows
+                for row in rows
             ]
 
     # ------------------------------------------------------------------

--- a/src/genai_tag_db_tools/db/overlay_reader.py
+++ b/src/genai_tag_db_tools/db/overlay_reader.py
@@ -374,6 +374,10 @@ class OverlayTagReader:
             candidate_ids = set(tag_by_id)
 
             status_by_tag = self._load_status_patches(session, candidate_ids)
+            self._apply_type_patches_to_statuses(
+                status_by_tag,
+                self._load_type_patches(session, candidate_ids),
+            )
             usage_by_tag = self._load_usage_patches(session, candidate_ids)
             trans_by_tag = self._load_translation_patches(session, candidate_ids)
             type_map = self._load_type_name_map(session)
@@ -479,6 +483,49 @@ class OverlayTagReader:
         for patch_list in result.values():
             patch_list.sort(key=lambda p: p.format_id)
         return result
+
+    def _load_type_patches(self, session: Session, tag_ids: set[int]) -> dict[int, list[UserTagTypePatch]]:
+        if not tag_ids:
+            return {}
+        try:
+            rows = (
+                session.query(UserTagTypePatch).filter(UserTagTypePatch.target_tag_id.in_(tag_ids)).all()
+            )
+        except OperationalError as exc:
+            if "no such table" in str(exc).lower():
+                return {}
+            raise
+        result: dict[int, list[UserTagTypePatch]] = {}
+        for row in rows:
+            result.setdefault(row.target_tag_id, []).append(row)
+        return result
+
+    def _apply_type_patches_to_statuses(
+        self,
+        status_by_tag: dict[int, list[UserTagStatusPatch]],
+        type_by_tag: dict[int, list[UserTagTypePatch]],
+    ) -> None:
+        for tag_id, type_patches in type_by_tag.items():
+            statuses = status_by_tag.setdefault(tag_id, [])
+            status_by_format = {status.format_id: status for status in statuses}
+            for type_patch in type_patches:
+                existing = status_by_format.get(type_patch.format_id)
+                if existing is not None:
+                    existing.type_id = type_patch.type_id
+                    continue
+                status = UserTagStatusPatch(
+                    target_scope=type_patch.target_scope,
+                    target_tag_id=type_patch.target_tag_id,
+                    format_id=type_patch.format_id,
+                    type_id=type_patch.type_id,
+                    alias=False,
+                    preferred_scope=type_patch.target_scope,
+                    preferred_tag_id=type_patch.target_tag_id,
+                    deprecated=False,
+                )
+                statuses.append(status)
+                status_by_format[type_patch.format_id] = status
+            statuses.sort(key=lambda p: p.format_id)
 
     def _load_usage_patches(
         self, session: Session, tag_ids: set[int]

--- a/src/genai_tag_db_tools/db/overlay_reader.py
+++ b/src/genai_tag_db_tools/db/overlay_reader.py
@@ -44,6 +44,10 @@ class OverlayTagReader:
         self.logger = getLogger(__name__)
         self.session_factory = session_factory
 
+    @staticmethod
+    def _is_missing_table_error(exc: OperationalError) -> bool:
+        return "no such table" in str(exc).lower()
+
     # ------------------------------------------------------------------
     # タグ取得 (USER_TAGS)
     # ------------------------------------------------------------------
@@ -208,14 +212,19 @@ class OverlayTagReader:
                 )
                 .one_or_none()
             )
-            type_row = (
-                session.query(UserTagTypePatch)
-                .filter(
-                    UserTagTypePatch.target_tag_id == tag_id,
-                    UserTagTypePatch.format_id == format_id,
+            try:
+                type_row = (
+                    session.query(UserTagTypePatch)
+                    .filter(
+                        UserTagTypePatch.target_tag_id == tag_id,
+                        UserTagTypePatch.format_id == format_id,
+                    )
+                    .one_or_none()
                 )
-                .one_or_none()
-            )
+            except OperationalError as exc:
+                if not self._is_missing_table_error(exc):
+                    raise
+                type_row = None
             if status_row is None and type_row is None:
                 return None
 
@@ -242,10 +251,15 @@ class OverlayTagReader:
                 status_query = status_query.filter(UserTagStatusPatch.target_tag_id == tag_id)
             status_rows = status_query.all()
 
-            type_query = session.query(UserTagTypePatch)
-            if tag_id is not None:
-                type_query = type_query.filter(UserTagTypePatch.target_tag_id == tag_id)
-            type_rows = type_query.all()
+            try:
+                type_query = session.query(UserTagTypePatch)
+                if tag_id is not None:
+                    type_query = type_query.filter(UserTagTypePatch.target_tag_id == tag_id)
+                type_rows = type_query.all()
+            except OperationalError as exc:
+                if not self._is_missing_table_error(exc):
+                    raise
+                type_rows = []
 
             statuses: dict[tuple[int, int], TagStatus] = {}
             for status_row in status_rows:
@@ -283,7 +297,12 @@ class OverlayTagReader:
             query = session.query(UserTagTypePatch)
             if tag_id is not None:
                 query = query.filter(UserTagTypePatch.target_tag_id == tag_id)
-            rows = query.all()
+            try:
+                rows = query.all()
+            except OperationalError as exc:
+                if self._is_missing_table_error(exc):
+                    return []
+                raise
             return [
                 UserTagTypePatch(
                     target_scope=row.target_scope,
@@ -492,7 +511,7 @@ class OverlayTagReader:
                 session.query(UserTagTypePatch).filter(UserTagTypePatch.target_tag_id.in_(tag_ids)).all()
             )
         except OperationalError as exc:
-            if "no such table" in str(exc).lower():
+            if self._is_missing_table_error(exc):
                 return {}
             raise
         result: dict[int, list[UserTagTypePatch]] = {}

--- a/src/genai_tag_db_tools/db/repository.py
+++ b/src/genai_tag_db_tools/db/repository.py
@@ -31,6 +31,7 @@ from genai_tag_db_tools.db.schema import (
     TagTypeName,
     TagUsageCounts,
     UserTagStatusPatch,
+    UserTagTypePatch,
 )
 from genai_tag_db_tools.models import TagSearchRow
 from genai_tag_db_tools.utils.messages import ErrorMessages
@@ -1549,6 +1550,37 @@ class TagRepository:
             )
         )
 
+    @staticmethod
+    def _write_type_patch_in_session(
+        session: Session,
+        *,
+        target_scope: str,
+        target_tag_id: int,
+        format_id: int,
+        type_id: int,
+    ) -> None:
+        existing = (
+            session.query(UserTagTypePatch)
+            .filter(
+                UserTagTypePatch.target_scope == target_scope,
+                UserTagTypePatch.target_tag_id == target_tag_id,
+                UserTagTypePatch.format_id == format_id,
+            )
+            .one_or_none()
+        )
+        if existing is not None:
+            existing.type_id = type_id
+            return
+
+        session.add(
+            UserTagTypePatch(
+                target_scope=target_scope,
+                target_tag_id=target_tag_id,
+                format_id=format_id,
+                type_id=type_id,
+            )
+        )
+
     def update_tags_type_batch(
         self,
         tag_updates: list,  # list[TagTypeUpdate] - avoid circular import
@@ -1614,22 +1646,12 @@ class TagRepository:
                             overlay_format_id,
                             overlay_type_name_to_type_id,
                         )
-                        existing_patch = (
-                            session.query(UserTagStatusPatch)
-                            .filter(
-                                UserTagStatusPatch.target_scope == scope,
-                                UserTagStatusPatch.target_tag_id == update.tag_id,
-                                UserTagStatusPatch.format_id == overlay_format_id,
-                            )
-                            .one_or_none()
-                        )
-                        self._write_status_patch_in_session(
+                        self._write_type_patch_in_session(
                             session,
                             target_scope=scope,
                             target_tag_id=update.tag_id,
                             format_id=overlay_format_id,
                             type_id=patch_type_id,
-                            deprecated=existing_patch.deprecated if existing_patch is not None else False,
                         )
                         continue
 
@@ -2350,7 +2372,10 @@ class MergedTagReader:
         return None
 
     def get_tag_status(self, tag_id: int, format_id: int) -> TagStatus | None:
-        return self._first_found("get_tag_status", tag_id, format_id)
+        for status in self.list_tag_statuses(tag_id):
+            if status.format_id == format_id:
+                return status
+        return None
 
     def get_usage_count(self, tag_id: int, format_id: int) -> int | None:
         return self._first_found("get_usage_count", tag_id, format_id)
@@ -2475,11 +2500,43 @@ class MergedTagReader:
         return result
 
     def list_tag_statuses(self, tag_id: int | None = None) -> list[TagStatus]:
-        return self._merge_by_key(
-            "list_tag_statuses",
-            lambda s: (s.tag_id, s.format_id),
-            tag_id=tag_id,
-        )
+        statuses: dict[tuple[int, int], TagStatus] = {}
+        for repo in self._iter_base_repos_low_to_high():
+            for status in repo.list_tag_statuses(tag_id):
+                statuses[(status.tag_id, status.format_id)] = status
+
+        if not self._has_user():
+            return list(statuses.values())
+
+        assert self.user_repo is not None
+        for patch in self.user_repo.list_status_patches(tag_id):
+            statuses[(patch.target_tag_id, patch.format_id)] = TagStatus(
+                tag_id=patch.target_tag_id,
+                format_id=patch.format_id,
+                type_id=patch.type_id,
+                alias=patch.alias,
+                preferred_tag_id=patch.preferred_tag_id,
+                deprecated=patch.deprecated,
+                deprecated_at=patch.deprecated_at,
+            )
+
+        for patch in self.user_repo.list_tag_type_patches(tag_id):
+            key = (patch.target_tag_id, patch.format_id)
+            existing = statuses.get(key)
+            if existing is not None:
+                existing.type_id = patch.type_id
+                continue
+            statuses[key] = TagStatus(
+                tag_id=patch.target_tag_id,
+                format_id=patch.format_id,
+                type_id=patch.type_id,
+                alias=False,
+                preferred_tag_id=patch.target_tag_id,
+                deprecated=False,
+                deprecated_at=None,
+            )
+
+        return list(statuses.values())
 
     def list_usage_counts(
         self, tag_id: int | None = None, format_id: int | None = None
@@ -3091,26 +3148,34 @@ class MergedTagReader:
 
         assert self.user_repo is not None
         try:
-            patched_statuses = {
-                status.tag_id: status
-                for status in self.user_repo.list_tag_statuses()
-                if status.format_id == format_id
+            tag_ids |= {
+                tag_id
+                for tag_id in self.user_repo.get_unknown_type_tag_ids(format_id)
+                if tag_id >= USER_TAG_ID_OFFSET
             }
         except OperationalError:
             return list(tag_ids)
-        user_type_map = {
-            type_id: type_name
-            for (fmt_id, type_id), type_name in self.user_repo.get_type_mapping_map().items()
-            if fmt_id == format_id
-        }
-        for tag_id, status in patched_statuses.items():
-            type_name = user_type_map.get(status.type_id)
-            if type_name is None:
-                continue
+
+        try:
+            type_patches = [
+                patch
+                for patch in self.user_repo.list_tag_type_patches()
+                if patch.format_id == format_id
+            ]
+            user_type_map = {
+                type_id: type_name
+                for (fmt_id, type_id), type_name in self.user_repo.get_type_mapping_map().items()
+                if fmt_id == format_id
+            }
+        except OperationalError:
+            return list(tag_ids)
+
+        for patch in type_patches:
+            type_name = user_type_map.get(patch.type_id)
             if type_name == "unknown":
-                tag_ids.add(tag_id)
+                tag_ids.add(patch.target_tag_id)
             else:
-                tag_ids.discard(tag_id)
+                tag_ids.discard(patch.target_tag_id)
 
         return list(tag_ids)
 

--- a/src/genai_tag_db_tools/db/repository.py
+++ b/src/genai_tag_db_tools/db/repository.py
@@ -1627,6 +1627,9 @@ class TagRepository:
             try:
                 overlay_format_id = format_id
                 if overlay_available:
+                    bind = session.get_bind()
+                    if not inspect(bind).has_table("USER_TAG_TYPE_PATCH"):
+                        cast(Any, UserTagTypePatch.__table__).create(bind, checkfirst=True)
                     overlay_format_id = self._get_or_create_format_id_in_session(
                         session, format_name or str(format_id), format_id
                     )
@@ -2103,12 +2106,21 @@ class MergedTagReader:
         assert self.user_repo is not None
         tag_ids = {row["tag_id"] for row in rows}
         patched_by_tag: dict[int, list[Any]] = {}
+        type_patched_by_tag: dict[int, list[Any]] = {}
         usage_by_tag: dict[int, list[TagUsageCounts]] = {}
         translations_by_tag = self.user_repo.get_translations_batch(list(tag_ids))
         # tombstone (#121): base 検索行に載ってきた翻訳もマージ時に除外する
         tombstones_by_tag = self._translation_tombstones_batch(list(tag_ids))
+        has_split_patches = hasattr(self.user_repo, "list_status_patches") and hasattr(
+            self.user_repo, "list_tag_type_patches"
+        )
         for tag_id in tag_ids:
-            patched_by_tag[tag_id] = self.user_repo.list_tag_statuses(tag_id)
+            if has_split_patches:
+                patched_by_tag[tag_id] = self.user_repo.list_status_patches(tag_id)
+                type_patched_by_tag[tag_id] = self.user_repo.list_tag_type_patches(tag_id)
+            else:
+                patched_by_tag[tag_id] = self.user_repo.list_tag_statuses(tag_id)
+                type_patched_by_tag[tag_id] = []
             usage_by_tag[tag_id] = self.user_repo.list_usage_counts(tag_id=tag_id)
 
         patched_rows: list[TagSearchRow] = []
@@ -2159,7 +2171,8 @@ class MergedTagReader:
                     updated["translations"] = translations
 
             patches = patched_by_tag.get(row["tag_id"], [])
-            if not patches:
+            type_patches = type_patched_by_tag.get(row["tag_id"], [])
+            if not patches and not type_patches:
                 updated["format_statuses"] = format_statuses
                 patched_rows.append(cast(TagSearchRow, updated))
                 continue
@@ -2189,6 +2202,24 @@ class MergedTagReader:
                     status["usage_count"] = patch_usage.count
                 format_statuses[fmt_name] = status
 
+            for patch in type_patches:
+                fmt_name = self._format_name_for_id(patch.format_id)
+                type_name = self._type_name_for_format_type(patch.format_id, patch.type_id)
+                status = self._format_status_dict(format_statuses.get(fmt_name))
+                status["type_id"] = patch.type_id
+                status["type_name"] = type_name
+                patch_usage = next(
+                    (
+                        item
+                        for item in usage_by_tag.get(row["tag_id"], [])
+                        if item.format_id == patch.format_id
+                    ),
+                    None,
+                )
+                if patch_usage is not None:
+                    status["usage_count"] = patch_usage.count
+                format_statuses[fmt_name] = status
+
             active_patch = self._select_active_status(patches, requested_format_id)
             if active_patch is not None:
                 updated["alias"] = active_patch.alias
@@ -2197,6 +2228,13 @@ class MergedTagReader:
                 updated["type_name"] = self._type_name_for_format_type(
                     active_patch.format_id,
                     active_patch.type_id,
+                )
+            active_type_patch = self._select_active_status(type_patches, requested_format_id)
+            if active_type_patch is not None:
+                updated["type_id"] = active_type_patch.type_id
+                updated["type_name"] = self._type_name_for_format_type(
+                    active_type_patch.format_id,
+                    active_type_patch.type_id,
                 )
             updated["format_statuses"] = format_statuses
             patched_rows.append(cast(TagSearchRow, updated))
@@ -3184,6 +3222,8 @@ class MergedTagReader:
             return
         for patch in type_patches:
             type_name = type_map.get(patch.type_id)
+            if type_name is None:
+                type_name = self._type_name_for_format_type(format_id, patch.type_id) or None
             if type_name == "unknown":
                 tag_ids.add(patch.target_tag_id)
             else:

--- a/src/genai_tag_db_tools/db/repository.py
+++ b/src/genai_tag_db_tools/db/repository.py
@@ -3095,9 +3095,9 @@ class MergedTagReader:
             for status in self.user_repo.list_tag_statuses()
             if status.format_id == format_id
         }
+        unknown_type_id = self.get_type_id_for_format("unknown", format_id)
         for tag_id, status in patched_statuses.items():
-            type_name = self.get_type_name_by_format_type_id(format_id, status.type_id)
-            if type_name == "unknown":
+            if unknown_type_id is not None and status.type_id == unknown_type_id:
                 tag_ids.add(tag_id)
             else:
                 tag_ids.discard(tag_id)

--- a/src/genai_tag_db_tools/db/repository.py
+++ b/src/genai_tag_db_tools/db/repository.py
@@ -3095,9 +3095,16 @@ class MergedTagReader:
             for status in self.user_repo.list_tag_statuses()
             if status.format_id == format_id
         }
-        unknown_type_id = self.user_repo.get_type_id_for_format("unknown", format_id)
+        user_type_map = {
+            type_id: type_name
+            for (fmt_id, type_id), type_name in self.user_repo.get_type_mapping_map().items()
+            if fmt_id == format_id
+        }
         for tag_id, status in patched_statuses.items():
-            if unknown_type_id is not None and status.type_id == unknown_type_id:
+            type_name = user_type_map.get(status.type_id)
+            if type_name is None:
+                continue
+            if type_name == "unknown":
                 tag_ids.add(tag_id)
             else:
                 tag_ids.discard(tag_id)

--- a/src/genai_tag_db_tools/db/repository.py
+++ b/src/genai_tag_db_tools/db/repository.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
 
 import polars as pl
 from sqlalchemy import func, inspect, or_
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.exc import IntegrityError, OperationalError
 from sqlalchemy.orm import Session
 
 from genai_tag_db_tools.db.query_utils import (
@@ -3090,11 +3090,14 @@ class MergedTagReader:
             return list(tag_ids)
 
         assert self.user_repo is not None
-        patched_statuses = {
-            status.tag_id: status
-            for status in self.user_repo.list_tag_statuses()
-            if status.format_id == format_id
-        }
+        try:
+            patched_statuses = {
+                status.tag_id: status
+                for status in self.user_repo.list_tag_statuses()
+                if status.format_id == format_id
+            }
+        except OperationalError:
+            return list(tag_ids)
         user_type_map = {
             type_id: type_name
             for (fmt_id, type_id), type_name in self.user_repo.get_type_mapping_map().items()

--- a/src/genai_tag_db_tools/db/repository.py
+++ b/src/genai_tag_db_tools/db/repository.py
@@ -2206,6 +2206,9 @@ class MergedTagReader:
                 fmt_name = self._format_name_for_id(patch.format_id)
                 type_name = self._type_name_for_format_type(patch.format_id, patch.type_id)
                 status = self._format_status_dict(format_statuses.get(fmt_name))
+                status.setdefault("alias", False)
+                status.setdefault("deprecated", False)
+                status.setdefault("preferred_tag_id", row["tag_id"])
                 status["type_id"] = patch.type_id
                 status["type_name"] = type_name
                 patch_usage = next(
@@ -2231,6 +2234,11 @@ class MergedTagReader:
                 )
             active_type_patch = self._select_active_status(type_patches, requested_format_id)
             if active_type_patch is not None:
+                fmt_name = self._format_name_for_id(active_type_patch.format_id)
+                active_type_status = self._format_status_dict(format_statuses.get(fmt_name))
+                if active_patch is None:
+                    updated["alias"] = active_type_status.get("alias", False)
+                    updated["deprecated"] = active_type_status.get("deprecated", False)
                 updated["type_id"] = active_type_patch.type_id
                 updated["type_name"] = self._type_name_for_format_type(
                     active_type_patch.format_id,

--- a/src/genai_tag_db_tools/db/repository.py
+++ b/src/genai_tag_db_tools/db/repository.py
@@ -2509,6 +2509,13 @@ class MergedTagReader:
             return list(statuses.values())
 
         assert self.user_repo is not None
+        if not hasattr(self.user_repo, "list_status_patches") or not hasattr(
+            self.user_repo, "list_tag_type_patches"
+        ):
+            for status in self.user_repo.list_tag_statuses(tag_id):
+                statuses[(status.tag_id, status.format_id)] = status
+            return list(statuses.values())
+
         for patch in self.user_repo.list_status_patches(tag_id):
             statuses[(patch.target_tag_id, patch.format_id)] = TagStatus(
                 tag_id=patch.target_tag_id,
@@ -3142,6 +3149,7 @@ class MergedTagReader:
         tag_ids: set[int] = set()
         for repo in self._iter_base_repos():
             tag_ids |= set(repo.get_unknown_type_tag_ids(format_id))
+            self._apply_type_patches_to_unknown_ids(tag_ids, repo, format_id)
 
         if not self._has_user():
             return list(tag_ids)
@@ -3156,28 +3164,30 @@ class MergedTagReader:
         except OperationalError:
             return list(tag_ids)
 
+        self._apply_type_patches_to_unknown_ids(tag_ids, self.user_repo, format_id)
+
+        return list(tag_ids)
+
+    def _apply_type_patches_to_unknown_ids(self, tag_ids: set[int], repo: Any, format_id: int) -> None:
+        list_type_patches = getattr(repo, "list_tag_type_patches", None)
+        get_type_mapping_map = getattr(repo, "get_type_mapping_map", None)
+        if list_type_patches is None or get_type_mapping_map is None:
+            return
         try:
-            type_patches = [
-                patch
-                for patch in self.user_repo.list_tag_type_patches()
-                if patch.format_id == format_id
-            ]
-            user_type_map = {
+            type_patches = [patch for patch in list_type_patches() if patch.format_id == format_id]
+            type_map = {
                 type_id: type_name
-                for (fmt_id, type_id), type_name in self.user_repo.get_type_mapping_map().items()
+                for (fmt_id, type_id), type_name in get_type_mapping_map().items()
                 if fmt_id == format_id
             }
         except OperationalError:
-            return list(tag_ids)
-
+            return
         for patch in type_patches:
-            type_name = user_type_map.get(patch.type_id)
+            type_name = type_map.get(patch.type_id)
             if type_name == "unknown":
                 tag_ids.add(patch.target_tag_id)
             else:
                 tag_ids.discard(patch.target_tag_id)
-
-        return list(tag_ids)
 
     # ------------------------------------------------------------------
     # Pattern E: Set union (簡易集約)

--- a/src/genai_tag_db_tools/db/repository.py
+++ b/src/genai_tag_db_tools/db/repository.py
@@ -3083,8 +3083,25 @@ class MergedTagReader:
             list[int]: unknownタイプのtag_idリスト。
         """
         tag_ids: set[int] = set()
-        for repo in self._iter_repos():
+        for repo in self._iter_base_repos():
             tag_ids |= set(repo.get_unknown_type_tag_ids(format_id))
+
+        if not self._has_user():
+            return list(tag_ids)
+
+        assert self.user_repo is not None
+        patched_statuses = {
+            status.tag_id: status
+            for status in self.user_repo.list_tag_statuses()
+            if status.format_id == format_id
+        }
+        for tag_id, status in patched_statuses.items():
+            type_name = self.get_type_name_by_format_type_id(format_id, status.type_id)
+            if type_name == "unknown":
+                tag_ids.add(tag_id)
+            else:
+                tag_ids.discard(tag_id)
+
         return list(tag_ids)
 
     # ------------------------------------------------------------------

--- a/src/genai_tag_db_tools/db/repository.py
+++ b/src/genai_tag_db_tools/db/repository.py
@@ -3095,7 +3095,7 @@ class MergedTagReader:
             for status in self.user_repo.list_tag_statuses()
             if status.format_id == format_id
         }
-        unknown_type_id = self.get_type_id_for_format("unknown", format_id)
+        unknown_type_id = self.user_repo.get_type_id_for_format("unknown", format_id)
         for tag_id, status in patched_statuses.items():
             if unknown_type_id is not None and status.type_id == unknown_type_id:
                 tag_ids.add(tag_id)

--- a/src/genai_tag_db_tools/db/schema.py
+++ b/src/genai_tag_db_tools/db/schema.py
@@ -276,6 +276,31 @@ class UserTagStatusPatch(UserOverlayBase):
     )
 
 
+class UserTagTypePatch(UserOverlayBase):
+    """base / user タグへの type 補正パッチ。
+
+    USER_TAG_STATUS_PATCH は alias / preferred / deprecated などの status 補正を持つ。
+    type 補正は status-only patch と区別できるよう、この表で明示的に管理する。
+    """
+
+    __tablename__ = "USER_TAG_TYPE_PATCH"
+
+    target_scope: Mapped[str] = mapped_column(primary_key=True)
+    target_tag_id: Mapped[int] = mapped_column(primary_key=True)
+    format_id: Mapped[int] = mapped_column(primary_key=True)
+    type_id: Mapped[int] = mapped_column()
+    created_at: Mapped[datetime | None] = mapped_column(DateTime, server_default=func.now(), nullable=True)
+    updated_at: Mapped[datetime | None] = mapped_column(DateTime, server_default=func.now(), nullable=True)
+
+    __table_args__ = (
+        CheckConstraint(
+            "target_scope IN ('base', 'user')",
+            name="ck_type_patch_target_scope",
+        ),
+        Index("ix_type_patch_target", "target_scope", "target_tag_id"),
+    )
+
+
 class UserTagTranslationPatch(UserOverlayBase):
     """base / user タグへの翻訳パッチ。
     TAG_TRANSLATIONS の FK なし版。target_scope + target_tag_id で対象タグを指定する。

--- a/src/genai_tag_db_tools/db/user_db_migration.py
+++ b/src/genai_tag_db_tools/db/user_db_migration.py
@@ -296,6 +296,22 @@ def migrate_legacy_to_overlay(
                         "updated_at": updated_at,
                     },
                 )
+                session.execute(
+                    text(
+                        "INSERT OR IGNORE INTO USER_TAG_TYPE_PATCH "
+                        "(target_scope, target_tag_id, format_id, type_id, created_at, updated_at) "
+                        "VALUES (:target_scope, :target_tag_id, :format_id, :type_id, "
+                        ":created_at, :updated_at)"
+                    ),
+                    {
+                        "target_scope": target_scope,
+                        "target_tag_id": target_tag_id,
+                        "format_id": format_id,
+                        "type_id": type_id,
+                        "created_at": created_at,
+                        "updated_at": updated_at,
+                    },
+                )
         result.status_migrated = len(old_statuses)
 
         # --- TAG_TRANSLATIONS → USER_TAG_TRANSLATION_PATCH ---

--- a/src/genai_tag_db_tools/db/user_tag_repository.py
+++ b/src/genai_tag_db_tools/db/user_tag_repository.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from logging import getLogger
+from typing import Any, cast
 
-from sqlalchemy import func
+from sqlalchemy import func, inspect
 from sqlalchemy.orm import Session
 
 from genai_tag_db_tools.db.schema import (
@@ -133,6 +134,7 @@ class UserTagRepository:
     ) -> None:
         """USER_TAG_TYPE_PATCH に type 補正を INSERT or UPDATE する。"""
         with self._session_factory() as session:
+            self._ensure_type_patch_table(session)
             existing = (
                 session.query(UserTagTypePatch)
                 .filter(
@@ -156,6 +158,12 @@ class UserTagRepository:
                 )
 
             session.commit()
+
+    @staticmethod
+    def _ensure_type_patch_table(session: Session) -> None:
+        bind = session.get_bind()
+        if not inspect(bind).has_table("USER_TAG_TYPE_PATCH"):
+            cast(Any, UserTagTypePatch.__table__).create(bind, checkfirst=True)
 
     def write_translation_preference(
         self, target_scope: str, target_tag_id: int, language: str, translation: str

--- a/src/genai_tag_db_tools/db/user_tag_repository.py
+++ b/src/genai_tag_db_tools/db/user_tag_repository.py
@@ -17,6 +17,7 @@ from genai_tag_db_tools.db.schema import (
     UserTagTranslationPatch,
     UserTagTranslationPreference,
     UserTagTranslationTombstone,
+    UserTagTypePatch,
     UserTagUsagePatch,
 )
 
@@ -120,6 +121,39 @@ class UserTagRepository:
                     deprecated=deprecated,
                 )
                 session.add(patch)
+
+            session.commit()
+
+    def write_type_patch(
+        self,
+        target_scope: str,
+        target_tag_id: int,
+        format_id: int,
+        type_id: int,
+    ) -> None:
+        """USER_TAG_TYPE_PATCH に type 補正を INSERT or UPDATE する。"""
+        with self._session_factory() as session:
+            existing = (
+                session.query(UserTagTypePatch)
+                .filter(
+                    UserTagTypePatch.target_scope == target_scope,
+                    UserTagTypePatch.target_tag_id == target_tag_id,
+                    UserTagTypePatch.format_id == format_id,
+                )
+                .one_or_none()
+            )
+
+            if existing is not None:
+                existing.type_id = type_id
+            else:
+                session.add(
+                    UserTagTypePatch(
+                        target_scope=target_scope,
+                        target_tag_id=target_tag_id,
+                        format_id=format_id,
+                        type_id=type_id,
+                    )
+                )
 
             session.commit()
 
@@ -510,6 +544,32 @@ class UserTagRepository:
                 preferred_tag_id=row.preferred_tag_id,
                 deprecated=row.deprecated,
                 deprecated_at=row.deprecated_at,
+            )
+
+    def get_type_patch(
+        self,
+        target_scope: str,
+        target_tag_id: int,
+        format_id: int,
+    ) -> UserTagTypePatch | None:
+        """既存の type patch を detached 風に返す。"""
+        with self._session_factory() as session:
+            row = (
+                session.query(UserTagTypePatch)
+                .filter(
+                    UserTagTypePatch.target_scope == target_scope,
+                    UserTagTypePatch.target_tag_id == target_tag_id,
+                    UserTagTypePatch.format_id == format_id,
+                )
+                .one_or_none()
+            )
+            if row is None:
+                return None
+            return UserTagTypePatch(
+                target_scope=row.target_scope,
+                target_tag_id=row.target_tag_id,
+                format_id=row.format_id,
+                type_id=row.type_id,
             )
 
     def has_applied_feedback(self, proposal_hash: str) -> bool:

--- a/src/genai_tag_db_tools/services/feedback_apply.py
+++ b/src/genai_tag_db_tools/services/feedback_apply.py
@@ -184,16 +184,12 @@ class LocalFeedbackApplyService:
         return target, format_id, status, proposed
 
     def _apply_type(self, proposal: DbFeedbackProposal) -> None:
-        target, format_id, type_id, status = self._prepare_type(proposal, create=True)
-        self._user_repository.write_patch(
+        target, format_id, type_id, _status = self._prepare_type(proposal, create=True)
+        self._user_repository.write_type_patch(
             target_scope=target.target_scope,
             target_tag_id=target.target_tag_id,
             format_id=format_id,
             type_id=type_id,
-            alias=status["alias"],
-            preferred_scope=status["preferred_scope"],
-            preferred_tag_id=status["preferred_tag_id"],
-            deprecated=status["deprecated"],
         )
 
     def _prepare_type(

--- a/tests/unit/test_feedback_apply.py
+++ b/tests/unit/test_feedback_apply.py
@@ -17,6 +17,7 @@ from genai_tag_db_tools.db.schema import (
     UserTag,
     UserTagStatusPatch,
     UserTagTranslationPatch,
+    UserTagTypePatch,
     UserTagUsagePatch,
 )
 from genai_tag_db_tools.db.user_tag_repository import UserTagRepository
@@ -270,10 +271,12 @@ def test_type_correction_preserves_existing_status_fields(user_repo, user_sessio
     apply_approved_feedback(_approved(proposal), user_repository=user_repo)
 
     with user_session_factory() as session:
-        patch = session.query(UserTagStatusPatch).one()
-        assert patch.type_id == 4
-        assert patch.deprecated is True
-        assert patch.alias is False
+        status_patch = session.query(UserTagStatusPatch).one()
+        type_patch = session.query(UserTagTypePatch).one()
+        assert status_patch.type_id == 0
+        assert status_patch.deprecated is True
+        assert status_patch.alias is False
+        assert type_patch.type_id == 4
         mapping = session.query(TagTypeFormatMapping).filter_by(format_id=format_id, type_id=4).one()
         assert mapping is not None
 
@@ -312,7 +315,7 @@ def test_type_correction_accepts_type_id_without_unknown_type_name(user_repo, us
     apply_approved_feedback(_approved(proposal), user_repository=user_repo)
 
     with user_session_factory() as session:
-        patch = session.query(UserTagStatusPatch).one()
+        patch = session.query(UserTagTypePatch).one()
         mappings = session.query(TagTypeFormatMapping).all()
     assert patch.format_id == format_id
     assert patch.type_id == 4
@@ -387,14 +390,11 @@ def test_type_correction_uses_reader_type_and_preserves_reader_status(
     )
 
     with user_session_factory() as session:
-        patch = session.query(UserTagStatusPatch).one()
+        patch = session.query(UserTagTypePatch).one()
+        assert session.query(UserTagStatusPatch).count() == 0
         assert session.query(TagTypeFormatMapping).count() == 0
     assert patch.format_id == 1
     assert patch.type_id == 4
-    assert patch.alias is True
-    assert patch.preferred_scope == "base"
-    assert patch.preferred_tag_id == 99
-    assert patch.deprecated is True
 
 
 def test_alias_addition_creates_user_alias_without_copying_preferred_base_tag(
@@ -492,7 +492,8 @@ def test_user_scope_type_correction_uses_reader_type_for_base_format(user_repo, 
     apply_approved_feedback(_approved(proposal), user_repository=user_repo, reader=_ReaderWithBaseFormats())
 
     with user_session_factory() as session:
-        patch = session.query(UserTagStatusPatch).one()
+        patch = session.query(UserTagTypePatch).one()
+        assert session.query(UserTagStatusPatch).count() == 0
         assert session.query(TagTypeFormatMapping).count() == 0
     assert patch.format_id == 1
     assert patch.type_id == 4

--- a/tests/unit/test_overlay_reader.py
+++ b/tests/unit/test_overlay_reader.py
@@ -23,6 +23,7 @@ from genai_tag_db_tools.db.schema import (
     UserTag,
     UserTagStatusPatch,
     UserTagTranslationPatch,
+    UserTagTypePatch,
     UserTagUsagePatch,
 )
 from genai_tag_db_tools.models import TagSearchRow
@@ -940,15 +941,11 @@ class TestOverlayTagReaderTypeMethods:
             self._seed_types(session)
             session.add(UserTag(tag_id=unknown_id, source_tag="m_src", tag="merged unknown"))
             session.add(
-                UserTagStatusPatch(
+                UserTagTypePatch(
                     target_scope="user",
                     target_tag_id=unknown_id,
                     format_id=3001,
                     type_id=7,
-                    alias=False,
-                    preferred_scope="user",
-                    preferred_tag_id=unknown_id,
-                    deprecated=False,
                 )
             )
             session.commit()

--- a/tests/unit/test_overlay_reader.py
+++ b/tests/unit/test_overlay_reader.py
@@ -720,6 +720,34 @@ class TestOverlayTagReaderSearchFilters:
         assert {r["tag_id"] for r in rows} == {char_id}
         assert rows[0]["type_name"] == "character"
 
+    def test_type_names_filter_uses_type_patch_without_status_patch(
+        self, overlay_reader, overlay_session_factory
+    ):
+        tag_id = USER_TAG_ID_OFFSET + 419
+        with overlay_session_factory() as session:
+            session.add(TagFormat(format_id=1000, format_name="danbooru"))
+            session.add(TagTypeName(type_name_id=1, type_name="unknown"))
+            session.add(TagTypeName(type_name_id=4, type_name="character"))
+            session.add(TagTypeFormatMapping(format_id=1000, type_id=0, type_name_id=1))
+            session.add(TagTypeFormatMapping(format_id=1000, type_id=4, type_name_id=4))
+            session.add(UserTag(tag_id=tag_id, source_tag="tp_src", tag="typepatch character"))
+            session.add(
+                UserTagTypePatch(
+                    target_scope="user",
+                    target_tag_id=tag_id,
+                    format_id=1000,
+                    type_id=4,
+                )
+            )
+            session.commit()
+
+        rows = overlay_reader.search_tags("typepatch", partial=True, type_names=["character"])
+
+        assert {row["tag_id"] for row in rows} == {tag_id}
+        assert rows[0]["type_id"] == 4
+        assert rows[0]["type_name"] == "character"
+        assert rows[0]["format_statuses"]["1000"]["type_name"] == "character"
+
     def test_type_names_unknown_returns_empty(self, overlay_reader, overlay_session_factory):
         tag_id = USER_TAG_ID_OFFSET + 418
         with overlay_session_factory() as session:

--- a/tests/unit/test_overlay_reader.py
+++ b/tests/unit/test_overlay_reader.py
@@ -219,6 +219,25 @@ class TestOverlayTagReaderStatus:
         statuses = overlay_reader.list_tag_statuses(tag_id=tag_id)
         assert statuses == []
 
+    def test_type_patch_reads_tolerate_missing_type_patch_table(
+        self, overlay_reader, overlay_session_factory
+    ):
+        tag_id = USER_TAG_ID_OFFSET + 240
+        with overlay_session_factory() as session:
+            session.add(UserTag(tag_id=tag_id, source_tag="legacy", tag="legacy_status_tag"))
+            session.add(self._make_patch(tag_id, 1000))
+            UserTagTypePatch.__table__.drop(session.get_bind())
+            session.commit()
+
+        status = overlay_reader.get_tag_status(tag_id, 1000)
+        statuses = overlay_reader.list_tag_statuses(tag_id=tag_id)
+        type_patches = overlay_reader.list_tag_type_patches(tag_id=tag_id)
+
+        assert status is not None
+        assert status.tag_id == tag_id
+        assert [row.tag_id for row in statuses] == [tag_id]
+        assert type_patches == []
+
 
 class TestOverlayTagReaderSearch:
     """search_tags のキーワードヒット動作を検証する。"""

--- a/tests/unit/test_tag_repository.py
+++ b/tests/unit/test_tag_repository.py
@@ -368,6 +368,60 @@ def test_type_patch_overrides_only_type_and_preserves_base_status_fields() -> No
     assert status.deprecated is True
 
 
+def test_user_only_overlay_unknown_type_ids_apply_type_patch() -> None:
+    """OverlayTagReader を base_repo として単独利用しても type patch を unknown 一覧へ反映する。"""
+
+    user_factory = _memory_session_factory(overlay=True)
+    user_reader = OverlayTagReader(user_factory)
+    merged_reader = MergedTagReader(base_repo=user_reader)
+
+    tag_id = 1_000_000_100
+    with user_factory() as session:
+        session.add(TagFormat(format_id=1000, format_name="Lorairo"))
+        session.add(TagTypeName(type_name_id=1, type_name="unknown"))
+        session.add(TagTypeName(type_name_id=2, type_name="character"))
+        session.add(TagTypeFormatMapping(format_id=1000, type_id=0, type_name_id=1))
+        session.add(TagTypeFormatMapping(format_id=1000, type_id=1, type_name_id=2))
+        session.add(UserTagTypePatch(target_scope="user", target_tag_id=tag_id, format_id=1000, type_id=1))
+        session.add(
+            UserTagStatusPatch(
+                target_scope="user",
+                target_tag_id=tag_id,
+                format_id=1000,
+                type_id=0,
+                alias=False,
+                preferred_scope="user",
+                preferred_tag_id=tag_id,
+                deprecated=False,
+            )
+        )
+        session.commit()
+
+    assert merged_reader.get_unknown_type_tag_ids(format_id=1000) == []
+
+
+def test_plain_user_repo_status_merge_remains_supported() -> None:
+    """user_repo が plain TagReader でも list_tag_statuses / get_tag_status が動く。"""
+
+    base_factory = _memory_session_factory()
+    user_factory = _memory_session_factory()
+    base_reader = TagReader(base_factory)
+    user_reader = TagReader(user_factory)
+    merged_reader = MergedTagReader(base_repo=base_reader, user_repo=user_reader)
+
+    tag_id = 42
+    with user_factory() as session:
+        session.add(TagFormat(format_id=1000, format_name="Lorairo"))
+        session.add(Tag(tag_id=tag_id, tag="legacy_user", source_tag="Legacy User"))
+        session.add(TagStatus(tag_id=tag_id, format_id=1000, type_id=3, alias=False, preferred_tag_id=tag_id))
+        session.commit()
+
+    status = merged_reader.get_tag_status(tag_id, 1000)
+
+    assert status is not None
+    assert status.type_id == 3
+
+
 def test_create_tag_returns_existing_id(session_factory: Callable[[], Session]) -> None:
     reader = TagReader(session_factory)
     repo = TagRepository(session_factory, reader=MergedTagReader(base_repo=reader))

--- a/tests/unit/test_tag_repository.py
+++ b/tests/unit/test_tag_repository.py
@@ -264,6 +264,42 @@ def test_merged_unknown_type_ids_classify_overlay_patch_with_user_type_mapping_o
     assert merged_reader.get_unknown_type_tag_ids(format_id=1000) == []
 
 
+def test_merged_unknown_type_ids_preserve_base_unknown_for_status_only_overlay_patch() -> None:
+    """user type mapping の無い status-only patch は base unknown 判定を維持する。"""
+
+    base_factory = _memory_session_factory()
+    user_factory = _memory_session_factory(overlay=True)
+    base_reader = TagReader(base_factory)
+    user_reader = OverlayTagReader(user_factory)
+    merged_reader = MergedTagReader(base_repo=base_reader, user_repo=user_reader)
+
+    tag_id = 197275
+    with base_factory() as session:
+        session.add(TagFormat(format_id=1000, format_name="Lorairo"))
+        session.add(TagTypeName(type_name_id=1, type_name="unknown"))
+        session.add(TagTypeFormatMapping(format_id=1000, type_id=0, type_name_id=1))
+        session.add(Tag(tag_id=tag_id, tag="status_only_unknown", source_tag="Status Only Unknown"))
+        session.add(TagStatus(tag_id=tag_id, format_id=1000, type_id=0, alias=False, preferred_tag_id=tag_id))
+        session.commit()
+
+    with user_factory() as session:
+        session.add(
+            UserTagStatusPatch(
+                target_scope="base",
+                target_tag_id=tag_id,
+                format_id=1000,
+                type_id=0,
+                alias=False,
+                preferred_scope="base",
+                preferred_tag_id=tag_id,
+                deprecated=True,
+            )
+        )
+        session.commit()
+
+    assert merged_reader.get_unknown_type_tag_ids(format_id=1000) == [tag_id]
+
+
 def test_create_tag_returns_existing_id(session_factory: Callable[[], Session]) -> None:
     reader = TagReader(session_factory)
     repo = TagRepository(session_factory, reader=MergedTagReader(base_repo=reader))

--- a/tests/unit/test_tag_repository.py
+++ b/tests/unit/test_tag_repository.py
@@ -180,6 +180,46 @@ def test_update_tags_type_batch_rolls_back_overlay_patch_when_batch_fails(
         assert session.query(UserTagTypePatch).all() == []
 
 
+def test_update_tags_type_batch_creates_missing_type_patch_table_for_old_overlay_db() -> None:
+    """旧 overlay DB に USER_TAG_TYPE_PATCH が無くても type patch 書き込み前に作成する。"""
+    from genai_tag_db_tools.models import TagTypeUpdate
+
+    base_factory = _memory_session_factory()
+    user_factory = _memory_session_factory(overlay=True)
+    base_reader = TagReader(base_factory)
+    user_reader = OverlayTagReader(user_factory)
+    merged_reader = MergedTagReader(base_repo=base_reader, user_repo=user_reader)
+    repo = TagRepository(user_factory, reader=merged_reader)
+
+    base_tag_id = 197279
+    with base_factory() as session:
+        session.add(TagFormat(format_id=1000, format_name="Lorairo"))
+        session.add(TagTypeName(type_name_id=1, type_name="general"))
+        session.add(TagTypeFormatMapping(format_id=1000, type_id=0, type_name_id=1))
+        session.add(Tag(tag_id=base_tag_id, tag="old_overlay_tag", source_tag="Old Overlay Tag"))
+        session.add(
+            TagStatus(
+                tag_id=base_tag_id,
+                format_id=1000,
+                type_id=0,
+                alias=False,
+                preferred_tag_id=base_tag_id,
+            )
+        )
+        session.commit()
+
+    with user_factory() as session:
+        UserTagTypePatch.__table__.drop(session.get_bind())
+        session.commit()
+
+    repo.update_tags_type_batch([TagTypeUpdate(tag_id=base_tag_id, type_name="general")], format_id=1000)
+
+    with user_factory() as session:
+        patch = session.query(UserTagTypePatch).one()
+
+    assert patch.target_tag_id == base_tag_id
+
+
 def test_merged_unknown_type_ids_use_overlay_status_as_effective_status() -> None:
     """user overlay で type 補正済みの base tag は unknown 一覧から除外する。"""
 
@@ -254,6 +294,33 @@ def test_merged_unknown_type_ids_classify_explicit_type_patch_with_user_type_map
         session.commit()
 
     assert merged_reader.get_unknown_type_tag_ids(format_id=1000) == []
+
+
+def test_merged_unknown_type_ids_classify_type_patch_with_base_type_mapping_fallback() -> None:
+    """user mapping が無い type patch は reader/base 側の type_id で unknown 判定する。"""
+
+    base_factory = _memory_session_factory()
+    user_factory = _memory_session_factory(overlay=True)
+    base_reader = TagReader(base_factory)
+    user_reader = OverlayTagReader(user_factory)
+    merged_reader = MergedTagReader(base_repo=base_reader, user_repo=user_reader)
+
+    tag_id = 197280
+    with base_factory() as session:
+        session.add(TagFormat(format_id=1000, format_name="Lorairo"))
+        session.add(TagTypeName(type_name_id=1, type_name="unknown"))
+        session.add(TagTypeName(type_name_id=2, type_name="character"))
+        session.add(TagTypeFormatMapping(format_id=1000, type_id=0, type_name_id=1))
+        session.add(TagTypeFormatMapping(format_id=1000, type_id=1, type_name_id=2))
+        session.add(Tag(tag_id=tag_id, tag="base_character_tag", source_tag="Base Character Tag"))
+        session.add(TagStatus(tag_id=tag_id, format_id=1000, type_id=1, alias=False, preferred_tag_id=tag_id))
+        session.commit()
+
+    with user_factory() as session:
+        session.add(UserTagTypePatch(target_scope="base", target_tag_id=tag_id, format_id=1000, type_id=0))
+        session.commit()
+
+    assert merged_reader.get_unknown_type_tag_ids(format_id=1000) == [tag_id]
 
 
 def test_merged_unknown_type_ids_preserve_base_unknown_for_status_only_overlay_patch() -> None:
@@ -366,6 +433,51 @@ def test_type_patch_overrides_only_type_and_preserves_base_status_fields() -> No
     assert status.alias is True
     assert status.preferred_tag_id == preferred_id
     assert status.deprecated is True
+
+
+def test_type_patch_search_merge_preserves_base_alias_fields() -> None:
+    """検索 merge でも type-only patch は base alias / preferred / deprecated を shadow しない。"""
+
+    base_factory = _memory_session_factory()
+    user_factory = _memory_session_factory(overlay=True)
+    base_reader = TagReader(base_factory)
+    user_reader = OverlayTagReader(user_factory)
+    merged_reader = MergedTagReader(base_repo=base_reader, user_repo=user_reader)
+
+    alias_id = 197281
+    preferred_id = 197282
+    with base_factory() as session:
+        session.add(TagFormat(format_id=1000, format_name="Lorairo"))
+        session.add(TagTypeName(type_name_id=1, type_name="general"))
+        session.add(TagTypeName(type_name_id=2, type_name="character"))
+        session.add(TagTypeFormatMapping(format_id=1000, type_id=0, type_name_id=1))
+        session.add(TagTypeFormatMapping(format_id=1000, type_id=1, type_name_id=2))
+        session.add(Tag(tag_id=alias_id, tag="alias_search_tag", source_tag="Alias Search Tag"))
+        session.add(Tag(tag_id=preferred_id, tag="preferred_search_tag", source_tag="Preferred Search Tag"))
+        session.add(
+            TagStatus(
+                tag_id=alias_id,
+                format_id=1000,
+                type_id=0,
+                alias=True,
+                preferred_tag_id=preferred_id,
+                deprecated=True,
+            )
+        )
+        session.commit()
+
+    with user_factory() as session:
+        session.add(UserTagTypePatch(target_scope="base", target_tag_id=alias_id, format_id=1000, type_id=1))
+        session.commit()
+
+    rows = merged_reader.search_tags("alias_search_tag", format_name="Lorairo")
+
+    assert len(rows) == 1
+    assert rows[0]["alias"] is True
+    assert rows[0]["deprecated"] is True
+    assert rows[0]["type_id"] == 1
+    assert rows[0]["type_name"] == "character"
+    assert rows[0]["format_statuses"]["Lorairo"]["preferred_tag_id"] == preferred_id
 
 
 def test_user_only_overlay_unknown_type_ids_apply_type_patch() -> None:

--- a/tests/unit/test_tag_repository.py
+++ b/tests/unit/test_tag_repository.py
@@ -180,6 +180,51 @@ def test_update_tags_type_batch_rolls_back_overlay_patch_when_batch_fails(
         assert session.query(UserTagStatusPatch).all() == []
 
 
+def test_merged_unknown_type_ids_use_overlay_status_as_effective_status() -> None:
+    """user overlay で type 補正済みの base tag は unknown 一覧から除外する。"""
+
+    base_factory = _memory_session_factory()
+    user_factory = _memory_session_factory(overlay=True)
+    base_reader = TagReader(base_factory)
+    user_reader = OverlayTagReader(user_factory)
+    merged_reader = MergedTagReader(base_repo=base_reader, user_repo=user_reader)
+
+    tag_id = 197273
+    with base_factory() as session:
+        session.add(TagFormat(format_id=1000, format_name="Lorairo"))
+        session.add(TagTypeName(type_name_id=1, type_name="unknown"))
+        session.add(TagTypeName(type_name_id=2, type_name="character"))
+        session.add(TagTypeFormatMapping(format_id=1000, type_id=0, type_name_id=1))
+        session.add(TagTypeFormatMapping(format_id=1000, type_id=1, type_name_id=2))
+        session.add(Tag(tag_id=tag_id, tag="base_unknown_tag", source_tag="Base Unknown Tag"))
+        session.add(TagStatus(tag_id=tag_id, format_id=1000, type_id=0, alias=False, preferred_tag_id=tag_id))
+        session.commit()
+
+    assert merged_reader.get_unknown_type_tag_ids(format_id=1000) == [tag_id]
+
+    with user_factory() as session:
+        session.add(TagFormat(format_id=1000, format_name="Lorairo"))
+        session.add(TagTypeName(type_name_id=1, type_name="unknown"))
+        session.add(TagTypeName(type_name_id=2, type_name="character"))
+        session.add(TagTypeFormatMapping(format_id=1000, type_id=0, type_name_id=1))
+        session.add(TagTypeFormatMapping(format_id=1000, type_id=1, type_name_id=2))
+        session.add(
+            UserTagStatusPatch(
+                target_scope="base",
+                target_tag_id=tag_id,
+                format_id=1000,
+                type_id=1,
+                alias=False,
+                preferred_scope="base",
+                preferred_tag_id=tag_id,
+                deprecated=False,
+            )
+        )
+        session.commit()
+
+    assert merged_reader.get_unknown_type_tag_ids(format_id=1000) == []
+
+
 def test_create_tag_returns_existing_id(session_factory: Callable[[], Session]) -> None:
     reader = TagReader(session_factory)
     repo = TagRepository(session_factory, reader=MergedTagReader(base_repo=reader))

--- a/tests/unit/test_tag_repository.py
+++ b/tests/unit/test_tag_repository.py
@@ -480,6 +480,51 @@ def test_type_patch_search_merge_preserves_base_alias_fields() -> None:
     assert rows[0]["format_statuses"]["Lorairo"]["preferred_tag_id"] == preferred_id
 
 
+def test_type_patch_search_merge_defaults_status_fields_for_type_only_requested_format() -> None:
+    """requested format が type-only patch だけなら row-level status はその format の初期値にする。"""
+
+    base_factory = _memory_session_factory()
+    user_factory = _memory_session_factory(overlay=True)
+    base_reader = TagReader(base_factory)
+    user_reader = OverlayTagReader(user_factory)
+    merged_reader = MergedTagReader(base_repo=base_reader, user_repo=user_reader)
+
+    tag_id = 197283
+    preferred_id = 197284
+    with base_factory() as session:
+        session.add(TagFormat(format_id=1, format_name="danbooru"))
+        session.add(TagFormat(format_id=1000, format_name="Lorairo"))
+        session.add(TagTypeName(type_name_id=1, type_name="general"))
+        session.add(TagTypeName(type_name_id=2, type_name="character"))
+        session.add(TagTypeFormatMapping(format_id=1, type_id=0, type_name_id=1))
+        session.add(TagTypeFormatMapping(format_id=1000, type_id=1, type_name_id=2))
+        session.add(Tag(tag_id=tag_id, tag="type_only_requested", source_tag="Type Only Requested"))
+        session.add(Tag(tag_id=preferred_id, tag="preferred_requested", source_tag="Preferred Requested"))
+        session.add(
+            TagStatus(
+                tag_id=tag_id,
+                format_id=1,
+                type_id=0,
+                alias=True,
+                preferred_tag_id=preferred_id,
+                deprecated=True,
+            )
+        )
+        session.commit()
+
+    with user_factory() as session:
+        session.add(UserTagTypePatch(target_scope="base", target_tag_id=tag_id, format_id=1000, type_id=1))
+        session.commit()
+
+    rows = merged_reader.search_tags("type_only_requested", format_name="Lorairo")
+
+    assert len(rows) == 1
+    assert rows[0]["alias"] is False
+    assert rows[0]["deprecated"] is False
+    assert rows[0]["type_name"] == "character"
+    assert rows[0]["format_statuses"]["Lorairo"]["preferred_tag_id"] == tag_id
+
+
 def test_user_only_overlay_unknown_type_ids_apply_type_patch() -> None:
     """OverlayTagReader を base_repo として単独利用しても type patch を unknown 一覧へ反映する。"""
 

--- a/tests/unit/test_tag_repository.py
+++ b/tests/unit/test_tag_repository.py
@@ -300,6 +300,27 @@ def test_merged_unknown_type_ids_preserve_base_unknown_for_status_only_overlay_p
     assert merged_reader.get_unknown_type_tag_ids(format_id=1000) == [tag_id]
 
 
+def test_merged_unknown_type_ids_tolerates_user_db_without_overlay_status_table() -> None:
+    """旧 user DB で USER_TAG_STATUS_PATCH が無くても base unknown を返す。"""
+
+    base_factory = _memory_session_factory()
+    user_factory = _memory_session_factory(overlay=False)
+    base_reader = TagReader(base_factory)
+    user_reader = OverlayTagReader(user_factory)
+    merged_reader = MergedTagReader(base_repo=base_reader, user_repo=user_reader)
+
+    tag_id = 197276
+    with base_factory() as session:
+        session.add(TagFormat(format_id=1000, format_name="Lorairo"))
+        session.add(TagTypeName(type_name_id=1, type_name="unknown"))
+        session.add(TagTypeFormatMapping(format_id=1000, type_id=0, type_name_id=1))
+        session.add(Tag(tag_id=tag_id, tag="legacy_user_db_unknown", source_tag="Legacy User DB Unknown"))
+        session.add(TagStatus(tag_id=tag_id, format_id=1000, type_id=0, alias=False, preferred_tag_id=tag_id))
+        session.commit()
+
+    assert merged_reader.get_unknown_type_tag_ids(format_id=1000) == [tag_id]
+
+
 def test_create_tag_returns_existing_id(session_factory: Callable[[], Session]) -> None:
     reader = TagReader(session_factory)
     repo = TagRepository(session_factory, reader=MergedTagReader(base_repo=reader))

--- a/tests/unit/test_tag_repository.py
+++ b/tests/unit/test_tag_repository.py
@@ -225,6 +225,45 @@ def test_merged_unknown_type_ids_use_overlay_status_as_effective_status() -> Non
     assert merged_reader.get_unknown_type_tag_ids(format_id=1000) == []
 
 
+def test_merged_unknown_type_ids_classify_overlay_patch_with_user_type_mapping_only() -> None:
+    """overlay patch の type_id 判定で base 側 mapping へ fall back しない。"""
+
+    base_factory = _memory_session_factory()
+    user_factory = _memory_session_factory(overlay=True)
+    base_reader = TagReader(base_factory)
+    user_reader = OverlayTagReader(user_factory)
+    merged_reader = MergedTagReader(base_repo=base_reader, user_repo=user_reader)
+
+    tag_id = 197274
+    with base_factory() as session:
+        session.add(TagFormat(format_id=1000, format_name="Lorairo"))
+        session.add(TagTypeName(type_name_id=1, type_name="unknown"))
+        session.add(TagTypeFormatMapping(format_id=1000, type_id=0, type_name_id=1))
+        session.add(Tag(tag_id=tag_id, tag="base_unknown_tag", source_tag="Base Unknown Tag"))
+        session.add(TagStatus(tag_id=tag_id, format_id=1000, type_id=0, alias=False, preferred_tag_id=tag_id))
+        session.commit()
+
+    with user_factory() as session:
+        session.add(TagFormat(format_id=1000, format_name="Lorairo"))
+        session.add(TagTypeName(type_name_id=2, type_name="general"))
+        session.add(TagTypeFormatMapping(format_id=1000, type_id=0, type_name_id=2))
+        session.add(
+            UserTagStatusPatch(
+                target_scope="base",
+                target_tag_id=tag_id,
+                format_id=1000,
+                type_id=0,
+                alias=False,
+                preferred_scope="base",
+                preferred_tag_id=tag_id,
+                deprecated=False,
+            )
+        )
+        session.commit()
+
+    assert merged_reader.get_unknown_type_tag_ids(format_id=1000) == []
+
+
 def test_create_tag_returns_existing_id(session_factory: Callable[[], Session]) -> None:
     reader = TagReader(session_factory)
     repo = TagRepository(session_factory, reader=MergedTagReader(base_repo=reader))

--- a/tests/unit/test_tag_repository.py
+++ b/tests/unit/test_tag_repository.py
@@ -21,6 +21,7 @@ from genai_tag_db_tools.db.schema import (
     TagUsageCounts,
     UserOverlayBase,
     UserTagStatusPatch,
+    UserTagTypePatch,
 )
 
 pytestmark = pytest.mark.db_tools
@@ -44,7 +45,7 @@ def session_factory() -> Callable[[], Session]:
 
 
 def test_update_tags_type_batch_writes_base_tag_type_overlay_patch() -> None:
-    """Base DB 由来タグの type 補正は USER_TAG_STATUS_PATCH に保存する (#1268/#136)。"""
+    """Base DB 由来タグの type 補正は USER_TAG_TYPE_PATCH に保存する (#1268/#136/#138)。"""
     from genai_tag_db_tools.models import TagTypeUpdate
 
     base_factory = _memory_session_factory()
@@ -79,12 +80,13 @@ def test_update_tags_type_batch_writes_base_tag_type_overlay_patch() -> None:
     with user_factory() as session:
         assert session.query(Tag).filter(Tag.tag_id == base_tag_id).one_or_none() is None
         assert session.query(TagStatus).filter(TagStatus.tag_id == base_tag_id).one_or_none() is None
+        assert session.query(UserTagStatusPatch).filter(UserTagStatusPatch.target_tag_id == base_tag_id).all() == []
         patch = (
-            session.query(UserTagStatusPatch)
+            session.query(UserTagTypePatch)
             .filter(
-                UserTagStatusPatch.target_scope == "base",
-                UserTagStatusPatch.target_tag_id == base_tag_id,
-                UserTagStatusPatch.format_id == 1000,
+                UserTagTypePatch.target_scope == "base",
+                UserTagTypePatch.target_tag_id == base_tag_id,
+                UserTagTypePatch.format_id == 1000,
             )
             .one()
         )
@@ -95,9 +97,6 @@ def test_update_tags_type_batch_writes_base_tag_type_overlay_patch() -> None:
             .scalar()
         )
 
-    assert patch.alias is False
-    assert patch.preferred_scope == "base"
-    assert patch.preferred_tag_id == base_tag_id
     assert type_name == "general"
 
     rows = merged_reader.search_tags("base_only_tag", format_name="Lorairo", type_name="general")
@@ -178,6 +177,7 @@ def test_update_tags_type_batch_rolls_back_overlay_patch_when_batch_fails(
 
     with user_factory() as session:
         assert session.query(UserTagStatusPatch).all() == []
+        assert session.query(UserTagTypePatch).all() == []
 
 
 def test_merged_unknown_type_ids_use_overlay_status_as_effective_status() -> None:
@@ -209,15 +209,11 @@ def test_merged_unknown_type_ids_use_overlay_status_as_effective_status() -> Non
         session.add(TagTypeFormatMapping(format_id=1000, type_id=0, type_name_id=1))
         session.add(TagTypeFormatMapping(format_id=1000, type_id=1, type_name_id=2))
         session.add(
-            UserTagStatusPatch(
+            UserTagTypePatch(
                 target_scope="base",
                 target_tag_id=tag_id,
                 format_id=1000,
                 type_id=1,
-                alias=False,
-                preferred_scope="base",
-                preferred_tag_id=tag_id,
-                deprecated=False,
             )
         )
         session.commit()
@@ -225,8 +221,8 @@ def test_merged_unknown_type_ids_use_overlay_status_as_effective_status() -> Non
     assert merged_reader.get_unknown_type_tag_ids(format_id=1000) == []
 
 
-def test_merged_unknown_type_ids_classify_overlay_patch_with_user_type_mapping_only() -> None:
-    """overlay patch の type_id 判定で base 側 mapping へ fall back しない。"""
+def test_merged_unknown_type_ids_classify_explicit_type_patch_with_user_type_mapping() -> None:
+    """明示 type patch は user type mapping で unknown 一覧から除外する。"""
 
     base_factory = _memory_session_factory()
     user_factory = _memory_session_factory(overlay=True)
@@ -248,15 +244,11 @@ def test_merged_unknown_type_ids_classify_overlay_patch_with_user_type_mapping_o
         session.add(TagTypeName(type_name_id=2, type_name="general"))
         session.add(TagTypeFormatMapping(format_id=1000, type_id=0, type_name_id=2))
         session.add(
-            UserTagStatusPatch(
+            UserTagTypePatch(
                 target_scope="base",
                 target_tag_id=tag_id,
                 format_id=1000,
                 type_id=0,
-                alias=False,
-                preferred_scope="base",
-                preferred_tag_id=tag_id,
-                deprecated=False,
             )
         )
         session.commit()
@@ -283,6 +275,9 @@ def test_merged_unknown_type_ids_preserve_base_unknown_for_status_only_overlay_p
         session.commit()
 
     with user_factory() as session:
+        session.add(TagFormat(format_id=1000, format_name="Lorairo"))
+        session.add(TagTypeName(type_name_id=2, type_name="general"))
+        session.add(TagTypeFormatMapping(format_id=1000, type_id=0, type_name_id=2))
         session.add(
             UserTagStatusPatch(
                 target_scope="base",
@@ -319,6 +314,58 @@ def test_merged_unknown_type_ids_tolerates_user_db_without_overlay_status_table(
         session.commit()
 
     assert merged_reader.get_unknown_type_tag_ids(format_id=1000) == [tag_id]
+
+
+def test_type_patch_overrides_only_type_and_preserves_base_status_fields() -> None:
+    """type-only patch は base の alias / preferred / deprecated を shadow しない。"""
+
+    base_factory = _memory_session_factory()
+    user_factory = _memory_session_factory(overlay=True)
+    base_reader = TagReader(base_factory)
+    user_reader = OverlayTagReader(user_factory)
+    merged_reader = MergedTagReader(base_repo=base_reader, user_repo=user_reader)
+
+    alias_id = 197277
+    preferred_id = 197278
+    with base_factory() as session:
+        session.add(TagFormat(format_id=1000, format_name="Lorairo"))
+        session.add(TagTypeName(type_name_id=1, type_name="unknown"))
+        session.add(TagTypeFormatMapping(format_id=1000, type_id=0, type_name_id=1))
+        session.add(Tag(tag_id=alias_id, tag="alias_tag", source_tag="Alias Tag"))
+        session.add(Tag(tag_id=preferred_id, tag="preferred_tag", source_tag="Preferred Tag"))
+        session.add(
+            TagStatus(
+                tag_id=alias_id,
+                format_id=1000,
+                type_id=0,
+                alias=True,
+                preferred_tag_id=preferred_id,
+                deprecated=True,
+            )
+        )
+        session.commit()
+
+    with user_factory() as session:
+        session.add(TagFormat(format_id=1000, format_name="Lorairo"))
+        session.add(TagTypeName(type_name_id=2, type_name="character"))
+        session.add(TagTypeFormatMapping(format_id=1000, type_id=1, type_name_id=2))
+        session.add(
+            UserTagTypePatch(
+                target_scope="base",
+                target_tag_id=alias_id,
+                format_id=1000,
+                type_id=1,
+            )
+        )
+        session.commit()
+
+    status = merged_reader.get_tag_status(alias_id, 1000)
+
+    assert status is not None
+    assert status.type_id == 1
+    assert status.alias is True
+    assert status.preferred_tag_id == preferred_id
+    assert status.deprecated is True
 
 
 def test_create_tag_returns_existing_id(session_factory: Callable[[], Session]) -> None:


### PR DESCRIPTION
## Summary
- Make MergedTagReader.get_unknown_type_tag_ids use user overlay status patches as the effective status
- Remove base/legacy unknown IDs when a user overlay patch changes that tag to a non-unknown type
- Add regression coverage for the LoRAIro tag-management flow found while validating NEXTAltair/LoRAIro#1270

## Verification
- `UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run pytest tests/unit/test_tag_repository.py -q`
- `UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run ruff check src/genai_tag_db_tools/db/repository.py tests/unit/test_tag_repository.py`
- `UV_PROJECT_ENVIRONMENT=/workspaces/LoRAIro/.venv uv run pytest tests/integration/test_overlay_tag_e2e.py -q` from LoRAIro worktree

Related to #136.