### PR TITLE
perf: TAGS の大小文字例外行スキャン (448 万行) を撤去する (#142)

### DIFF
--- a/src/genai_tag_db_tools/db/query_utils.py
+++ b/src/genai_tag_db_tools/db/query_utils.py
@@ -1,9 +1,8 @@
 import string
-import weakref
 from logging import Logger
 from typing import Any, TypedDict
 
-from sqlalchemy import exists, func, not_, select
+from sqlalchemy import exists, not_, select
 from sqlalchemy.orm import Session
 from sqlalchemy.sql import literal_column, or_
 
@@ -37,30 +36,30 @@ TAG_ID_IN_CHUNK = 900
 # 同じ照合を再現するための変換テーブル (str.lower は Unicode 全体を畳むため不一致)。
 _ASCII_LOWER_TABLE = str.maketrans(string.ascii_uppercase, string.ascii_lowercase)
 
-# TAGS の「ASCII 小文字化で不変でない」例外行のキャッシュ (engine 単位)。
-# base DB (数百万行) は runtime 中は不変で、例外行は全体の 0.01% 未満なので、
-# 一度のスキャン結果を保持すれば以降の完全一致照合は index だけで済む。
-# TAGS を書き換える経路 (TagRepository) は invalidate_case_exception_cache() を呼ぶこと。
-_case_exception_cache: "weakref.WeakKeyDictionary[Any, list[tuple[int, str | None, str | None]]]" = (
-    weakref.WeakKeyDictionary()
-)
-
-
 def sqlite_ascii_lower(value: str) -> str:
     """SQLite の lower() / COLLATE NOCASE と同じ ASCII 限定の小文字化を行う。"""
     return value.translate(_ASCII_LOWER_TABLE)
 
 
-def invalidate_case_exception_cache(bind: Any | None = None) -> None:
-    """TAGS の大小文字例外行キャッシュを無効化する。
+def exact_match_keys(keyword: str) -> set[str]:
+    """TAGS の完全一致照合に使う index 引き当てキーを返す (Issue #142)。
+
+    canonical タグは実質すべて小文字なので、キーを畳めば `Blue Hair` → `blue hair`
+    が index 一致で引ける。一方 **格納値は畳まない**: `:d` (tag_id 25296) と
+    `:D` (1087135) のように大小のみが異なる格納値が別タグを指すため
+    (base DB 実測で 34 組)、格納値を畳むと別タグを拾ってしまう。
+
+    大文字混じりの格納値 (base DB に 49 行) を表記どおりに引けるよう、生キーも
+    併せて probe する。いずれも index (`idx_tags_tag` / `idx_tags_source_tag`) が
+    効くため、従来の 448 万行スキャンは不要になる。
 
     Args:
-        bind: 無効化対象の engine。None なら全 engine 分を破棄する。
+        keyword: 生の検索キーワード。
+
+    Returns:
+        `{生キー, ASCII 小文字化キー}`。
     """
-    if bind is None:
-        _case_exception_cache.clear()
-    else:
-        _case_exception_cache.pop(bind, None)
+    return {keyword, sqlite_ascii_lower(keyword)}
 
 
 def _chunked_in(column: Any, values: list[int]) -> Any:
@@ -149,66 +148,40 @@ class TagSearchQueryBuilder:
         return {row[0] for row in union_query.all()}
 
     def _exact_match_tag_rows(self, match_keys: set[str]) -> list[tuple[int, str | None, str | None]]:
-        """ASCII 小文字化済みキーに case-insensitive 完全一致する TAGS 行を返す。
+        """キーに完全一致する TAGS 行を index 経路で返す。
 
         `lower(col) IN (...)` / `COLLATE NOCASE ==` は index を使えず TAGS 全表スキャン
-        (数百万行、1 回あたり秒〜十秒台) になる (LoRAIro #1203/#1206)。行の大多数は既に
-        小文字なので、(1) index が効く完全一致 IN と (2) 小文字化で不変でない例外行
-        (engine 単位で 1 回だけスキャンしキャッシュ) の Python 照合に分割し、照合結果を
-        変えずに index を活用する。
+        (数百万行、1 回あたり秒台) になる (LoRAIro #1203/#1206)。キー側を畳んで生キーと
+        併せて probe することで、格納値を畳まずに index (`idx_tags_tag` /
+        `idx_tags_source_tag`) だけで照合する (Issue #142)。
 
         Args:
-            match_keys: `sqlite_ascii_lower` 済みの照合キー集合。
+            match_keys: `exact_match_keys()` が組み立てた照合キー集合。
 
         Returns:
-            (tag_id, tag, source_tag) のリスト。例外行経由の重複を含み得る
-            (呼び出し側は set に畳むため実害なし)。
+            (tag_id, tag, source_tag) のリスト。
         """
         if not match_keys:
             return []
         keys = list(match_keys)
-        rows: list[tuple[int, str | None, str | None]] = list(
+        return list(
             self.session.query(Tag.tag_id, Tag.tag, Tag.source_tag)
             .filter(or_(Tag.tag.in_(keys), Tag.source_tag.in_(keys)))
             .all()
         )
-        for tag_id, tag, source_tag in self._case_exceptional_tag_rows():
-            if (tag is not None and sqlite_ascii_lower(tag) in match_keys) or (
-                source_tag is not None and sqlite_ascii_lower(source_tag) in match_keys
-            ):
-                rows.append((tag_id, tag, source_tag))
-        return rows
 
     def _exact_match_tag_ids(self, keyword: str) -> set[int]:
         """単一 keyword の完全一致で tag_id 集合を返す。
 
-        TAGS は canonical 化されている (実質すべて小文字) ため大小を無視して照合するが、
-        翻訳は大小を区別する (Issue #139: `Aiki` と `aiki` は別タグ)。
+        TAGS は canonical 化されている (実質すべて小文字) ためキーを畳んで照合するが、
+        格納値は畳まない (Issue #142)。翻訳は大小を区別する (Issue #139)。
 
         Args:
             keyword: 生の検索キーワード (小文字化前)。
         """
-        ids = {row[0] for row in self._exact_match_tag_rows({sqlite_ascii_lower(keyword)})}
+        ids = {row[0] for row in self._exact_match_tag_rows(exact_match_keys(keyword))}
         ids.update(row[0] for row in self._exact_match_translation_rows({keyword}))
         return ids
-
-    def _case_exceptional_tag_rows(self) -> list[tuple[int, str | None, str | None]]:
-        """ASCII 小文字化で不変でない TAGS 行を engine 単位のキャッシュ付きで返す。"""
-        bind = self.session.get_bind()
-        cached = _case_exception_cache.get(bind)
-        if cached is None:
-            cached = list(
-                self.session.query(Tag.tag_id, Tag.tag, Tag.source_tag)
-                .filter(
-                    or_(
-                        Tag.tag != func.lower(Tag.tag),
-                        Tag.source_tag != func.lower(Tag.source_tag),
-                    )
-                )
-                .all()
-            )
-            _case_exception_cache[bind] = cached
-        return cached
 
     def _exact_match_translation_rows(self, match_keys: set[str]) -> list[tuple[int, str | None]]:
         """キーに完全一致する翻訳行を返す (大文字小文字を区別する、Issue #139)。
@@ -423,17 +396,17 @@ class TagSearchQueryBuilder:
             return {}
 
         keyword_set = set(keywords)
-        # TAGS は大小を無視して照合するため lower 化したキーで突き合わせる。
-        # 同一 lower 値を持つ keyword が複数あっても、それぞれに tag_id を割り当てる。
-        keywords_by_lower: dict[str, set[str]] = {}
+        # TAGS はキー側だけ畳んで照合する (格納値は畳まない、Issue #142)。
+        # 生キーと畳んだキーの両方を probe キーにし、格納値と binary 一致で突き合わせる。
+        keywords_by_key: dict[str, set[str]] = {}
         for keyword in keyword_set:
-            keywords_by_lower.setdefault(sqlite_ascii_lower(keyword), set()).add(keyword)
-        lower_keys = set(keywords_by_lower.keys())
+            for key in exact_match_keys(keyword):
+                keywords_by_key.setdefault(key, set()).add(keyword)
 
         # index 活用の完全一致照合 (LoRAIro #1203/#1206: 従来の lower(col) IN (...) は
         # index を使えず keyword 数に関係なく毎回 TAGS/TAG_TRANSLATIONS の全表スキャンだった)。
         # 翻訳は大小を区別するため生キーで引く (Issue #139)。
-        tag_rows = self._exact_match_tag_rows(lower_keys)
+        tag_rows = self._exact_match_tag_rows(set(keywords_by_key.keys()))
         trans_rows = self._exact_match_translation_rows(keyword_set)
 
         tag_ids_by_keyword: dict[str, set[int]] = {keyword: set() for keyword in keyword_set}
@@ -441,7 +414,7 @@ class TagSearchQueryBuilder:
             for value in (tag, source_tag):
                 if value is None:
                     continue
-                for keyword in keywords_by_lower.get(sqlite_ascii_lower(value), ()):
+                for keyword in keywords_by_key.get(value, ()):
                     tag_ids_by_keyword[keyword].add(tag_id)
         for tag_id, translation in trans_rows:
             if translation is None:

--- a/src/genai_tag_db_tools/db/repository.py
+++ b/src/genai_tag_db_tools/db/repository.py
@@ -17,7 +17,6 @@ from genai_tag_db_tools.db.query_utils import (
     TagSearchQueryBuilder,
     TagSearchResultBuilder,
     contains_like_pattern,
-    invalidate_case_exception_cache,
     normalize_search_keyword,
     sqlite_ascii_lower,
 )
@@ -629,7 +628,6 @@ class TagRepository:
                 msg = ErrorMessages.DB_OPERATION_FAILED.format(error_msg=str(e))
                 self.logger.error(msg)
                 raise ValueError(msg) from e
-            invalidate_case_exception_cache(session.get_bind())
             return new_tag.tag_id
 
     @staticmethod
@@ -740,7 +738,6 @@ class TagRepository:
                     msg = ErrorMessages.DB_OPERATION_FAILED.format(error_msg=str(retry_error))
                     self.logger.error(msg)
                     raise ValueError(msg) from retry_error
-            invalidate_case_exception_cache(session.get_bind())
             return tag_id
 
     def _write_status_and_translations_in_session(
@@ -781,7 +778,6 @@ class TagRepository:
             if tag is not None:
                 tag_obj.tag = tag
             session.commit()
-            invalidate_case_exception_cache(session.get_bind())
 
     def delete_tag(self, tag_id: int) -> None:
         with self.session_factory() as session:
@@ -792,7 +788,6 @@ class TagRepository:
                 raise ValueError(msg)
             session.delete(tag_obj)
             session.commit()
-            invalidate_case_exception_cache(session.get_bind())
 
     def bulk_insert_tags(self, df: pl.DataFrame) -> None:
         required_cols = {"source_tag", "tag"}
@@ -817,7 +812,6 @@ class TagRepository:
                 session.rollback()
                 msg = ErrorMessages.DB_OPERATION_FAILED.format(error_msg=str(e))
                 raise ValueError(msg) from e
-            invalidate_case_exception_cache(session.get_bind())
 
     def create_tag_with_id(self, tag_id: int, source_tag: str, tag: str) -> int:
         if not tag or not source_tag:
@@ -841,7 +835,6 @@ class TagRepository:
             try:
                 session.add(Tag(tag_id=tag_id, source_tag=source_tag, tag=tag))
                 session.commit()
-                invalidate_case_exception_cache(session.get_bind())
                 return tag_id
             except IntegrityError as e:
                 session.rollback()
@@ -2276,9 +2269,12 @@ class MergedTagReader:
             if needle and not any(needle in value.casefold() for value in haystacks):
                 return False
         elif normalized:
-            # exact 照合: TAGS は canonical (小文字前提) なので大小を無視するが、翻訳は
-            # 大小を区別する (Issue #139: `Aiki` と `aiki` は別タグ)。SQL 側と同じ
-            # ASCII 限定の折り畳みを使う (casefold は Unicode 全体を畳み SQL と不一致)。
+            # exact 照合: タグ名は大小を無視する。user overlay が `COLLATE NOCASE` で
+            # 引く (case-variant な user 重複タグをブラウズで残す #1223) ため、ここで
+            # 畳まないとその行を落としてしまう。base 側の case-variant 衝突 (#142) は
+            # SQL 層 (`_exact_match_tag_rows`) で既に解決済み。
+            # 翻訳は大小を区別する (Issue #139: `Aiki` と `aiki` は別タグ)。折り畳みは
+            # SQL と同じ ASCII 限定 (casefold は Unicode 全体を畳み SQL と不一致)。
             folded = sqlite_ascii_lower(normalized)
             tag_hit = any(folded == sqlite_ascii_lower(value) for value in tag_values)
             translation_hit = any(normalized == value for value in translation_values)

--- a/tests/unit/test_query_utils.py
+++ b/tests/unit/test_query_utils.py
@@ -11,7 +11,6 @@ from genai_tag_db_tools.db.query_utils import (
     TagSearchPreloader,
     TagSearchQueryBuilder,
     TagSearchResultBuilder,
-    invalidate_case_exception_cache,
     sqlite_ascii_lower,
 )
 from genai_tag_db_tools.db.schema import (
@@ -91,20 +90,42 @@ def test_initial_tag_ids_for_keywords_is_case_insensitive(
     assert result == {"Blue Hair": {1}}
 
 
-def test_exact_match_finds_uppercase_stored_rows_via_exception_path(
+def test_exact_match_does_not_fold_stored_tag_values(
     session_factory: Callable[[], Session],
 ) -> None:
-    """DB 側に大文字混じりで格納された行も index 迂回の例外行経路で照合できる。"""
+    """小文字キーは大文字混じりの格納値に一致しない (Issue #142)。
+
+    `:d` (tag_id 25296) と `:D` (1087135) のように、大小のみが異なる格納値が
+    別タグを指す (base DB 実測で 34 組)。格納値を畳んで照合すると別タグを拾う。
+    """
     with session_factory() as session:
         session.add(Tag(tag_id=1, source_tag="Blue_Hair", tag="Blue Hair"))
         session.add(Tag(tag_id=2, source_tag="blue_hair", tag="blue hair"))
         session.commit()
         builder = TagSearchQueryBuilder(session)
-        result = builder.initial_tag_ids_for_keywords(["blue hair"])
-        single = builder.initial_tag_ids("blue hair", use_like=False)
 
-    assert result == {"blue hair": {1, 2}}
-    assert single == {1, 2}
+        # 格納値が小文字の行は、キーを畳んで index で引ける (従来どおり)
+        assert builder.initial_tag_ids_for_keywords(["blue hair"]) == {"blue hair": {2}}
+        assert builder.initial_tag_ids("blue hair", use_like=False) == {2}
+
+        # 表記どおりに打てば大文字混じりの行も引ける
+        assert builder.initial_tag_ids("Blue Hair", use_like=False) == {1, 2}
+
+
+def test_exact_match_case_variant_tags_do_not_collide(
+    session_factory: Callable[[], Session],
+) -> None:
+    """大小のみ異なる格納タグが別 tag_id の場合、取り違えない (Issue #142)。"""
+    with session_factory() as session:
+        session.add(Tag(tag_id=1, source_tag=":D", tag=":D"))
+        session.add(Tag(tag_id=2, source_tag=":d", tag=":d"))
+        session.commit()
+        builder = TagSearchQueryBuilder(session)
+
+        # 小文字キーは小文字の行だけを引く
+        assert builder.initial_tag_ids(":d", use_like=False) == {2}
+        # 大文字キーは自身 + 畳んだキーの行を引く (canonical が小文字である前提を保つ)
+        assert builder.initial_tag_ids(":D", use_like=False) == {1, 2}
 
 
 def test_translation_match_is_case_sensitive(
@@ -150,25 +171,6 @@ def test_translation_case_variants_resolve_to_distinct_tags(
         assert builder.initial_tag_ids_for_keywords(["aiki"]) == {"aiki": {2}}
         assert builder.initial_tag_ids("Aiki", use_like=False) == {1}
         assert builder.initial_tag_ids("aiki", use_like=False) == {2}
-
-
-def test_case_exception_cache_is_refreshed_after_invalidate(
-    session_factory: Callable[[], Session],
-) -> None:
-    """例外行キャッシュは invalidate 後に再構築され、後から入った大文字行を拾える。"""
-    with session_factory() as session:
-        session.add(Tag(tag_id=1, source_tag="cat", tag="cat"))
-        session.commit()
-        builder = TagSearchQueryBuilder(session)
-        assert builder.initial_tag_ids_for_keywords(["mixed case"]) == {}
-
-        # キャッシュ構築後に大文字混じり行を直接追加 (通常は TagRepository が invalidate する)
-        session.add(Tag(tag_id=2, source_tag="Mixed_Case", tag="Mixed Case"))
-        session.commit()
-        invalidate_case_exception_cache(session.get_bind())
-        result = builder.initial_tag_ids_for_keywords(["mixed case"])
-
-    assert result == {"mixed case": {2}}
 
 
 def test_sqlite_ascii_lower_folds_ascii_only() -> None:


### PR DESCRIPTION
Closes #142

## 変更内容

`_case_exceptional_tag_rows` は、プロセス初回の完全一致検索で TAGS 448 万行をフルスキャンして 49 行を拾っていた。base 3 本で約 **2.6 秒** (ページキャッシュが冷えていれば約 **9.5 秒**)。LoRAIro ではこれが GUI スレッドを塞ぐ。

キー側だけを畳んで生キーと併せて probe する (`exact_match_keys()`) ことで、**格納値を畳まずに** index (`idx_tags_tag` / `idx_tags_source_tag`) だけで照合する。スキャンとキャッシュ (`invalidate_case_exception_cache` を含む) は不要になり削除した。

## 正しさも改善する

`:d` (tag_id 25296) と `:D` (1087135) のように、大小のみが異なる格納値が **別タグ**を指す。base DB (cc0) の実測:

```sql
-- 大文字混じり行のうち、小文字版が別 tag_id として併存する数
SELECT count(*) FROM TAGS a WHERE a.tag <> lower(a.tag)
  AND EXISTS (SELECT 1 FROM TAGS b WHERE b.tag = lower(a.tag) AND b.tag_id <> a.tag_id);
-- 34
```

格納値を畳む従来の照合は、小文字キー `:d` で `:D` (別タグ) を余計に拾っていた。#139 で翻訳に適用したのと同じ問題。

## 挙動変更 (受け入れる副作用)

大文字混じりの格納タグ 49 行のうち、小文字版が併存しない **14 行**は表記どおりに打たないと引けなくなる。実例は `:P´`, `A.P:D`, `C:\)`, `Woo:\)` などの顔文字系。

`Blue Hair` → `blue hair` のような通常のケースは従来どおり引ける (canonical タグは実質すべて小文字で、キー側を畳むため)。

## user overlay は変更しない

user DB は `COLLATE NOCASE` で引き続き大小を無視する (case-variant な user 重複タグをブラウズで残す #1223 / #1212)。merged の Python フィルタもタグ名は畳んだまま維持した。base 側の case-variant 衝突は SQL 層で解決済みなので、フィルタ側で畳んでも誤検出は増えない。

user DB は小さくスキャンコストの問題がないため、ここを case-sensitive にする動機はない。

## 実 DB 計測 (devcontainer)

| | #142 前 | #142 後 |
|---|---|---|
| 未登録タグ 3 段検索 (プロセス初回) | 2,624 ms | **127 ms** |
| 同 (2 回目以降) | 18 ms | 38 ms |
| `1girl` | 89 ms | 153 ms |

初回が 20 倍速くなる代わりに、2 回目以降と `1girl` がわずかに遅くなる。probe キーが 1 個から最大 2 個に増え、`IN` の要素が倍になるため。プロセス全体では大幅な改善。

## 検証

- `make test-genai-tag` 相当: **906 passed**
- LoRAIro 本体 (本ブランチを pin して): **5,817 passed, 2 skipped**
- `ruff check` / `mypy` クリーン
- 追加/更新テスト:
  - `test_exact_match_does_not_fold_stored_tag_values` (旧 `test_exact_match_finds_uppercase_stored_rows_via_exception_path` を差し替え)
  - `test_exact_match_case_variant_tags_do_not_collide` (`:d` が `:D` を拾わない)
  - `test_case_exception_cache_is_refreshed_after_invalidate` を削除 (対象ごと撤去)

## Not Verified

- 実機 GUI での動作確認は未実施
- `ruff check` に既存の `UP042` (`core/language_detection.py`) が残るが master 由来で無関係

Refs: NEXTAltair/LoRAIro#1275

🤖 Generated with [Claude Code](https://claude.com/claude-code)
