### PR TITLE
fix(db): 翻訳の完全一致を case-sensitive にして全表スキャンを撤去 (#139)

### DIFF
--- a/src/genai_tag_db_tools/db/query_utils.py
+++ b/src/genai_tag_db_tools/db/query_utils.py
@@ -1,4 +1,3 @@
-import re
 import string
 import weakref
 from logging import Logger
@@ -37,9 +36,6 @@ TAG_ID_IN_CHUNK = 900
 # SQLite の lower() / COLLATE NOCASE は ASCII A-Z のみ折り畳む。Python 側で
 # 同じ照合を再現するための変換テーブル (str.lower は Unicode 全体を畳むため不一致)。
 _ASCII_LOWER_TABLE = str.maketrans(string.ascii_uppercase, string.ascii_lowercase)
-
-# ASCII 小文字を含むか (大文字混じり行の lower() 済み値と一致し得るか) の判定
-_HAS_ASCII_LOWER_RE = re.compile(r"[a-z]")
 
 # TAGS の「ASCII 小文字化で不変でない」例外行のキャッシュ (engine 単位)。
 # base DB (数百万行) は runtime 中は不変で、例外行は全体の 0.01% 未満なので、
@@ -118,11 +114,12 @@ class TagSearchQueryBuilder:
         limit: int | None = None,
         offset: int = 0,
     ) -> set[int]:
-        # 完全一致 (use_like=False) は COLLATE NOCASE 相当の照合を index 活用経路で行う
-        # (LoRAIro #1203/#1206: NOCASE 比較は index を使えず数百万行の全表スキャンになる)。
+        # 完全一致 (use_like=False) は index 活用経路で照合する (LoRAIro #1203/#1206:
+        # NOCASE 比較は index を使えず数百万行の全表スキャンになる)。TAGS は大小を無視し、
+        # 翻訳は大小を区別する (Issue #139)。
         # LIKE は SQLite 既定で ASCII 大文字小文字を無視するため挙動は変えない。
         if not use_like:
-            ids = sorted(self._exact_match_tag_ids({sqlite_ascii_lower(keyword)}))
+            ids = sorted(self._exact_match_tag_ids(keyword))
             # ページングを決定的にするため tag_id 昇順で offset/limit を適用する (従来の
             # UNION + order_by と同じ意味論)。
             if offset:
@@ -182,10 +179,17 @@ class TagSearchQueryBuilder:
                 rows.append((tag_id, tag, source_tag))
         return rows
 
-    def _exact_match_tag_ids(self, match_keys: set[str]) -> set[int]:
-        """`_exact_match_tag_rows` + 翻訳一致の tag_id 集合版 (単一 keyword の完全一致用)。"""
-        ids = {row[0] for row in self._exact_match_tag_rows(match_keys)}
-        ids.update(row[0] for row in self._exact_match_translation_rows(match_keys))
+    def _exact_match_tag_ids(self, keyword: str) -> set[int]:
+        """単一 keyword の完全一致で tag_id 集合を返す。
+
+        TAGS は canonical 化されている (実質すべて小文字) ため大小を無視して照合するが、
+        翻訳は大小を区別する (Issue #139: `Aiki` と `aiki` は別タグ)。
+
+        Args:
+            keyword: 生の検索キーワード (小文字化前)。
+        """
+        ids = {row[0] for row in self._exact_match_tag_rows({sqlite_ascii_lower(keyword)})}
+        ids.update(row[0] for row in self._exact_match_translation_rows({keyword}))
         return ids
 
     def _case_exceptional_tag_rows(self) -> list[tuple[int, str | None, str | None]]:
@@ -207,32 +211,25 @@ class TagSearchQueryBuilder:
         return cached
 
     def _exact_match_translation_rows(self, match_keys: set[str]) -> list[tuple[int, str | None]]:
-        """ASCII 小文字化済みキーに case-insensitive 完全一致する翻訳行を返す。
+        """キーに完全一致する翻訳行を返す (大文字小文字を区別する、Issue #139)。
 
-        index が効く完全一致 IN で小文字行を取り、大文字混じり行は
-        `translation <> lower(translation)` で絞った narrow スキャンで補完する
-        (TAG_TRANSLATIONS は TAGS より十分小さく、このスキャンは実測 0.1 秒台)。
-        キーが ASCII 小文字を 1 つも含まない場合 (CJK のみ等)、大文字混じり行の
-        lower() 済み値と一致し得ないため narrow スキャンを省略する。
+        翻訳は TAGS と違い canonical 化されておらず、`Aiki` と `aiki` のように大小のみが
+        異なる表記が別タグを指す (base DB 実測で 358 組)。小文字化して照合すると誤った
+        tag_id を返しうるため、`translation` の binary 一致のみで照合する。
+
+        Args:
+            match_keys: 照合キー (小文字化しない生の文字列)。
+
+        Returns:
+            (tag_id, translation) のリスト。
         """
         if not match_keys:
             return []
-        keys = list(match_keys)
-        rows: list[tuple[int, str | None]] = list(
+        return list(
             self.session.query(TagTranslation.tag_id, TagTranslation.translation)
-            .filter(TagTranslation.translation.in_(keys))
+            .filter(TagTranslation.translation.in_(list(match_keys)))
             .all()
         )
-        if any(_HAS_ASCII_LOWER_RE.search(key) for key in keys):
-            rows.extend(
-                self.session.query(TagTranslation.tag_id, TagTranslation.translation)
-                .filter(
-                    TagTranslation.translation != func.lower(TagTranslation.translation),
-                    func.lower(TagTranslation.translation).in_(keys),
-                )
-                .all()
-            )
-        return rows
 
     def filtered_tag_ids(
         self,
@@ -273,7 +270,7 @@ class TagSearchQueryBuilder:
             query = self.session.query(tag_id_column)
         else:
             # 完全一致は index 活用経路で候補 tag_id を先に確定する (LoRAIro #1203/#1206)。
-            candidate_ids = sorted(self._exact_match_tag_ids({sqlite_ascii_lower(keyword)}))
+            candidate_ids = sorted(self._exact_match_tag_ids(keyword))
             if not candidate_ids:
                 return set(), resolved_format_id
             tag_id_column = Tag.tag_id
@@ -426,30 +423,31 @@ class TagSearchQueryBuilder:
             return {}
 
         keyword_set = set(keywords)
-        # 大文字小文字を無視して照合するため lower 化したキーで突き合わせる。
+        # TAGS は大小を無視して照合するため lower 化したキーで突き合わせる。
         # 同一 lower 値を持つ keyword が複数あっても、それぞれに tag_id を割り当てる。
         keywords_by_lower: dict[str, set[str]] = {}
         for keyword in keyword_set:
-            keywords_by_lower.setdefault(keyword.lower(), set()).add(keyword)
+            keywords_by_lower.setdefault(sqlite_ascii_lower(keyword), set()).add(keyword)
         lower_keys = set(keywords_by_lower.keys())
 
         # index 活用の完全一致照合 (LoRAIro #1203/#1206: 従来の lower(col) IN (...) は
-        # index を使えず keyword 数に関係なく毎回 TAGS/TAG_TRANSLATIONS の全表スキャンだった)
+        # index を使えず keyword 数に関係なく毎回 TAGS/TAG_TRANSLATIONS の全表スキャンだった)。
+        # 翻訳は大小を区別するため生キーで引く (Issue #139)。
         tag_rows = self._exact_match_tag_rows(lower_keys)
-        trans_rows = self._exact_match_translation_rows(lower_keys)
+        trans_rows = self._exact_match_translation_rows(keyword_set)
 
         tag_ids_by_keyword: dict[str, set[int]] = {keyword: set() for keyword in keyword_set}
         for tag_id, tag, source_tag in tag_rows:
             for value in (tag, source_tag):
                 if value is None:
                     continue
-                for keyword in keywords_by_lower.get(value.lower(), ()):
+                for keyword in keywords_by_lower.get(sqlite_ascii_lower(value), ()):
                     tag_ids_by_keyword[keyword].add(tag_id)
         for tag_id, translation in trans_rows:
             if translation is None:
                 continue
-            for keyword in keywords_by_lower.get(translation.lower(), ()):
-                tag_ids_by_keyword[keyword].add(tag_id)
+            if translation in tag_ids_by_keyword:
+                tag_ids_by_keyword[translation].add(tag_id)
 
         return {keyword: ids for keyword, ids in tag_ids_by_keyword.items() if ids}
 

--- a/src/genai_tag_db_tools/db/repository.py
+++ b/src/genai_tag_db_tools/db/repository.py
@@ -19,6 +19,7 @@ from genai_tag_db_tools.db.query_utils import (
     contains_like_pattern,
     invalidate_case_exception_cache,
     normalize_search_keyword,
+    sqlite_ascii_lower,
 )
 from genai_tag_db_tools.db.schema import (
     USER_TAG_ID_OFFSET,
@@ -2263,14 +2264,26 @@ class MergedTagReader:
         deprecated: bool | None,
     ) -> bool:
         normalized, use_like = normalize_search_keyword(keyword, partial)
-        needle = normalized.strip("%").casefold() if use_like else normalized.casefold()
-        haystacks = [row["tag"], row.get("source_tag") or ""]
+        tag_values = [row["tag"], row.get("source_tag") or ""]
+        translation_values: list[str] = []
         for values in row.get("translations", {}).values():
-            haystacks.extend(values)
-        if needle and use_like and not any(needle in value.casefold() for value in haystacks):
-            return False
-        if needle and not use_like and not any(needle == value.casefold() for value in haystacks):
-            return False
+            translation_values.extend(values)
+
+        if use_like:
+            # LIKE は SQLite 既定で大小を無視するため、部分一致は従来どおり畳んで比較する。
+            needle = normalized.strip("%").casefold()
+            haystacks = tag_values + translation_values
+            if needle and not any(needle in value.casefold() for value in haystacks):
+                return False
+        elif normalized:
+            # exact 照合: TAGS は canonical (小文字前提) なので大小を無視するが、翻訳は
+            # 大小を区別する (Issue #139: `Aiki` と `aiki` は別タグ)。SQL 側と同じ
+            # ASCII 限定の折り畳みを使う (casefold は Unicode 全体を畳み SQL と不一致)。
+            folded = sqlite_ascii_lower(normalized)
+            tag_hit = any(folded == sqlite_ascii_lower(value) for value in tag_values)
+            translation_hit = any(normalized == value for value in translation_values)
+            if not tag_hit and not translation_hit:
+                return False
 
         if alias is not None and row["alias"] is not alias:
             return False
@@ -2318,7 +2331,8 @@ class MergedTagReader:
             return []
         assert self.user_repo is not None
         normalized, use_like = normalize_search_keyword(keyword, partial)
-        needle = normalized.strip("%").casefold() if use_like else normalized.casefold()
+        # 翻訳は大小を区別する (Issue #139)。部分一致 (LIKE) は SQLite 既定に合わせて畳む。
+        needle = normalized.strip("%").casefold() if use_like else normalized
         rows: list[TagSearchRow] = []
         for translation in self.user_repo.list_translations():
             if language is not None and translation.language != language:
@@ -2326,7 +2340,7 @@ class MergedTagReader:
             value = translation.translation or ""
             if needle and use_like and needle not in value.casefold():
                 continue
-            if needle and not use_like and needle != value.casefold():
+            if needle and not use_like and needle != value:
                 continue
             tag = self.get_tag_by_id(translation.tag_id)
             if tag is None:

--- a/tests/unit/test_query_utils.py
+++ b/tests/unit/test_query_utils.py
@@ -107,19 +107,49 @@ def test_exact_match_finds_uppercase_stored_rows_via_exception_path(
     assert single == {1, 2}
 
 
-def test_exact_match_matches_uppercase_translations(
+def test_translation_match_is_case_sensitive(
     session_factory: Callable[[], Session],
 ) -> None:
-    """大文字混じり翻訳行も narrow スキャン経路で case-insensitive に一致する。"""
+    """翻訳は大文字小文字を区別して照合する (Issue #139)。
+
+    `Aiki` と `aiki` のように大小のみが異なる翻訳が別タグを指すため、
+    小文字化した照合は誤った tag_id を返しうる。
+    """
     with session_factory() as session:
         session.add(Tag(tag_id=1, source_tag="cat", tag="cat"))
         session.add(TagTranslation(translation_id=1, tag_id=1, language="en", translation="Cat Ears"))
         session.add(TagTranslation(translation_id=2, tag_id=1, language="ja", translation="猫耳"))
         session.commit()
         builder = TagSearchQueryBuilder(session)
-        result = builder.initial_tag_ids_for_keywords(["cat ears", "猫耳"])
 
-    assert result == {"cat ears": {1}, "猫耳": {1}}
+        # 表記どおりなら一致する (非 ASCII はそもそも大小の概念がないので常に一致)
+        assert builder.initial_tag_ids_for_keywords(["Cat Ears", "猫耳"]) == {
+            "Cat Ears": {1},
+            "猫耳": {1},
+        }
+        assert builder.initial_tag_ids("Cat Ears", use_like=False) == {1}
+
+        # 小文字化した入力は大文字混じり翻訳に一致しない
+        assert builder.initial_tag_ids_for_keywords(["cat ears"]) == {}
+        assert builder.initial_tag_ids("cat ears", use_like=False) == set()
+
+
+def test_translation_case_variants_resolve_to_distinct_tags(
+    session_factory: Callable[[], Session],
+) -> None:
+    """大小のみ異なる翻訳が別タグを指す場合、取り違えない (Issue #139)。"""
+    with session_factory() as session:
+        session.add(Tag(tag_id=1, source_tag="aiki_upper", tag="aiki upper"))
+        session.add(Tag(tag_id=2, source_tag="aiki_lower", tag="aiki lower"))
+        session.add(TagTranslation(translation_id=1, tag_id=1, language="en", translation="Aiki"))
+        session.add(TagTranslation(translation_id=2, tag_id=2, language="en", translation="aiki"))
+        session.commit()
+        builder = TagSearchQueryBuilder(session)
+
+        assert builder.initial_tag_ids_for_keywords(["Aiki"]) == {"Aiki": {1}}
+        assert builder.initial_tag_ids_for_keywords(["aiki"]) == {"aiki": {2}}
+        assert builder.initial_tag_ids("Aiki", use_like=False) == {1}
+        assert builder.initial_tag_ids("aiki", use_like=False) == {2}
 
 
 def test_case_exception_cache_is_refreshed_after_invalidate(

--- a/tests/unit/test_tag_repository.py
+++ b/tests/unit/test_tag_repository.py
@@ -1701,3 +1701,55 @@ def test_register_tag_with_status_type_id_none_defaults_and_preserves(
             .one()
         )
         assert status.type_id == 2
+
+
+def _search_row(tag: str, translations: dict[str, list[str]]) -> dict:
+    return {
+        "tag_id": 1,
+        "tag": tag,
+        "source_tag": None,
+        "usage_count": 0,
+        "alias": False,
+        "deprecated": False,
+        "type_id": None,
+        "type_name": "general",
+        "translations": translations,
+        "format_statuses": {},
+    }
+
+
+def _matches(reader: MergedTagReader, row: dict, keyword: str) -> bool:
+    return reader._search_row_matches_filters(
+        row,
+        keyword,
+        partial=False,
+        type_name=None,
+        type_names=None,
+        language=None,
+        min_usage=None,
+        max_usage=None,
+        alias=None,
+        deprecated=None,
+    )
+
+
+def test_merged_exact_filter_matches_translation_case_sensitively() -> None:
+    """merged 経路の exact 照合も翻訳は大小を区別する (#139 Codex P2)。
+
+    `_exact_match_translation_rows` だけ case-sensitive にしても、この Python 側
+    フィルタが casefold 比較のままだと merged/bulk 検索で `aiki` が `Aiki` を拾う。
+    """
+    reader = MergedTagReader.__new__(MergedTagReader)
+    row = _search_row("aiki-tag", {"en": ["Aiki"]})
+
+    assert _matches(reader, row, "Aiki") is True
+    assert _matches(reader, row, "aiki") is False
+
+
+def test_merged_exact_filter_still_matches_tag_case_insensitively() -> None:
+    """TAGS 側 (canonical) は従来どおり大小無視で照合する。"""
+    reader = MergedTagReader.__new__(MergedTagReader)
+    row = _search_row("blue hair", {})
+
+    assert _matches(reader, row, "Blue Hair") is True
+    assert _matches(reader, row, "blue hair") is True


### PR DESCRIPTION
Closes #139

## 変更内容

翻訳 (`TAG_TRANSLATIONS`) の完全一致照合を **case-sensitive** にし、`_exact_match_translation_rows` の全表スキャンを撤去した。

- `_exact_match_translation_rows`: 大小無視の補完スキャン (`translation <> lower(translation) AND lower(translation) IN (?)`) を削除し、`translation IN (?)` の binary 一致のみに。既存の `idx_translations_text` が効く
- `_exact_match_tag_ids`: 引数を照合キー集合から生キーワードへ変更。TAGS は大小無視 (従来どおり)、翻訳は大小区別
- `initial_tag_ids_for_keywords` (bulk 経路): 同じスキャンを踏んでいたため併せて修正。TAGS の照合キー生成を `str.lower()` (Unicode 全体を畳む) から `sqlite_ascii_lower()` へ揃え、SQLite の `lower()` と挙動を一致させた
- 未使用になった `_HAS_ASCII_LOWER_RE` と `import re` を削除

`TAGS` 側 (`_exact_match_tag_rows` / `_case_exceptional_tag_rows` キャッシュ) は canonical タグが小文字前提なので現状維持。

## なぜ index 追加ではなく大小無視の撤去か

`COLLATE NOCASE` / `lower(translation)` 式インデックスを足せば index SEARCH にはなるが、**誤った tag_id を返す問題が残る**。翻訳は canonical 化されておらず、大小のみが異なる表記が別タグを指すため:

| 小文字キー | 実際の翻訳 | tag_id |
|---|---|---|
| `aiki` | `Aiki` / `aiki` | 742460 / 2023168 |
| `ak-12(ドールズフロントライン)` | `AK-12(...)` / `ak-12(...)` | 32965 / 32966 |
| `anarchy` | `Anarchy` / `anarchy` | 177448 / 2349271 |

cc0 DB 実測で 358 組。追加した `test_translation_case_variants_resolve_to_distinct_tags` は、修正前は `{'Aiki': {1, 2}}` を返して落ちる (取り違えの再現)。

## 実測 (実 base DB、3 段検索)

| クエリ | 修正前 | 修正後 |
|---|---|---|
| 未登録タグ (warm) | 2,702 ms | **59.9 ms** |
| `1girl` | 1,240 ms | **191.7 ms** |

## 受け入れる副作用

小文字入力で大文字混じり翻訳に当たらなくなる (cc0: en 366,694/1,656,936、ja 18,458/370,952)。ja の実例は `Uの字口`、`ルーナ（Helluva Boss）` など固有名詞・記号で、小文字入力する動機が乏しい。

## マージ順序 (重要)

呼び出し元の LoRAIro は検索キーを小文字化して渡している (`annotation_record.py:496`)。**この PR を先に merge して LoRAIro が pin を上げると、大文字混じり翻訳が「未登録」と誤判定され user DB へ重複登録される。**

NEXTAltair/LoRAIro#1288 (呼び出し元の `lower()` 撤去) を先に入れるか、submodule pin 更新と同時に入れること。

## 検証

- `make test-genai-tag` 相当: 901 passed
- `ruff format` / `ruff check` / `mypy` クリーン
- 実 base DB での before/after 計測 (上表)

## Not Verified

- 修正後も `1girl` の 3 段検索に 191.7 ms、プロセス初回の未登録タグ解決に約 2.98 秒残る。後者は `_case_exceptional_tag_rows` による TAGS (448 万行) の engine 単位 1 回のフルスキャンで、本 PR のスコープ外

Refs: NEXTAltair/LoRAIro#1275

🤖 Generated with [Claude Code](https://claude.com/claude-code)
