### PR TITLE
perf: 起動時に base DB の SHA256 (8.4GB) を計算しない

### DIFF
--- a/src/genai_tag_db_tools/core_api.py
+++ b/src/genai_tag_db_tools/core_api.py
@@ -236,7 +236,20 @@ def default_sources() -> list[DbSourceRef]:
     ]
 
 
-def ensure_databases(requests: list[EnsureDbRequest]) -> list[EnsureDbResult]:
+def ensure_databases(
+    requests: list[EnsureDbRequest], *, compute_digest: bool = True
+) -> list[EnsureDbResult]:
+    """base DB を用意し、その所在 (と任意で SHA256) を返す。
+
+    Args:
+        requests: 取得対象の DB。
+        compute_digest: SHA256 を計算するか。base DB は 1 本あたり数 GB あり、
+            ハッシュ計算だけで数秒〜十数秒かかる。ダイジェストを読まない呼び出し
+            (`initialize_databases` 経由の起動処理) では False にする。
+
+    Returns:
+        DB ごとの結果。`compute_digest=False` のとき `sha256` は None。
+    """
     if not requests:
         raise ValueError("requests は空にできません")
 
@@ -248,7 +261,7 @@ def ensure_databases(requests: list[EnsureDbRequest]) -> list[EnsureDbResult]:
         results.append(
             EnsureDbResult(
                 db_path=str(db_path),
-                sha256=_compute_sha256(db_path),
+                sha256=_compute_sha256(db_path) if compute_digest else None,
                 revision=None,
                 cached=is_cached,
             )
@@ -276,6 +289,11 @@ def initialize_databases(
             is provided, otherwise False.
         format_name: Format name for user DB (e.g., "Lorairo", "MyApp").
             If None, defaults to "tag-db".
+
+    Note:
+        返り値の `sha256` は常に None。ダイジェストが要るときは
+        `ensure_databases(..., compute_digest=True)` を直接呼ぶこと
+        (`ensure-dbs` CLI はそちらを使う)。
     """
     resolved_user_db_dir = Path(user_db_dir) if user_db_dir is not None else None
     if init_user_db is None:
@@ -286,7 +304,8 @@ def initialize_databases(
     requested_sources = sources or default_sources()
     requests = [EnsureDbRequest(source=source, cache=cache) for source in requested_sources]
 
-    results = ensure_databases(requests)
+    # 起動経路では SHA256 を読まないので計算しない (8.4GB のハッシュ計算に実測 13 秒)。
+    results = ensure_databases(requests, compute_digest=False)
     base_paths = [Path(result.db_path) for result in results]
     runtime.set_base_database_paths(base_paths)
     runtime.init_engine(base_paths[0])

--- a/src/genai_tag_db_tools/models.py
+++ b/src/genai_tag_db_tools/models.py
@@ -72,7 +72,7 @@ class EnsureDbResult(BaseModel):
 
     Args:
         db_path: ローカルSQLiteの実体パス（HFキャッシュ内のsymlink）。
-        sha256: 取得ファイルのSHA256。
+        sha256: 取得ファイルのSHA256。ダイジェスト計算を省いた場合は None。
         revision: 解決されたリビジョン（コミットハッシュ）。
         cached: オフラインモードでキャッシュを使用したか。
 
@@ -83,7 +83,7 @@ class EnsureDbResult(BaseModel):
     """
 
     db_path: str = Field(..., description="ローカルSQLiteの実体パス")
-    sha256: str = Field(..., description="取得ファイルのSHA256")
+    sha256: str | None = Field(default=None, description="取得ファイルのSHA256 (未計算なら None)")
     revision: str | None = Field(default=None, description="解決されたリビジョン")
     cached: bool = Field(default=False, description="キャッシュのみ使用したか")
 

--- a/tests/unit/test_core_api.py
+++ b/tests/unit/test_core_api.py
@@ -119,6 +119,57 @@ def test_ensure_databases_returns_cached_status_per_spec(monkeypatch, tmp_path):
     assert results[1].sha256 == _hash_bytes(b"bb")
 
 
+def test_ensure_databases_skips_digest_when_not_requested(monkeypatch, tmp_path):
+    """compute_digest=False では SHA256 を計算しない。
+
+    base DB は数 GB あり、ハッシュ計算だけで十数秒かかる。ダイジェストを読まない
+    呼び出し (起動処理) はこれを省く。
+    """
+    db_a = tmp_path / "a.sqlite"
+    db_a.write_bytes(b"a")
+
+    monkeypatch.setattr(
+        hf_downloader,
+        "download_with_offline_fallback",
+        lambda spec, *, token=None: (db_a, True),
+    )
+
+    def fail_if_called(path):
+        raise AssertionError(f"SHA256 を計算してはいけない: {path}")
+
+    monkeypatch.setattr(core_api, "_compute_sha256", fail_if_called)
+
+    results = core_api.ensure_databases(
+        [_build_request(tmp_path, "org/a", "a.sqlite")], compute_digest=False
+    )
+
+    assert results[0].sha256 is None
+    assert results[0].db_path == str(db_a)
+
+
+def test_initialize_databases_does_not_hash_base_dbs(tmp_path, monkeypatch):
+    """起動経路 (initialize_databases) は base DB をハッシュしない。"""
+    db = tmp_path / "base.sqlite"
+    db.write_bytes(b"x")
+
+    monkeypatch.setattr(
+        hf_downloader,
+        "download_with_offline_fallback",
+        lambda spec, *, token=None: (db, True),
+    )
+    monkeypatch.setattr(core_api.runtime, "set_base_database_paths", lambda paths: None)
+    monkeypatch.setattr(core_api.runtime, "init_engine", lambda path: None)
+
+    def fail_if_called(path):
+        raise AssertionError(f"起動処理で SHA256 を計算してはいけない: {path}")
+
+    monkeypatch.setattr(core_api, "_compute_sha256", fail_if_called)
+
+    results = core_api.initialize_databases(user_db_dir=tmp_path, init_user_db=False)
+
+    assert all(result.sha256 is None for result in results)
+
+
 def _usage_row(tag_id: int, usage: int) -> dict[str, object]:
     return {
         "tag": f"t{tag_id}",

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -91,9 +91,15 @@ def test_ensure_db_result_valid():
 
 
 @pytest.mark.db_tools
-def test_ensure_db_result_requires_all_fields():
+def test_ensure_db_result_requires_db_path():
     with pytest.raises(ValidationError):
-        EnsureDbResult(db_path="/path/to/db.sqlite", cached=True)
+        EnsureDbResult(cached=True)
+
+
+def test_ensure_db_result_sha256_is_optional():
+    """SHA256 は任意 (compute_digest=False の起動経路では計算しない)。"""
+    result = EnsureDbResult(db_path="/path/to/db.sqlite", cached=True)
+    assert result.sha256 is None
 
 
 @pytest.mark.db_tools


### PR DESCRIPTION
## 問題

`initialize_databases()` は `ensure_databases()` 経由で base DB 3 本 (cc0 2.8GB + mit + cc4、合計約 8.4GB) の SHA256 を **毎プロセス** 計算している。

```python
EnsureDbResult(
    db_path=str(db_path),
    sha256=_compute_sha256(db_path),   # 8.4GB を読んでハッシュ
    ...
)
```

しかし `initialize_databases()` の返り値の `sha256` を読む呼び出し元は**どこにも無い**。実際に消費しているのは `ensure-dbs` CLI / MCP tool の出力のみ (`emit_item(result)`)。LoRAIro 側も `len(results)` をログに出すだけ。

## 影響

LoRAIro では `ensure_tag_db_initialized()` が遅延初期化で、**最初のタグ操作時に GUI スレッドから**呼ばれる。この 13 秒はそのまま UI 停止として現れる (NEXTAltair/LoRAIro#1275 のバッチタグ追加停滞の一部)。

## 変更

`ensure_databases(requests, *, compute_digest: bool = True)` を追加し、起動経路 (`initialize_databases`) では `compute_digest=False` を渡す。`ensure-dbs` CLI は既定の `True` のままなのでダイジェスト出力は変わらない。

`EnsureDbResult.sha256` は `str | None` (未計算なら None) になる。

## 実測 (devcontainer, ext4, page cache warm)

| | 修正前 | 修正後 |
|---|---|---|
| `ensure_tag_db_initialized()` cold | 13,297 ms | **2,305 ms** |

単体の sha256 計算は 2.8GB あたり実測 6.5 秒。

## 検証

- `make test-genai-tag` 相当: **903 passed**
- `mypy` クリーン
- 追加テスト:
  - `test_ensure_databases_skips_digest_when_not_requested`: `compute_digest=False` で `_compute_sha256` が呼ばれないこと
  - `test_initialize_databases_does_not_hash_base_dbs`: 起動経路がハッシュしないこと
  - `test_ensure_db_result_sha256_is_optional`
- 既存の `test_ensure_databases_returns_cached_status_per_spec` が `ensure-dbs` 側のダイジェスト計算を引き続き守る

## 破壊的変更

`EnsureDbResult.sha256` が `str | None` になる。`ensure-dbs` 経由の出力では従来どおり文字列が入るため、CLI/tool の利用者への影響はない。

## Not Verified

- 残る 2,305 ms の内訳 (HF offline 解決 + runtime init) は未調査
- `ruff check` に既存の `UP042` (`core/language_detection.py`) が 1 件残るが、master 由来で本 PR とは無関係

Refs: NEXTAltair/LoRAIro#1275

🤖 Generated with [Claude Code](https://claude.com/claude-code)
